### PR TITLE
Add defensive code around WaitIndefinitely to prevent stuck waits

### DIFF
--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -1613,9 +1613,9 @@ namespace Soulseek
 
             try
             {
-                MessageReceivedEventArgs responseReceivedEventArgs = default;
-                IMessageConnection responseConnection = default;
-                long responseLength = 0;
+                MessageReceivedEventArgs responseReceivedEventArgs;
+                IMessageConnection responseConnection;
+                long? responseLength;
 
                 // prepare an indefinite wait for the operation. this is completed by either successful completion of the message
                 // transfer, or by the receiving connection being disconnected.
@@ -1636,7 +1636,7 @@ namespace Soulseek
 
                     // wait for the receipt of the response message.  this may come back on a connection different from the one which made the request.
                     (responseReceivedEventArgs, responseConnection) = await responseConnectionWait.ConfigureAwait(false);
-                    responseLength = responseReceivedEventArgs.Length - 4;
+                    responseLength = responseReceivedEventArgs?.Length - 4;
 
                     responseConnection.Disconnected += (sender, args) =>
                         Waiter.Throw(browseWaitKey, new ConnectionException($"Peer connection disconnected unexpectedly: {args.Message}", args.Exception));
@@ -1653,7 +1653,7 @@ namespace Soulseek
 
                 // fake a progress update since we'll always miss the first packet (this is what fires the received event, so
                 // we've already read the first 4k or whatever the read buffer size is)
-                UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs.Code, 0, responseLength));
+                UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs?.Code, 0, responseLength.Value));
 
                 var response = await browseWait.ConfigureAwait(false);
 
@@ -1663,7 +1663,7 @@ namespace Soulseek
                 // case, fake it
                 if (!completionEventFired)
                 {
-                    UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs.Code, responseLength, responseLength));
+                    UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs?.Code, responseLength.Value, responseLength.Value));
                 }
 
                 return response.Directories;

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -1642,17 +1642,17 @@ namespace Soulseek
                         Waiter.Throw(browseWaitKey, new ConnectionException($"Peer connection disconnected unexpectedly: {args.Message}", args.Exception));
 
                     responseConnection.MessageDataRead += UpdateProgress;
-
-                    // fake a progress update since we'll always miss the first packet (this is what fires the received event, so
-                    // we've already read the first 4k or whatever the read buffer size is)
-                    UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs.Code, 0, responseLength));
                 }
                 catch (Exception ex)
                 {
                     // if anything in the try block above threw, throw the wait for the browse.  because it is indefinite, it needs to be removed before
-                    // this code exits.
+                    // this code exits.  once the response connection is returned and the disconnected event bound the risk is mitigated.
                     Waiter.Throw(browseWaitKey, ex);
                 }
+
+                // fake a progress update since we'll always miss the first packet (this is what fires the received event, so
+                // we've already read the first 4k or whatever the read buffer size is)
+                UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs.Code, 0, responseLength));
 
                 var response = await browseWait.ConfigureAwait(false);
 
