### PR TITLE
Handle PeerQueueFailed messages when download is rejected

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -69,7 +69,7 @@
             Arguments.Populate(clearExistingValues: false);
 
             var options = new SoulseekClientOptions(
-                minimumDiagnosticLevel: DiagnosticLevel.None,
+                minimumDiagnosticLevel: DiagnosticLevel.Debug,
                 peerConnectionOptions: new ConnectionOptions(connectTimeout: 30, readTimeout: 5),
                 transferConnectionOptions: new ConnectionOptions(connectTimeout: 30, readTimeout: 10)
             );

--- a/src/Soulseek/Common/Exceptions/DownloadException.cs
+++ b/src/Soulseek/Common/Exceptions/DownloadException.cs
@@ -64,4 +64,53 @@ namespace Soulseek.Exceptions
         {
         }
     }
+
+    /// <summary>
+    ///     Represents errors that occur when a download request is rejected.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class DownloadRejectedException : SoulseekClientException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DownloadRejectedException"/> class.
+        /// </summary>
+        public DownloadRejectedException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DownloadRejectedException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public DownloadRejectedException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DownloadRejectedException"/> class with a specified error message and a
+        ///     reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner
+        ///     exception is specified.
+        /// </param>
+        public DownloadRejectedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DownloadRejectedException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected DownloadRejectedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
 }

--- a/src/Soulseek/DownloadStates.cs
+++ b/src/Soulseek/DownloadStates.cs
@@ -73,5 +73,10 @@ namespace Soulseek
         ///     Completed due to transfer error.
         /// </summary>
         Errored = 256,
+
+        /// <summary>
+        ///     Completed due to rejection by peer.
+        /// </summary>
+        Rejected = 512,
     }
 }

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -966,5 +966,59 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.IsType<TimeoutException>(ex.InnerException);
             }
         }
+
+        [Trait("Category", "DownloadInternalAsync")]
+        [Theory(DisplayName = "DownloadInternalAsync throws DownloadException on transfer rejection"), AutoData]
+        public async Task DownloadInternalAsync_Throws_DownloadException_On_Transfer_Rejection(string username, IPAddress ip, int port, string filename, int token, int size)
+        {
+            var options = new SoulseekClientOptions(messageTimeout: 5);
+
+            var response = new PeerTransferResponse(token, false, size, string.Empty);
+            var responseWaitKey = new WaitKey(MessageCode.PeerTransferResponse, username, token);
+
+            var request = new PeerTransferRequest(TransferDirection.Download, token, filename, size);
+
+            var transferConn = new Mock<IConnection>();
+            transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
+
+            var waiter = new Mock<IWaiter>();
+            waiter.Setup(m => m.Wait<PeerTransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+
+            waiter.Setup(m => m.WaitIndefinitely<PeerTransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                .Throws(new DownloadRejectedException("foo"));
+
+            waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            waiter.Setup(m => m.WaitIndefinitely<byte[]>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<byte[]>(data));
+            waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(transferConn.Object));
+            waiter.Setup(m => m.Wait<GetPeerAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetPeerAddressResponse(username, ip, port)));
+
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            var connManager = new Mock<IConnectionManager>();
+            connManager.Setup(m => m.GetOrAddUnsolicitedConnectionAsync(It.IsAny<ConnectionKey>(), It.IsAny<string>(), It.IsAny<EventHandler<Message>>(), It.IsAny<ConnectionOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(conn.Object));
+
+            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, connectionManager: connManager.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                byte[] downloadedData = null;
+                var ex = await Record.ExceptionAsync(async () => downloadedData = await s.InvokeMethod<Task<byte[]>>("DownloadInternalAsync", username, filename, token, new DownloadOptions(), null));
+
+                Assert.NotNull(ex);
+                Assert.IsType<DownloadException>(ex);
+                Assert.IsType<DownloadRejectedException>(ex.InnerException);
+            }
+        }
     }
 }


### PR DESCRIPTION
Receipt of this message will now properly report a download as failed.

Closes #122