### PR TITLE
Make File, FileAttribute, and Directory immutable, refactor BrowseResponse.Parse() to .TryParse()

### DIFF
--- a/src/Soulseek.NET/Common/Directory.cs
+++ b/src/Soulseek.NET/Common/Directory.cs
@@ -22,19 +22,26 @@ namespace Soulseek.NET
         /// <summary>
         ///     Initializes a new instance of the <see cref="Directory"/> class.
         /// </summary>
-        internal Directory()
+        /// <param name="directoryname">The directory name.</param>
+        /// <param name="fileCount">The number of files.</param>
+        /// <param name="fileList">The optional list of <see cref="File"/> s.</param>
+        public Directory(string directoryname, int fileCount, List<File> fileList = null)
         {
+            Directoryname = directoryname;
+            FileCount = fileCount;
+
+            FileList = fileList ?? new List<File>();
         }
 
         /// <summary>
         ///     Gets the directory name.
         /// </summary>
-        public string Directoryname { get; internal set; }
+        public string Directoryname { get; }
 
         /// <summary>
         ///     Gets the number of files within the directory.
         /// </summary>
-        public int FileCount { get; internal set; }
+        public int FileCount { get; }
 
         /// <summary>
         ///     Gets the collection of files contained within the directory.
@@ -42,8 +49,8 @@ namespace Soulseek.NET
         public IEnumerable<File> Files => FileList.AsReadOnly();
 
         /// <summary>
-        ///     Gets or sets the list of files contained within the directory.
+        ///     Gets the list of files contained within the directory.
         /// </summary>
-        internal List<File> FileList { get; set; } = new List<File>();
+        private List<File> FileList { get; }
     }
 }

--- a/src/Soulseek.NET/Common/File.cs
+++ b/src/Soulseek.NET/Common/File.cs
@@ -20,18 +20,25 @@ namespace Soulseek.NET
     /// </summary>
     public sealed class File
     {
-        #region Internal Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="File"/> class.
         /// </summary>
-        internal File()
+        /// <param name="code">The file code.</param>
+        /// <param name="filename">The file name.</param>
+        /// <param name="extension">The file extension.</param>
+        /// <param name="size">The file size in bytes.</param>
+        /// <param name="attributeCount">The number of file <see cref="FileAttribute"/> s.</param>
+        /// <param name="attributeList">The optional list of <see cref="FileAttribute"/> s.</param>
+        public File(int code, string filename, long size, string extension, int attributeCount, List<FileAttribute> attributeList = null)
         {
+            Code = code;
+            Filename = filename;
+            Size = size;
+            Extension = extension;
+            AttributeCount = attributeCount;
+
+            AttributeList = attributeList ?? new List<FileAttribute>();
         }
-
-        #endregion Internal Constructors
-
-        #region Public Properties
 
         /// <summary>
         ///     Gets the number of file <see cref="FileAttribute"/> s.
@@ -56,17 +63,17 @@ namespace Soulseek.NET
         /// <summary>
         ///     Gets the file code.
         /// </summary>
-        public int Code { get; internal set; }
+        public int Code { get; }
 
         /// <summary>
         ///     Gets the file extension.
         /// </summary>
-        public string Extension { get; internal set; }
+        public string Extension { get; }
 
         /// <summary>
         ///     Gets the file name.
         /// </summary>
-        public string Filename { get; internal set; }
+        public string Filename { get; }
 
         /// <summary>
         ///     Gets the value of the <see cref="FileAttributeType.Length"/> attribute.
@@ -79,22 +86,14 @@ namespace Soulseek.NET
         public int? SampleRate => GetAttributeValue(FileAttributeType.SampleRate);
 
         /// <summary>
-        ///     Gets the file size.
+        ///     Gets the file size in bytes.
         /// </summary>
-        public long Size { get; internal set; }
-
-        #endregion Public Properties
-
-        #region Internal Properties
+        public long Size { get; }
 
         /// <summary>
-        ///     Gets or sets the internal list of file attributes.
+        ///     Gets the internal list of file attributes.
         /// </summary>
-        internal List<FileAttribute> AttributeList { get; set; } = new List<FileAttribute>();
-
-        #endregion Internal Properties
-
-        #region Public Methods
+        private List<FileAttribute> AttributeList { get; }
 
         /// <summary>
         ///     Returns the value of the specified attribute <paramref name="type"/>.
@@ -105,7 +104,5 @@ namespace Soulseek.NET
         {
             return AttributeList.SingleOrDefault(a => a.Type == type)?.Value;
         }
-
-        #endregion Public Methods
     }
 }

--- a/src/Soulseek.NET/Common/FileAttribute.cs
+++ b/src/Soulseek.NET/Common/FileAttribute.cs
@@ -17,29 +17,25 @@ namespace Soulseek.NET
     /// </summary>
     public sealed class FileAttribute
     {
-        #region Internal Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="FileAttribute"/> class.
         /// </summary>
-        internal FileAttribute()
+        /// <param name="type">The attribute type.</param>
+        /// <param name="value">The attribute value.</param>
+        public FileAttribute(FileAttributeType type, int value)
         {
+            Type = type;
+            Value = value;
         }
-
-        #endregion Internal Constructors
-
-        #region Public Properties
 
         /// <summary>
         ///     Gets the attribute type.
         /// </summary>
-        public FileAttributeType Type { get; internal set; }
+        public FileAttributeType Type { get; }
 
         /// <summary>
         ///     Gets the attribute value.
         /// </summary>
-        public int Value { get; internal set; }
-
-        #endregion Public Properties
+        public int Value { get; }
     }
 }