@@ -1974,7 +1974,7 @@ namespace Soulseek
             }
             finally
             {
-                // clean up the wait in case the code threw before it was awaited.
+                // clean up the waits in case the code threw before they were awaited.
                 Waiter.Complete(download.WaitKey);
                 Waiter.Complete(transferStartRequestedWaitKey);
 

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -1648,6 +1648,7 @@ namespace Soulseek
                     // if anything in the try block above threw, throw the wait for the browse.  because it is indefinite, it needs to be removed before
                     // this code exits.  once the response connection is returned and the disconnected event bound the risk is mitigated.
                     Waiter.Throw(browseWaitKey, ex);
+                    throw;
                 }
 
                 // fake a progress update since we'll always miss the first packet (this is what fires the received event, so

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -1613,6 +1613,10 @@ namespace Soulseek
 
             try
             {
+                MessageReceivedEventArgs responseReceivedEventArgs = default;
+                IMessageConnection responseConnection = default;
+                long responseLength = 0;
+
                 // prepare an indefinite wait for the operation. this is completed by either successful completion of the message
                 // transfer, or by the receiving connection being disconnected.
                 var browseWait = Waiter.WaitIndefinitely<BrowseResponse>(browseWaitKey, cancellationToken);
@@ -1623,23 +1627,32 @@ namespace Soulseek
                 var responseConnectionKey = new WaitKey(Constants.WaitKey.BrowseResponseConnection, username);
                 var responseConnectionWait = Waiter.Wait<(MessageReceivedEventArgs, IMessageConnection)>(responseConnectionKey, options.ResponseTimeout, cancellationToken);
 
-                // fetch the user's address and a connection and write the browse request to the remote user
-                var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
-                var connection = await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
-                await connection.WriteAsync(new BrowseRequest().ToByteArray(), cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    // fetch the user's address and a connection and write the browse request to the remote user
+                    var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
+                    var connection = await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
+                    await connection.WriteAsync(new BrowseRequest().ToByteArray(), cancellationToken).ConfigureAwait(false);
 
-                // wait for the receipt of the response message
-                var (responseReceivedEventArgs, responseConnection) = await responseConnectionWait.ConfigureAwait(false);
-                var responseLength = responseReceivedEventArgs.Length - 4;
+                    // wait for the receipt of the response message.  this may come back on a connection different from the one which made the request.
+                    (responseReceivedEventArgs, responseConnection) = await responseConnectionWait.ConfigureAwait(false);
+                    responseLength = responseReceivedEventArgs.Length - 4;
 
-                responseConnection.Disconnected += (sender, args) =>
-                    Waiter.Throw(browseWaitKey, new ConnectionException($"Peer connection disconnected unexpectedly: {args.Message}", args.Exception));
+                    responseConnection.Disconnected += (sender, args) =>
+                        Waiter.Throw(browseWaitKey, new ConnectionException($"Peer connection disconnected unexpectedly: {args.Message}", args.Exception));
 
-                responseConnection.MessageDataRead += UpdateProgress;
+                    responseConnection.MessageDataRead += UpdateProgress;
 
-                // fake a progress update since we'll always miss the first packet (this is what fires the received event, so
-                // we've already read the first 4k or whatever the read buffer size is)
-                UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs.Code, 0, responseLength));
+                    // fake a progress update since we'll always miss the first packet (this is what fires the received event, so
+                    // we've already read the first 4k or whatever the read buffer size is)
+                    UpdateProgress(responseConnection, new MessageDataReadEventArgs(responseReceivedEventArgs.Code, 0, responseLength));
+                }
+                catch (Exception ex)
+                {
+                    // if anything in the try block above threw, throw the wait for the browse.  because it is indefinite, it needs to be removed before
+                    // this code exits.
+                    Waiter.Throw(browseWaitKey, ex);
+                }
 
                 var response = await browseWait.ConfigureAwait(false);
 
@@ -1802,6 +1815,8 @@ namespace Soulseek
                 TransferProgressUpdated?.Invoke(this, eventArgs);
             }
 
+            var transferStartRequestedWaitKey = new WaitKey(MessageCode.Peer.TransferRequest, download.Username, download.Filename);
+
             try
             {
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
@@ -1812,8 +1827,7 @@ namespace Soulseek
                 // returned immediately, while the request will be sent only when we've reached the front of the remote queue.
                 var transferRequestAcknowledged = Waiter.Wait<TransferResponse>(
                     new WaitKey(MessageCode.Peer.TransferResponse, download.Username, download.Token), null, cancellationToken);
-                var transferStartRequested = Waiter.WaitIndefinitely<TransferRequest>(
-                    new WaitKey(MessageCode.Peer.TransferRequest, download.Username, download.Filename), cancellationToken);
+                var transferStartRequested = Waiter.WaitIndefinitely<TransferRequest>(transferStartRequestedWaitKey, cancellationToken);
 
                 // request the file
                 await peerConnection.WriteAsync(new TransferRequest(TransferDirection.Download, token, filename).ToByteArray(), cancellationToken).ConfigureAwait(false);
@@ -1962,6 +1976,7 @@ namespace Soulseek
             {
                 // clean up the wait in case the code threw before it was awaited.
                 Waiter.Complete(download.WaitKey);
+                Waiter.Complete(transferStartRequestedWaitKey);
 
                 download.Connection?.Dispose();
 


### PR DESCRIPTION
Specifically, within the `BrowseInternalAsync` method the indefinite wait would get "stuck" if the connection wasn't established.  The other instance within the `Download` method is more paranoia than anything; there's a slight chance of a memory leak.