--- a/src/Soulseek.NET/Messaging/Responses/BrowseResponse.cs
+++ b/src/Soulseek.NET/Messaging/Responses/BrowseResponse.cs
@@ -69,11 +69,11 @@ namespace Soulseek.NET.Messaging.Responses
 
                 for (int i = 0; i < temp.DirectoryCount; i++)
                 {
-                    var dir = new Directory
-                    {
-                        Directoryname = reader.ReadString(),
-                        FileCount = reader.ReadInteger(),
-                    };
+                    var dir = new Directory(
+                        directoryname: reader.ReadString(),
+                        fileCount: reader.ReadInteger());
+
+                    var fileList = new List<File>();
 
                     for (int j = 0; j < dir.FileCount; j++)
                     {
@@ -95,7 +95,7 @@ namespace Soulseek.NET.Messaging.Responses
                             attributeList.Add(attribute);
                         }
 
-                        dir.FileList.Add(new File(
+                        fileList.Add(new File(
                             code: file.Code,
                             filename: file.Filename,
                             size: file.Size,
@@ -104,7 +104,10 @@ namespace Soulseek.NET.Messaging.Responses
                             attributeList: attributeList));
                     }
 
-                    temp.DirectoryList.Add(dir);
+                    temp.DirectoryList.Add(new Directory(
+                        directoryname: dir.Directoryname,
+                        fileCount: dir.FileCount,
+                        fileList: fileList));
                 }
             }
             catch (Exception)

--- a/src/Soulseek.NET/Messaging/Responses/SearchResponse.cs
+++ b/src/Soulseek.NET/Messaging/Responses/SearchResponse.cs
@@ -120,27 +120,31 @@ namespace Soulseek.NET.Messaging.Responses
 
             for (int i = 0; i < count; i++)
             {
-                var file = new File
-                {
-                    Code = reader.ReadByte(),
-                    Filename = reader.ReadString(),
-                    Size = reader.ReadLong(),
-                    Extension = reader.ReadString(),
-                    AttributeCount = reader.ReadInteger()
-                };
+                var file = new File(
+                    code: reader.ReadByte(),
+                    filename: reader.ReadString(),
+                    size: reader.ReadLong(),
+                    extension: reader.ReadString(),
+                    attributeCount: reader.ReadInteger());
+
+                var attributeList = new List<FileAttribute>();
 
                 for (int j = 0; j < file.AttributeCount; j++)
                 {
-                    var attribute = new FileAttribute
-                    {
-                        Type = (FileAttributeType)reader.ReadInteger(),
-                        Value = reader.ReadInteger()
-                    };
+                    var attribute = new FileAttribute(
+                        type: (FileAttributeType)reader.ReadInteger(),
+                        value: reader.ReadInteger());
 
-                    file.AttributeList.Add(attribute);
+                    attributeList.Add(attribute);
                 }
 
-                files.Add(file);
+                files.Add(new File(
+                    code: file.Code,
+                    filename: file.Filename,
+                    size: file.Size,
+                    extension: file.Extension,
+                    attributeCount: file.AttributeCount,
+                    attributeList: attributeList));
             }
 
             return files;

--- a/src/Soulseek.NET/SoulseekClient.cs
+++ b/src/Soulseek.NET/SoulseekClient.cs
@@ -642,7 +642,17 @@ namespace Soulseek.NET
                     break;
 
                 case MessageCode.PeerBrowseResponse:
-                    MessageWaiter.Complete(new WaitKey(MessageCode.PeerBrowseResponse, connection.Key.Username), BrowseResponse.Parse(message));
+                    var browseWaitKey = new WaitKey(MessageCode.PeerBrowseResponse, connection.Key.Username);
+
+                    if (BrowseResponse.TryParse(message, out var browseResponse))
+                    {
+                        MessageWaiter.Complete(browseWaitKey, browseResponse);
+                    }
+                    else
+                    {
+                        MessageWaiter.Throw(browseWaitKey, new MessageReadException("The peer returned an invalid browse response."));
+                    }
+
                     break;
 
                 case MessageCode.PeerTransferResponse:

--- a/tests/Soulseek.NET.Tests.Unit/Messaging/ResponsesTests.cs
+++ b/tests/Soulseek.NET.Tests.Unit/Messaging/ResponsesTests.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="ResponsesTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+//     published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+//     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.NET.Tests.Unit.Messaging
+{
+    using System;
+    using Soulseek.NET.Messaging;
+    using Soulseek.NET.Messaging.Responses;
+    using Xunit;
+
+    public class ResponsesTests
+    {
+
+    }
+}


### PR DESCRIPTION
Make `.TryParse()` follow the same pattern from the .NET framework.