### PR TITLE
Refactor ConnectAsync

### DIFF
--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -184,7 +184,7 @@
                     if (args.Level == DiagnosticLevel.Debug) Console.ForegroundColor = ConsoleColor.DarkGray;
                     if (args.Level == DiagnosticLevel.Warning) Console.ForegroundColor = ConsoleColor.Yellow;
 
-                    Console.WriteLine($"[{DateTime.Now.ToString("HH:mm:ss.fff")}] [DIAGNOSTIC:{e.GetType().Name}] [{args.Level}] {args.Message}");
+                    Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [DIAGNOSTIC:{e.GetType().Name}] [{args.Level}] {args.Message}");
                     Console.ResetColor();
                 }
             };
@@ -295,6 +295,7 @@
         /// <exception cref="Exception">Thrown on any other Exception other than a rejection.  A generic message will be passed to the remote user for security reasons.</exception>
         private Task EnqueueDownloadAction(string username, IPEndPoint endpoint, string filename, ITransferTracker tracker)
         {
+            _ = endpoint;
             filename = filename.ToLocalOSPath();
             var fileInfo = new FileInfo(filename);
 

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -166,7 +166,7 @@
                 minimumDiagnosticLevel: DiagnosticLevel,
                 serverConnectionOptions: new ConnectionOptions(connectTimeout: ConnectTimeout, inactivityTimeout: InactivityTimeout),
                 peerConnectionOptions: new ConnectionOptions(connectTimeout: ConnectTimeout, inactivityTimeout: InactivityTimeout),
-                transferConnectionOptions: new ConnectionOptions(connectTimeout: ConnectTimeout, inactivityTimeout: InactivityTimeout),
+                transferConnectionOptions: new ConnectionOptions(connectTimeout: ConnectTimeout, inactivityTimeout: 0),
                 userInfoResponseResolver: UserInfoResponseResolver,
                 browseResponseResolver: BrowseResponseResolver,
                 directoryContentsResponseResolver: DirectoryContentsResponseResolver,

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -51,7 +51,7 @@
             ListenPort = Configuration.GetValue<int>("LISTEN_PORT", 50000);
             OutputDirectory = Configuration.GetValue<string>("OUTPUT_DIR");
             SharedDirectory = Configuration.GetValue<string>("SHARED_DIR");
-            EnableDistributedNetwork = Configuration.GetValue<bool>("ENABLE_DNET", true);
+            EnableDistributedNetwork = Configuration.GetValue<bool>("ENABLE_DNET", false);
             DistributedChildLimit = Configuration.GetValue<int>("DNET_CHILD_LIMIT", 10);
             DiagnosticLevel = Configuration.GetValue<DiagnosticLevel>("DIAGNOSTIC", DiagnosticLevel.Info);
             ConnectTimeout = Configuration.GetValue<int>("CONNECT_TIMEOUT", 5000);

--- a/src/Soulseek/Common/Extensions.cs
+++ b/src/Soulseek/Common/Extensions.cs
@@ -108,23 +108,6 @@ namespace Soulseek
         }
 
         /// <summary>
-        ///     Resolves the IP address in the given string to an instance of <see cref="IPAddress"/>.
-        /// </summary>
-        /// <param name="address">The IP address string to resolve.</param>
-        /// <returns>The resolved IPAddress.</returns>
-        public static IPAddress ResolveIPAddress(this string address)
-        {
-            if (IPAddress.TryParse(address, out IPAddress ip))
-            {
-                return ip;
-            }
-            else
-            {
-                return Dns.GetHostEntry(address).AddressList[0];
-            }
-        }
-
-        /// <summary>
         ///     Returns the MD5 hash of a string.
         /// </summary>
         /// <param name="str">The string to hash.</param>

--- a/src/Soulseek/Common/Extensions.cs
+++ b/src/Soulseek/Common/Extensions.cs
@@ -17,7 +17,6 @@ namespace Soulseek
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
-    using System.Net;
     using System.Security.Cryptography;
     using System.Text;
     using System.Threading.Tasks;

--- a/src/Soulseek/ConnectionOptions.cs
+++ b/src/Soulseek/ConnectionOptions.cs
@@ -72,6 +72,37 @@ namespace Soulseek
         }
 
         /// <summary>
+        ///     Returns true if the specified instance is equal to this instance, false otherwise.
+        /// </summary>
+        /// <param name="obj">The instance to which to compare this one.</param>
+        /// <returns>A value indicating whether the instances are equal.</returns>
+        public override bool Equals(object obj)
+        {
+            try
+            {
+                var right = (ConnectionOptions)obj;
+
+                return ReadBufferSize == right?.ReadBufferSize
+                    && WriteBufferSize == right?.WriteBufferSize
+                    && ConnectTimeout == right?.ConnectTimeout
+                    && InactivityTimeout == right?.InactivityTimeout;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code for this instance.</returns>
+        public override int GetHashCode()
+        {
+            return ReadBufferSize.GetHashCode() + WriteBufferSize.GetHashCode() + ConnectTimeout.GetHashCode() + InactivityTimeout.GetHashCode();
+        }
+
+        /// <summary>
         ///     Returns this instance with <see cref="InactivityTimeout"/> fixed to -1, disabling it.
         /// </summary>
         /// <returns>This instance with InactivityTimeout disabled.</returns>

--- a/src/Soulseek/ConnectionOptions.cs
+++ b/src/Soulseek/ConnectionOptions.cs
@@ -21,13 +21,17 @@ namespace Soulseek
         ///     Initializes a new instance of the <see cref="ConnectionOptions"/> class.
         /// </summary>
         /// <param name="readBufferSize">The read buffer size for underlying TCP connections.</param>
+        /// <param name="readTimeout">The timeout, in milliseconds, for individual read operations.</param>
         /// <param name="writeBufferSize">The write buffer size for underlying TCP connections.</param>
+        /// <param name="writeTimeout">The timeout, in milliseconds, for individual write operations.</param>
         /// <param name="connectTimeout">The connection timeout, in milliseconds, for client and peer TCP connections.</param>
         /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
-        public ConnectionOptions(int readBufferSize = 8192, int writeBufferSize = 8192, int connectTimeout = 5000, int inactivityTimeout = 15000)
+        public ConnectionOptions(int readBufferSize = 8192, int readTimeout = 5000, int writeBufferSize = 8192, int writeTimeout = 5000, int connectTimeout = 5000, int inactivityTimeout = 15000)
         {
             ReadBufferSize = readBufferSize;
+            ReadTimeout = readTimeout;
             WriteBufferSize = writeBufferSize;
+            WriteTimeout = writeTimeout;
             ConnectTimeout = connectTimeout;
             InactivityTimeout = inactivityTimeout;
         }
@@ -52,21 +56,35 @@ namespace Soulseek
         public int ReadBufferSize { get; }
 
         /// <summary>
+        ///     Gets the timeout, in milliseconds, for individual read operations. (Default = 5000).
+        /// </summary>
+        public int ReadTimeout { get; }
+
+        /// <summary>
         ///     Gets the write buffer size for underlying TCP connections. (Default = 8192).
         /// </summary>
         public int WriteBufferSize { get; }
 
         /// <summary>
+        ///     Gets the timeout, in milliseconds, for individual write operations. (Default = 5000).
+        /// </summary>
+        public int WriteTimeout { get; }
+
+        /// <summary>
         ///     Deconstructs this instance.
         /// </summary>
         /// <param name="readBufferSize">The read buffer size for underlying TCP connections.</param>
+        /// <param name="readTimeout">The timeout, in milliseconds, for individual read operations.</param>
         /// <param name="writeBufferSize">The write buffer size for underlying TCP connections.</param>
+        /// <param name="writeTimeout">The timeout, in milliseconds, for individual write operations.</param>
         /// <param name="connectTimeout">The connection timeout, in milliseconds, for client and peer TCP connections.</param>
         /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
-        public void Deconstruct(out int readBufferSize, out int writeBufferSize, out int connectTimeout, out int inactivityTimeout)
+        public void Deconstruct(out int readBufferSize, out int readTimeout, out int writeBufferSize, out int writeTimeout, out int connectTimeout, out int inactivityTimeout)
         {
             readBufferSize = ReadBufferSize;
+            readTimeout = ReadTimeout;
             writeBufferSize = WriteBufferSize;
+            writeTimeout = WriteTimeout;
             connectTimeout = ConnectTimeout;
             inactivityTimeout = InactivityTimeout;
         }

--- a/src/Soulseek/ConnectionOptions.cs
+++ b/src/Soulseek/ConnectionOptions.cs
@@ -21,17 +21,13 @@ namespace Soulseek
         ///     Initializes a new instance of the <see cref="ConnectionOptions"/> class.
         /// </summary>
         /// <param name="readBufferSize">The read buffer size for underlying TCP connections.</param>
-        /// <param name="readTimeout">The timeout, in milliseconds, for individual read operations.</param>
         /// <param name="writeBufferSize">The write buffer size for underlying TCP connections.</param>
-        /// <param name="writeTimeout">The timeout, in milliseconds, for individual write operations.</param>
         /// <param name="connectTimeout">The connection timeout, in milliseconds, for client and peer TCP connections.</param>
         /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
-        public ConnectionOptions(int readBufferSize = 8192, int readTimeout = 5000, int writeBufferSize = 8192, int writeTimeout = 5000, int connectTimeout = 5000, int inactivityTimeout = 15000)
+        public ConnectionOptions(int readBufferSize = 8192, int writeBufferSize = 8192, int connectTimeout = 5000, int inactivityTimeout = 15000)
         {
             ReadBufferSize = readBufferSize;
-            ReadTimeout = readTimeout;
             WriteBufferSize = writeBufferSize;
-            WriteTimeout = writeTimeout;
             ConnectTimeout = connectTimeout;
             InactivityTimeout = inactivityTimeout;
         }
@@ -56,35 +52,21 @@ namespace Soulseek
         public int ReadBufferSize { get; }
 
         /// <summary>
-        ///     Gets the timeout, in milliseconds, for individual read operations. (Default = 5000).
-        /// </summary>
-        public int ReadTimeout { get; }
-
-        /// <summary>
         ///     Gets the write buffer size for underlying TCP connections. (Default = 8192).
         /// </summary>
         public int WriteBufferSize { get; }
 
         /// <summary>
-        ///     Gets the timeout, in milliseconds, for individual write operations. (Default = 5000).
-        /// </summary>
-        public int WriteTimeout { get; }
-
-        /// <summary>
         ///     Deconstructs this instance.
         /// </summary>
         /// <param name="readBufferSize">The read buffer size for underlying TCP connections.</param>
-        /// <param name="readTimeout">The timeout, in milliseconds, for individual read operations.</param>
         /// <param name="writeBufferSize">The write buffer size for underlying TCP connections.</param>
-        /// <param name="writeTimeout">The timeout, in milliseconds, for individual write operations.</param>
         /// <param name="connectTimeout">The connection timeout, in milliseconds, for client and peer TCP connections.</param>
         /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
-        public void Deconstruct(out int readBufferSize, out int readTimeout, out int writeBufferSize, out int writeTimeout, out int connectTimeout, out int inactivityTimeout)
+        public void Deconstruct(out int readBufferSize, out int writeBufferSize, out int connectTimeout, out int inactivityTimeout)
         {
             readBufferSize = ReadBufferSize;
-            readTimeout = ReadTimeout;
             writeBufferSize = WriteBufferSize;
-            writeTimeout = WriteTimeout;
             connectTimeout = ConnectTimeout;
             inactivityTimeout = InactivityTimeout;
         }

--- a/src/Soulseek/ConnectionOptions.cs
+++ b/src/Soulseek/ConnectionOptions.cs
@@ -70,5 +70,14 @@ namespace Soulseek
             connectTimeout = ConnectTimeout;
             inactivityTimeout = InactivityTimeout;
         }
+
+        /// <summary>
+        ///     Returns this instance with <see cref="InactivityTimeout"/> fixed to -1, disabling it.
+        /// </summary>
+        /// <returns>This instance with InactivityTimeout disabled.</returns>
+        public ConnectionOptions WithoutInactivityTimeout()
+        {
+            return new ConnectionOptions(ReadBufferSize, WriteBufferSize, ConnectTimeout, inactivityTimeout: -1);
+        }
     }
 }

--- a/src/Soulseek/ConnectionOptions.cs
+++ b/src/Soulseek/ConnectionOptions.cs
@@ -57,52 +57,6 @@ namespace Soulseek
         public int WriteBufferSize { get; }
 
         /// <summary>
-        ///     Deconstructs this instance.
-        /// </summary>
-        /// <param name="readBufferSize">The read buffer size for underlying TCP connections.</param>
-        /// <param name="writeBufferSize">The write buffer size for underlying TCP connections.</param>
-        /// <param name="connectTimeout">The connection timeout, in milliseconds, for client and peer TCP connections.</param>
-        /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
-        public void Deconstruct(out int readBufferSize, out int writeBufferSize, out int connectTimeout, out int inactivityTimeout)
-        {
-            readBufferSize = ReadBufferSize;
-            writeBufferSize = WriteBufferSize;
-            connectTimeout = ConnectTimeout;
-            inactivityTimeout = InactivityTimeout;
-        }
-
-        /// <summary>
-        ///     Returns true if the specified instance is equal to this instance, false otherwise.
-        /// </summary>
-        /// <param name="obj">The instance to which to compare this one.</param>
-        /// <returns>A value indicating whether the instances are equal.</returns>
-        public override bool Equals(object obj)
-        {
-            try
-            {
-                var right = (ConnectionOptions)obj;
-
-                return ReadBufferSize == right?.ReadBufferSize
-                    && WriteBufferSize == right?.WriteBufferSize
-                    && ConnectTimeout == right?.ConnectTimeout
-                    && InactivityTimeout == right?.InactivityTimeout;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        ///     Returns the hash code for this instance.
-        /// </summary>
-        /// <returns>The hash code for this instance.</returns>
-        public override int GetHashCode()
-        {
-            return ReadBufferSize.GetHashCode() + WriteBufferSize.GetHashCode() + ConnectTimeout.GetHashCode() + InactivityTimeout.GetHashCode();
-        }
-
-        /// <summary>
         ///     Returns this instance with <see cref="InactivityTimeout"/> fixed to -1, disabling it.
         /// </summary>
         /// <returns>This instance with InactivityTimeout disabled.</returns>

--- a/src/Soulseek/Exceptions/AddressException.cs
+++ b/src/Soulseek/Exceptions/AddressException.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="AddressException.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+//     as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+//     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Exceptions
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    ///     Represents errors that occur while changing the currently logged in user's password.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class AddressException : SoulseekClientException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AddressException"/> class.
+        /// </summary>
+        public AddressException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AddressException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public AddressException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AddressException"/> class with a specified error message and a
+        ///     reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no
+        ///     inner exception is specified.
+        /// </param>
+        public AddressException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AddressException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected AddressException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Soulseek/ISoulseekClient.cs
+++ b/src/Soulseek/ISoulseekClient.cs
@@ -239,8 +239,11 @@ namespace Soulseek
         Task ChangePasswordAsync(string password, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously connects the client to the server specified in the <see cref="Address"/> and <see cref="Port"/> properties.
+        ///     Asynchronously connects the client to default server, but does not log in.
         /// </summary>
+        /// <remarks>
+        ///     To fully establish a connection, <see cref="LoginAsync(string, string, CancellationToken?)"/> must be invoked.
+        /// </remarks>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
@@ -250,23 +253,51 @@ namespace Soulseek
         Task ConnectAsync(CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously connects the client to the server specified in the <see cref="Address"/> and <see cref="Port"/>
-        ///     properties, then logs in using the specified <paramref name="username"/> and <paramref name="password"/>.
+        ///     Asynchronously connects the client to the specified server <paramref name="address"/> and <paramref name="port"/>,
+        ///     but does not log in.
+        /// </summary>
+        /// <remarks>
+        ///     To fully establish a connection, <see cref="LoginAsync(string, string, CancellationToken?)"/> must be invoked.
+        /// </remarks>
+        /// <param name="address">The address of the server to which to connect.</param>
+        /// <param name="port">The port to which to connect.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="ConnectionException">Thrown when an exception is encountered during the operation.</exception>
+        Task ConnectAsync(string address, int port, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        ///     Asynchronously connects the client to the default server and logs in using the specified
+        ///     <paramref name="username"/> and <paramref name="password"/>.
         /// </summary>
         /// <param name="username">The username with which to log in.</param>
         /// <param name="password">The password with which to log in.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="password"/> is null, empty, or consists only of whitespace.
-        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
-        /// <exception cref="ConnectionException">Thrown when an exception is encountered while establishing the connection.</exception>
-        /// <exception cref="LoginRejectedException">Thrown when the login is rejected by the remote server.</exception>
-        /// <exception cref="LoginException">Thrown when an exception is encountered during the login operation.</exception>
+        /// <exception cref="ConnectionException">Thrown when an exception is encountered during the operation.</exception>
         Task ConnectAsync(string username, string password, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        ///     Asynchronously connects the client to the specified server <paramref name="address"/> and <paramref name="port"/>
+        ///     and logs in using the specified <paramref name="username"/> and <paramref name="password"/>.
+        /// </summary>
+        /// <param name="address">The address of the server to which to connect.</param>
+        /// <param name="port">The port to which to connect.</param>
+        /// <param name="username">The username with which to log in.</param>
+        /// <param name="password">The password with which to log in.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="ConnectionException">Thrown when an exception is encountered during the operation.</exception>
+        Task ConnectAsync(string address, int port, string username, string password, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Disconnects the client from the server.

--- a/src/Soulseek/ISoulseekClient.cs
+++ b/src/Soulseek/ISoulseekClient.cs
@@ -141,7 +141,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the server port.
         /// </summary>
-        int Port { get; }
+        int? Port { get; }
 
         /// <summary>
         ///     Gets the current state of the underlying TCP connection.

--- a/src/Soulseek/ISoulseekClient.cs
+++ b/src/Soulseek/ISoulseekClient.cs
@@ -263,6 +263,12 @@ namespace Soulseek
         /// <param name="port">The port to which to connect.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="address"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="port"/> is not within the valid port range 0-65535.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -277,6 +283,9 @@ namespace Soulseek
         /// <param name="password">The password with which to log in.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/> or <paramref name="password"/> is null or empty.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -293,6 +302,15 @@ namespace Soulseek
         /// <param name="password">The password with which to log in.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="address"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="port"/> is not within the valid port range 0-65535.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/> or <paramref name="password"/> is null or empty.
+        /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>

--- a/src/Soulseek/Network/ConnectionFactory.cs
+++ b/src/Soulseek/Network/ConnectionFactory.cs
@@ -12,6 +12,7 @@
 
 namespace Soulseek.Network
 {
+    using System;
     using System.Net;
     using Soulseek.Network.Tcp;
 
@@ -21,16 +22,6 @@ namespace Soulseek.Network
     internal sealed class ConnectionFactory : IConnectionFactory
     {
         /// <summary>
-        ///     Gets a <see cref="IConnection"/> with the specified parameters.
-        /// </summary>
-        /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
-        /// <param name="options">The optional options for the connection.</param>
-        /// <param name="tcpClient">The optional TcpClient instance to use.</param>
-        /// <returns>The created connection.</returns>
-        public IConnection GetConnection(IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null) =>
-            new Connection(ipEndPoint, options, tcpClient);
-
-        /// <summary>
         ///     Gets a <see cref="IMessageConnection"/> with the specified parameters.
         /// </summary>
         /// <param name="username">The username of the peer associated with the connection, if applicable.</param>
@@ -39,6 +30,49 @@ namespace Soulseek.Network
         /// <param name="tcpClient">The optional TcpClient instance to use.</param>
         /// <returns>The created connection.</returns>
         public IMessageConnection GetMessageConnection(string username, IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null) =>
-            new MessageConnection(username, ipEndPoint, options, tcpClient);
+            new MessageConnection(username, ipEndPoint, options ?? new ConnectionOptions(), tcpClient);
+
+        /// <summary>
+        ///     Gets a <see cref="IMessageConnection"/> for use with a server connection and binds the specified event handlers
+        ///     before returning.
+        /// </summary>
+        /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
+        /// <param name="connectedEventHandler">The event handler for <see cref="IConnection.Connected"/>.</param>
+        /// <param name="disconnectedEventHandler">The handler for <see cref="IConnection.Disconnected"/>.</param>
+        /// <param name="messageReadEventHandler">The handler for <see cref="IMessageConnection.MessageRead"/>.</param>
+        /// <param name="options">The options for the connection.</param>
+        /// <param name="tcpClient">The optional TcpClient instance to use.</param>
+        /// <returns>The created connection with event handlers bound.</returns>
+        public IMessageConnection GetServerConnection(
+            IPEndPoint ipEndPoint,
+            EventHandler connectedEventHandler,
+            EventHandler<ConnectionDisconnectedEventArgs> disconnectedEventHandler,
+            EventHandler<MessageReadEventArgs> messageReadEventHandler,
+            ConnectionOptions options = null,
+            ITcpClient tcpClient = null)
+        {
+            var connection = new MessageConnection(ipEndPoint, GetOptionsWithoutInactivityTimeout(options ?? new ConnectionOptions()), tcpClient);
+            connection.Connected += connectedEventHandler;
+            connection.Disconnected += disconnectedEventHandler;
+            connection.MessageRead += messageReadEventHandler;
+
+            return connection;
+        }
+
+        /// <summary>
+        ///     Gets a <see cref="IConnection"/> for use with transfer connections with the specified parameters.
+        /// </summary>
+        /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
+        /// <param name="options">The optional options for the connection.</param>
+        /// <param name="tcpClient">The optional TcpClient instance to use.</param>
+        /// <returns>The created connection.</returns>
+        public IConnection GetTransferConnection(IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null) =>
+            new Connection(ipEndPoint, GetOptionsWithoutInactivityTimeout(options ?? new ConnectionOptions()), tcpClient);
+
+        private ConnectionOptions GetOptionsWithoutInactivityTimeout(ConnectionOptions options = null)
+        {
+            var (readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, _) = options ?? new ConnectionOptions();
+            return new ConnectionOptions(readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, inactivityTimeout: -1);
+        }
     }
 }

--- a/src/Soulseek/Network/ConnectionFactory.cs
+++ b/src/Soulseek/Network/ConnectionFactory.cs
@@ -51,7 +51,7 @@ namespace Soulseek.Network
             ConnectionOptions options = null,
             ITcpClient tcpClient = null)
         {
-            var connection = new MessageConnection(ipEndPoint, GetOptionsWithoutInactivityTimeout(options ?? new ConnectionOptions()), tcpClient);
+            var connection = new MessageConnection(ipEndPoint, (options ?? new ConnectionOptions()).WithoutInactivityTimeout(), tcpClient);
             connection.Connected += connectedEventHandler;
             connection.Disconnected += disconnectedEventHandler;
             connection.MessageRead += messageReadEventHandler;
@@ -67,12 +67,6 @@ namespace Soulseek.Network
         /// <param name="tcpClient">The optional TcpClient instance to use.</param>
         /// <returns>The created connection.</returns>
         public IConnection GetTransferConnection(IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null) =>
-            new Connection(ipEndPoint, GetOptionsWithoutInactivityTimeout(options ?? new ConnectionOptions()), tcpClient);
-
-        private ConnectionOptions GetOptionsWithoutInactivityTimeout(ConnectionOptions options = null)
-        {
-            var (readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, _) = options ?? new ConnectionOptions();
-            return new ConnectionOptions(readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, inactivityTimeout: -1);
-        }
+            new Connection(ipEndPoint, (options ?? new ConnectionOptions()).WithoutInactivityTimeout(), tcpClient);
     }
 }

--- a/src/Soulseek/Network/IConnectionFactory.cs
+++ b/src/Soulseek/Network/IConnectionFactory.cs
@@ -12,6 +12,7 @@
 
 namespace Soulseek.Network
 {
+    using System;
     using System.Net;
     using Soulseek.Network.Tcp;
 
@@ -21,15 +22,6 @@ namespace Soulseek.Network
     internal interface IConnectionFactory
     {
         /// <summary>
-        ///     Gets a <see cref="IConnection"/> with the specified parameters.
-        /// </summary>
-        /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
-        /// <param name="options">The optional options for the connection.</param>
-        /// <param name="tcpClient">The optional TcpClient instance to use.</param>
-        /// <returns>The created connection.</returns>
-        IConnection GetConnection(IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null);
-
-        /// <summary>
         ///     Gets a <see cref="IMessageConnection"/> with the specified parameters.
         /// </summary>
         /// <param name="username">The username of the peer associated with the connection, if applicable.</param>
@@ -38,5 +30,33 @@ namespace Soulseek.Network
         /// <param name="tcpClient">The optional TcpClient instance to use.</param>
         /// <returns>The created connection.</returns>
         IMessageConnection GetMessageConnection(string username, IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null);
+
+        /// <summary>
+        ///     Gets a <see cref="IMessageConnection"/> for use with a server connection and binds the specified event handlers
+        ///     before returning.
+        /// </summary>
+        /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
+        /// <param name="connectedEventHandler">The event handler for <see cref="IConnection.Connected"/>.</param>
+        /// <param name="disconnectedEventHandler">The handler for <see cref="IConnection.Disconnected"/>.</param>
+        /// <param name="messageReadEventHandler">The handler for <see cref="IMessageConnection.MessageRead"/>.</param>
+        /// <param name="options">The options for the connection.</param>
+        /// <param name="tcpClient">The optional TcpClient instance to use.</param>
+        /// <returns>The created connection with event handlers bound.</returns>
+        IMessageConnection GetServerConnection(
+            IPEndPoint ipEndPoint,
+            EventHandler connectedEventHandler,
+            EventHandler<ConnectionDisconnectedEventArgs> disconnectedEventHandler,
+            EventHandler<MessageReadEventArgs> messageReadEventHandler,
+            ConnectionOptions options = null,
+            ITcpClient tcpClient = null);
+
+        /// <summary>
+        ///     Gets a <see cref="IConnection"/> for use with transfer connections with the specified parameters.
+        /// </summary>
+        /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
+        /// <param name="options">The optional options for the connection.</param>
+        /// <param name="tcpClient">The optional TcpClient instance to use.</param>
+        /// <returns>The created connection.</returns>
+        IConnection GetTransferConnection(IPEndPoint ipEndPoint, ConnectionOptions options = null, ITcpClient tcpClient = null);
     }
 }

--- a/src/Soulseek/Network/PeerConnectionManager.cs
+++ b/src/Soulseek/Network/PeerConnectionManager.cs
@@ -164,7 +164,7 @@ namespace Soulseek.Network
         {
             Diagnostic.Debug($"Inbound transfer connection to {username} ({incomingConnection.IPEndPoint}) for token {token} accepted. (type: {incomingConnection.Type}, id: {incomingConnection.Id}");
 
-            var connection = ConnectionFactory.GetConnection(
+            var connection = ConnectionFactory.GetTransferConnection(
                 incomingConnection.IPEndPoint,
                 SoulseekClient.Options.TransferConnectionOptions,
                 incomingConnection.HandoffTcpClient());
@@ -455,7 +455,7 @@ namespace Soulseek.Network
         {
             Diagnostic.Debug($"Attempting inbound indirect transfer connection to {connectToPeerResponse.Username} ({connectToPeerResponse.IPEndPoint}) for token {connectToPeerResponse.Token}");
 
-            var connection = ConnectionFactory.GetConnection(
+            var connection = ConnectionFactory.GetTransferConnection(
                 connectToPeerResponse.IPEndPoint,
                 SoulseekClient.Options.TransferConnectionOptions);
 
@@ -659,7 +659,7 @@ namespace Soulseek.Network
         {
             Diagnostic.Debug($"Attempting direct transfer connection for token {token} to {ipEndPoint}");
 
-            var connection = ConnectionFactory.GetConnection(ipEndPoint, SoulseekClient.Options.TransferConnectionOptions);
+            var connection = ConnectionFactory.GetTransferConnection(ipEndPoint, SoulseekClient.Options.TransferConnectionOptions);
 
             connection.Type = ConnectionTypes.Outbound | ConnectionTypes.Direct;
             connection.Disconnected += (sender, e) => Diagnostic.Debug($"Transfer connection for token {token} to {ipEndPoint} disconnected. (type: {connection.Type}, id: {connection.Id})");
@@ -697,7 +697,7 @@ namespace Soulseek.Network
                     .Wait<IConnection>(new WaitKey(Constants.WaitKey.SolicitedPeerConnection, username, solicitationToken), SoulseekClient.Options.TransferConnectionOptions.ConnectTimeout, cancellationToken)
                     .ConfigureAwait(false))
                 {
-                    var connection = ConnectionFactory.GetConnection(
+                    var connection = ConnectionFactory.GetTransferConnection(
                         incomingConnection.IPEndPoint,
                         SoulseekClient.Options.TransferConnectionOptions,
                         incomingConnection.HandoffTcpClient());

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -2060,8 +2060,8 @@ namespace Soulseek
         private IMessageConnection GetServerConnection(IPEndPoint endpoint, SoulseekClientOptions options, IServerMessageHandler serverMessageHandler)
         {
             // substitute the existing inactivity value with -1 to keep the connection open indefinitely
-            var (readBufferSize, writeBufferSize, connectTimeout, _) = options.ServerConnectionOptions;
-            var connectionOptions = new ConnectionOptions(readBufferSize, writeBufferSize, connectTimeout, inactivityTimeout: -1);
+            var (readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, _) = options.ServerConnectionOptions;
+            var connectionOptions = new ConnectionOptions(readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, inactivityTimeout: -1);
 
             var serverConnection = new MessageConnection(endpoint, connectionOptions);
             serverConnection.Connected += (sender, e) => ChangeState(SoulseekClientStates.Connected, $"Connected to {IPEndPoint}");

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -43,36 +43,13 @@ namespace Soulseek
         /// </summary>
         /// <param name="options">The client options.</param>
         public SoulseekClient(SoulseekClientOptions options)
-            : this(DefaultAddress, DefaultPort, options)
+            : this(options, serverConnection: null)
         {
         }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="SoulseekClient"/> class.
         /// </summary>
-        /// <param name="address">The address of the server to which to connect.</param>
-        /// <param name="port">The port to which to connect.</param>
-        /// <param name="options">The client options.</param>
-        public SoulseekClient(string address = DefaultAddress, int port = DefaultPort, SoulseekClientOptions options = null)
-            : this(address, port, options, null)
-        {
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="SoulseekClient"/> class.
-        /// </summary>
-        /// <param name="endpoint">The IP endpoint of the server to which to connect.</param>
-        /// <param name="options">The client options.</param>
-        public SoulseekClient(IPEndPoint endpoint, SoulseekClientOptions options = null)
-            : this(endpoint?.Address.ToString(), endpoint?.Port ?? DefaultPort, options, null)
-        {
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="SoulseekClient"/> class.
-        /// </summary>
-        /// <param name="address">The address of the server to which to connect.</param>
-        /// <param name="port">The port to which to connect.</param>
         /// <param name="options">The client options.</param>
         /// <param name="serverConnection">The IMessageConnection instance to use.</param>
         /// <param name="connectionFactory">The IConnectionFactory instance to use.</param>
@@ -87,8 +64,6 @@ namespace Soulseek
         /// <param name="tokenFactory">The ITokenFactory instance to use.</param>
         /// <param name="diagnosticFactory">The IDiagnosticFactory instance to use.</param>
         internal SoulseekClient(
-            string address,
-            int port,
             SoulseekClientOptions options = null,
             IMessageConnection serverConnection = null,
             IConnectionFactory connectionFactory = null,
@@ -103,16 +78,8 @@ namespace Soulseek
             ITokenFactory tokenFactory = null,
             IDiagnosticFactory diagnosticFactory = null)
         {
-            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
-            {
-                throw new ArgumentOutOfRangeException(nameof(port), $"The port must be within the range {IPEndPoint.MinPort}-{IPEndPoint.MaxPort} (specified: {port})");
-            }
-
-            Address = address;
-            var ipAddress = ResolveIPAddress(Address);
-            IPEndPoint = new IPEndPoint(ipAddress, port);
-
             Options = options ?? new SoulseekClientOptions();
+            ServerConnection = serverConnection;
 
             Waiter = waiter ?? new Waiter(Options.MessageTimeout);
             TokenFactory = tokenFactory ?? new TokenFactory(Options.StartingToken);
@@ -165,13 +132,6 @@ namespace Soulseek
                 Disconnect("Kicked from server", new KickedFromServerException());
                 KickedFromServer?.Invoke(this, e);
             };
-
-            ServerConnection = serverConnection ?? ConnectionFactory.GetServerConnection(
-                IPEndPoint,
-                ServerConnection_Connected,
-                ServerConnection_Disconnected,
-                ServerConnection_MessageRead,
-                Options.ServerConnectionOptions);
         }
 
         /// <summary>
@@ -279,7 +239,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the unresolved server address.
         /// </summary>
-        public string Address { get; }
+        public string Address { get; private set; }
 
         /// <summary>
         ///     Gets the resolved server address.
@@ -289,7 +249,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the resolved server endpoint.
         /// </summary>
-        public IPEndPoint IPEndPoint { get; }
+        public IPEndPoint IPEndPoint { get; private set; }
 
         /// <summary>
         ///     Gets the resolved server address.
@@ -320,7 +280,7 @@ namespace Soulseek
         internal virtual IPeerConnectionManager PeerConnectionManager { get; }
         internal virtual IPeerMessageHandler PeerMessageHandler { get; }
         internal virtual ConcurrentDictionary<int, SearchInternal> Searches { get; set; } = new ConcurrentDictionary<int, SearchInternal>();
-        internal virtual IMessageConnection ServerConnection { get; }
+        internal virtual IMessageConnection ServerConnection { get; private set; }
         internal virtual IServerMessageHandler ServerMessageHandler { get; }
         internal virtual ConcurrentDictionary<int, TransferInternal> Uploads { get; set; } = new ConcurrentDictionary<int, TransferInternal>();
         internal virtual IWaiter Waiter { get; }
@@ -486,8 +446,11 @@ namespace Soulseek
         }
 
         /// <summary>
-        ///     Asynchronously connects the client to the server specified in the <see cref="Address"/> and <see cref="Port"/> properties.
+        ///     Asynchronously connects the client to default server, but does not log in.
         /// </summary>
+        /// <remarks>
+        ///     To fully establish a connection, <see cref="LoginAsync(string, string, CancellationToken?)"/> must be invoked.
+        /// </remarks>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
@@ -501,26 +464,65 @@ namespace Soulseek
                 throw new InvalidOperationException($"The client is already connected");
             }
 
-            return ConnectInternalAsync(cancellationToken ?? CancellationToken.None);
+            return ConnectInternalAsync(DefaultAddress, DefaultPort, cancellationToken ?? CancellationToken.None);
         }
 
         /// <summary>
-        ///     Asynchronously connects the client to the server specified in the <see cref="Address"/> and <see cref="Port"/>
-        ///     properties, then logs in using the specified <paramref name="username"/> and <paramref name="password"/>.
+        ///     Asynchronously connects the client to the specified server <paramref name="address"/> and <paramref name="port"/>,
+        ///     but does not log in.
+        /// </summary>
+        /// <remarks>
+        ///     To fully establish a connection, <see cref="LoginAsync(string, string, CancellationToken?)"/> must be invoked.
+        /// </remarks>
+        /// <param name="address">The address of the server to which to connect.</param>
+        /// <param name="port">The port to which to connect.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="address"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="port"/> is not within the valid port range 0-65535.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="ConnectionException">Thrown when an exception is encountered during the operation.</exception>
+        public Task ConnectAsync(string address, int port, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                throw new ArgumentException("Address must not be a null or empty string, or one consisting only of whitespace", nameof(address));
+            }
+
+            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
+            {
+                throw new ArgumentOutOfRangeException(nameof(port), $"The port must be within the range {IPEndPoint.MinPort}-{IPEndPoint.MaxPort} (specified: {port})");
+            }
+
+            if (State.HasFlag(SoulseekClientStates.Connected))
+            {
+                throw new InvalidOperationException($"The client is already connected");
+            }
+
+            return ConnectInternalAsync(address, port, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     Asynchronously connects the client to the default server and logs in using the specified
+        ///     <paramref name="username"/> and <paramref name="password"/>.
         /// </summary>
         /// <param name="username">The username with which to log in.</param>
         /// <param name="password">The password with which to log in.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="password"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="password"/> is null or empty.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
-        /// <exception cref="ConnectionException">Thrown when an exception is encountered while establishing the connection.</exception>
-        /// <exception cref="LoginRejectedException">Thrown when the login is rejected by the remote server.</exception>
-        /// <exception cref="LoginException">Thrown when an exception is encountered during the login operation.</exception>
+        /// <exception cref="ConnectionException">Thrown when an exception is encountered during the operation.</exception>
         public Task ConnectAsync(string username, string password, CancellationToken? cancellationToken = null)
         {
             if (string.IsNullOrEmpty(username))
@@ -538,7 +540,60 @@ namespace Soulseek
                 throw new InvalidOperationException($"The client is already connected");
             }
 
-            return ConnectAndLoginAsync(username, password, cancellationToken ?? CancellationToken.None);
+            return ConnectAndLoginAsync(DefaultAddress, DefaultPort, username, password, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     Asynchronously connects the client to the specified server <paramref name="address"/> and <paramref name="port"/>
+        ///     and logs in using the specified <paramref name="username"/> and <paramref name="password"/>.
+        /// </summary>
+        /// <param name="address">The address of the server to which to connect.</param>
+        /// <param name="port">The port to which to connect.</param>
+        /// <param name="username">The username with which to log in.</param>
+        /// <param name="password">The password with which to log in.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="address"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the <paramref name="port"/> is not within the valid port range 0-65535.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/> or <paramref name="password"/> is null or empty.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="ConnectionException">Thrown when an exception is encountered during the operation.</exception>
+        public Task ConnectAsync(string address, int port, string username, string password, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                throw new ArgumentException("Address must not be a null or empty string, or one consisting only of whitespace", nameof(address));
+            }
+
+            if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
+            {
+                throw new ArgumentOutOfRangeException(nameof(port), $"The port must be within the range {IPEndPoint.MinPort}-{IPEndPoint.MaxPort} (specified: {port})");
+            }
+
+            if (string.IsNullOrEmpty(username))
+            {
+                throw new ArgumentException("Username may not be null or an empty string", nameof(username));
+            }
+
+            if (string.IsNullOrEmpty(password))
+            {
+                throw new ArgumentException("Password may not be null or an empty string", nameof(password));
+            }
+
+            if (State.HasFlag(SoulseekClientStates.Connected))
+            {
+                throw new InvalidOperationException($"The client is already connected");
+            }
+
+            return ConnectAndLoginAsync(address, port, username, password, cancellationToken ?? CancellationToken.None);
         }
 
         /// <summary>
@@ -1749,22 +1804,34 @@ namespace Soulseek
             }
         }
 
-        private async Task ConnectAndLoginAsync(string username, string password, CancellationToken cancellationToken)
+        private async Task ConnectAndLoginAsync(string address, int port, string username, string password, CancellationToken cancellationToken)
         {
-            await ConnectInternalAsync(cancellationToken).ConfigureAwait(false);
+            await ConnectInternalAsync(address, port, cancellationToken).ConfigureAwait(false);
             await LoginInternalAsync(username, password, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task ConnectInternalAsync(CancellationToken cancellationToken)
+        private async Task ConnectInternalAsync(string address, int port, CancellationToken cancellationToken)
         {
             try
             {
+                Address = address;
+                var ipAddress = ResolveIPAddress(address);
+                IPEndPoint = new IPEndPoint(ipAddress, port);
+
+                ServerConnection = ConnectionFactory.GetServerConnection(
+                    IPEndPoint,
+                    ServerConnection_Connected,
+                    ServerConnection_Disconnected,
+                    ServerConnection_MessageRead,
+                    Options.ServerConnectionOptions);
+
                 Listener?.Start();
 
                 await ServerConnection.ConnectAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
             {
+                Listener?.Stop();
                 throw new ConnectionException($"Failed to connect: {ex.Message}", ex);
             }
         }

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -2368,7 +2368,7 @@ namespace Soulseek
                 }
                 catch (SocketException ex)
                 {
-                    throw new SoulseekClientException($"Failed to resolve address '{Address}': {ex.Message}", ex);
+                    throw new AddressException($"Failed to resolve address '{Address}': {ex.Message}", ex);
                 }
             }
         }

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -1842,7 +1842,11 @@ namespace Soulseek
             {
                 message = message ?? exception?.Message ?? "Client disconnected";
 
-                ServerConnection.Disconnected -= ServerConnection_Disconnected;
+                if (ServerConnection != default)
+                {
+                    ServerConnection.Disconnected -= ServerConnection_Disconnected;
+                }
+
                 ServerConnection?.Disconnect(message, exception);
 
                 Listener?.Stop();

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -244,7 +244,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the resolved server address.
         /// </summary>
-        public IPAddress IPAddress => IPEndPoint.Address;
+        public IPAddress IPAddress => IPEndPoint?.Address;
 
         /// <summary>
         ///     Gets the resolved server endpoint.
@@ -259,7 +259,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets server port.
         /// </summary>
-        public int Port => IPEndPoint.Port;
+        public int? Port => IPEndPoint?.Port;
 
         /// <summary>
         ///     Gets the current state of the underlying TCP connection.

--- a/src/Soulseek/SoulseekClientOptions.cs
+++ b/src/Soulseek/SoulseekClientOptions.cs
@@ -128,9 +128,9 @@ namespace Soulseek
             MinimumDiagnosticLevel = minimumDiagnosticLevel;
             StartingToken = startingToken;
 
-            ServerConnectionOptions = serverConnectionOptions ?? new ConnectionOptions();
+            ServerConnectionOptions = WithoutInactivityTimeout(serverConnectionOptions ?? new ConnectionOptions());
             PeerConnectionOptions = peerConnectionOptions ?? new ConnectionOptions();
-            TransferConnectionOptions = transferConnectionOptions ?? new ConnectionOptions();
+            TransferConnectionOptions = WithoutInactivityTimeout(transferConnectionOptions ?? new ConnectionOptions());
             IncomingConnectionOptions = incomingConnectionOptions ?? new ConnectionOptions();
             DistributedConnectionOptions = distributedConnectionOptions ?? new ConnectionOptions();
 
@@ -259,5 +259,12 @@ namespace Soulseek
         ///     Gets the delegate used to resolve the <see cref="UserInfo"/> for an incoming request. (Default = a blank/zeroed response).
         /// </summary>
         public Func<string, IPEndPoint, Task<UserInfo>> UserInfoResponseResolver { get; }
+
+        private ConnectionOptions WithoutInactivityTimeout(ConnectionOptions options = null)
+        {
+            options = options ?? new ConnectionOptions();
+            var (readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, _) = options;
+            return new ConnectionOptions(readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, inactivityTimeout: -1);
+        }
     }
 }

--- a/src/Soulseek/SoulseekClientOptions.cs
+++ b/src/Soulseek/SoulseekClientOptions.cs
@@ -128,9 +128,9 @@ namespace Soulseek
             MinimumDiagnosticLevel = minimumDiagnosticLevel;
             StartingToken = startingToken;
 
-            ServerConnectionOptions = WithoutInactivityTimeout(serverConnectionOptions ?? new ConnectionOptions());
+            ServerConnectionOptions = (serverConnectionOptions ?? new ConnectionOptions()).WithoutInactivityTimeout();
             PeerConnectionOptions = peerConnectionOptions ?? new ConnectionOptions();
-            TransferConnectionOptions = WithoutInactivityTimeout(transferConnectionOptions ?? new ConnectionOptions());
+            TransferConnectionOptions = (transferConnectionOptions ?? new ConnectionOptions()).WithoutInactivityTimeout();
             IncomingConnectionOptions = incomingConnectionOptions ?? new ConnectionOptions();
             DistributedConnectionOptions = distributedConnectionOptions ?? new ConnectionOptions();
 
@@ -259,12 +259,5 @@ namespace Soulseek
         ///     Gets the delegate used to resolve the <see cref="UserInfo"/> for an incoming request. (Default = a blank/zeroed response).
         /// </summary>
         public Func<string, IPEndPoint, Task<UserInfo>> UserInfoResponseResolver { get; }
-
-        private ConnectionOptions WithoutInactivityTimeout(ConnectionOptions options = null)
-        {
-            options = options ?? new ConnectionOptions();
-            var (readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, _) = options;
-            return new ConnectionOptions(readBufferSize, readTimeout, writeBufferSize, writeTimeout, connectTimeout, inactivityTimeout: -1);
-        }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Client/AcknowledgePrivilegeNotificationAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AcknowledgePrivilegeNotificationAsyncTests.cs
@@ -72,7 +72,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -90,7 +90,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -110,7 +110,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -129,7 +129,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/AddUserAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AddUserAsyncTests.cs
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -100,7 +100,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -125,7 +125,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionException("foo"));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -151,7 +151,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -176,7 +176,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
@@ -99,7 +99,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<(MessageReceivedEventArgs, IMessageConnection)>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult((new MessageReceivedEventArgs(1, new byte[] { 0x0 }), conn.Object)));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -135,7 +135,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<(MessageReceivedEventArgs, IMessageConnection)>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult((new MessageReceivedEventArgs(length, new byte[] { 0x0 }), conn.Object)));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -177,7 +177,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<(MessageReceivedEventArgs, IMessageConnection)>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult((new MessageReceivedEventArgs(length, new byte[] { 0x0 }), conn.Object)));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -216,7 +216,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<(MessageReceivedEventArgs, IMessageConnection)>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult((new MessageReceivedEventArgs(1, new byte[] { 0x0 }), conn.Object)));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -250,7 +250,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<(MessageReceivedEventArgs, IMessageConnection)>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException<(MessageReceivedEventArgs, IMessageConnection)>(new TimeoutException()));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -278,7 +278,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -307,7 +307,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -334,7 +334,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -368,7 +368,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<(MessageReceivedEventArgs, IMessageConnection)>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult((new MessageReceivedEventArgs(1, new byte[] { 0x0 }), conn.Object)));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);

--- a/tests/Soulseek.Tests.Unit/Client/ChangePasswordAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ChangePasswordAsyncTests.cs
@@ -73,7 +73,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -95,7 +95,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -119,7 +119,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new ConnectionException()));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -143,7 +143,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -166,7 +166,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -322,7 +322,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var manager = new Mock<IPeerConnectionManager>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -351,7 +351,7 @@ namespace Soulseek.Tests.Unit.Client
             manager.Setup(m => m.GetOrAddMessageConnectionAsync(It.IsAny<string>(), endpoint, It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -381,7 +381,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Throws(new TimeoutException());
 
             using (var stream = new MemoryStream())
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -416,7 +416,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -448,7 +448,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -481,7 +481,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -515,7 +515,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -563,7 +563,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.AwaitTransferConnectionAsync(username, filename, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -604,7 +604,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -654,7 +654,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.AwaitTransferConnectionAsync(username, filename, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -707,7 +707,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -761,7 +761,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -829,7 +829,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -882,7 +882,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(transferConn.Object));
 
             using (var stream = new MemoryStream())
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -942,7 +942,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(transferConn.Object));
 
             using (var stream = new MemoryStream())
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -999,7 +999,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.AwaitTransferConnectionAsync(username, filename, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1072,7 +1072,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1130,7 +1130,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1193,7 +1193,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1246,7 +1246,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1309,7 +1309,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1342,7 +1342,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, null, waiter: waiter.Object, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(null, waiter: waiter.Object, serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1405,7 +1405,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1461,7 +1461,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1515,7 +1515,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1567,7 +1567,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1621,7 +1621,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.AwaitTransferConnectionAsync(username, filename, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<IConnection>(expected));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
@@ -106,7 +106,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -142,7 +142,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -165,7 +165,7 @@ namespace Soulseek.Tests.Unit.Client
             var serverConn = new Mock<IMessageConnection>();
             var connManager = new Mock<IPeerConnectionManager>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -201,7 +201,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -236,7 +236,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetDownloadPlaceInQueueAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDownloadPlaceInQueueAsyncTests.cs
@@ -122,7 +122,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -148,7 +148,7 @@ namespace Soulseek.Tests.Unit.Client
             var serverConn = new Mock<IMessageConnection>();
             var connManager = new Mock<IPeerConnectionManager>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -186,7 +186,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -224,7 +224,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -262,7 +262,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetPrivilegesAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetPrivilegesAsyncTests.cs
@@ -50,7 +50,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<int>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -69,7 +69,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<int>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -88,7 +88,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<int>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -111,7 +111,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetRoomListAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetRoomListAsyncTests.cs
@@ -67,7 +67,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<IReadOnlyCollection<Room>>(It.Is<WaitKey>(k => k.Equals(key)), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult(rooms));
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -87,7 +87,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -107,7 +107,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -126,7 +126,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
@@ -72,7 +72,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -91,7 +91,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -110,7 +110,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -133,7 +133,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -156,7 +156,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -175,7 +175,7 @@ namespace Soulseek.Tests.Unit.Client
             cache.Setup(m => m.TryGet(username, out endpoint))
                 .Returns(true);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, new SoulseekClientOptions(userEndPointCache: cache.Object)))
+            using (var s = new SoulseekClient(new SoulseekClientOptions(userEndPointCache: cache.Object)))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -202,7 +202,7 @@ namespace Soulseek.Tests.Unit.Client
                 // wait the sempahore to make the test code wait
                 var wait = sem.WaitAsync();
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, new SoulseekClientOptions(userEndPointCache: cache.Object)))
+                using (var s = new SoulseekClient(new SoulseekClientOptions(userEndPointCache: cache.Object)))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
                     s.SetProperty("UserEndPointSemaphores", semaphores);
@@ -243,7 +243,7 @@ namespace Soulseek.Tests.Unit.Client
             cache.Setup(m => m.TryGet(username, out endpoint))
                 .Returns(false);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(userEndPointCache: cache.Object)))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(userEndPointCache: cache.Object)))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -256,15 +256,16 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "GetUserEndPointAsync")]
         [Theory(DisplayName = "GetUserEndPointAsync throws UserEndPointCacheException when cache operation throws"), AutoData]
-        public async Task GetUserEndPointAsync_Throws_UserEndPointCacheException_When_Cache_Operation_Throws(string username, IPEndPoint endpoint)
+        public async Task GetUserEndPointAsync_Throws_UserEndPointCacheException_When_Cache_Operation_Throws(string username)
         {
             var exception = new Exception();
+            var endpoint = new IPEndPoint(0, 0);
 
             var cache = new Mock<IUserEndPointCache>();
             cache.Setup(m => m.TryGet(username, out endpoint))
                 .Throws(exception);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, new SoulseekClientOptions(userEndPointCache: cache.Object)))
+            using (var s = new SoulseekClient(new SoulseekClientOptions(userEndPointCache: cache.Object)))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
@@ -13,6 +13,7 @@
 namespace Soulseek.Tests.Unit.Client
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -182,6 +183,96 @@ namespace Soulseek.Tests.Unit.Client
 
                 Assert.Equal(endpoint.Address, addr.Address);
                 Assert.Equal(endpoint.Port, addr.Port);
+            }
+        }
+
+        [Trait("Category", "GetUserEndPointAsync")]
+        [Theory(DisplayName = "GetUserEndPointAsync returns cached endpoint if cached by previous thread"), AutoData]
+        public async Task GetUserEndPointAsync_Returns_Cached_Endpoint_If_Cached_By_Previous_Thread(string username, IPEndPoint endpoint)
+        {
+            var cache = new Mock<IUserEndPointCache>();
+            cache.Setup(m => m.TryGet(username, out endpoint))
+                .Returns(false);
+
+            using (var sem = new SemaphoreSlim(1, 1))
+            {
+                var semaphores = new ConcurrentDictionary<string, SemaphoreSlim>();
+                semaphores.TryAdd(username, sem);
+
+                // wait the sempahore to make the test code wait
+                var wait = sem.WaitAsync();
+
+                using (var s = new SoulseekClient("127.0.0.1", 1, new SoulseekClientOptions(userEndPointCache: cache.Object)))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                    s.SetProperty("UserEndPointSemaphores", semaphores);
+
+                    // invoke, but dont await.  this will wait the semaphore
+                    var addrWait = s.GetUserEndPointAsync(username);
+
+                    // simulate a cache update while we were waiting
+                    cache.Setup(m => m.TryGet(username, out endpoint))
+                        .Returns(true);
+
+                    // release the semaphore to cause the code above to enter the critical section
+                    sem.Release();
+                    await wait;
+
+                    // cache hit and return
+                    var addr = await addrWait;
+
+                    Assert.Equal(endpoint.Address, addr.Address);
+                    Assert.Equal(endpoint.Port, addr.Port);
+                }
+            }
+        }
+
+        [Trait("Category", "GetUserEndPointAsync")]
+        [Theory(DisplayName = "GetUserEndPointAsync returns expected values on cache miss"), AutoData]
+        public async Task GetUserEndPointAsync_Returns_Expected_Values_On_Cache_Miss(string username, IPEndPoint endpoint)
+        {
+            var waiter = new Mock<IWaiter>();
+            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+                .Returns(Task.CompletedTask);
+
+            var cache = new Mock<IUserEndPointCache>();
+            cache.Setup(m => m.TryGet(username, out endpoint))
+                .Returns(false);
+
+            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(userEndPointCache: cache.Object)))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var addr = await s.GetUserEndPointAsync(username);
+
+                Assert.Equal(endpoint.Address, addr.Address);
+                Assert.Equal(endpoint.Port, addr.Port);
+            }
+        }
+
+        [Trait("Category", "GetUserEndPointAsync")]
+        [Theory(DisplayName = "GetUserEndPointAsync throws UserEndPointCacheException when cache operation throws"), AutoData]
+        public async Task GetUserEndPointAsync_Throws_UserEndPointCacheException_When_Cache_Operation_Throws(string username, IPEndPoint endpoint)
+        {
+            var exception = new Exception();
+
+            var cache = new Mock<IUserEndPointCache>();
+            cache.Setup(m => m.TryGet(username, out endpoint))
+                .Throws(exception);
+
+            using (var s = new SoulseekClient("127.0.0.1", 1, new SoulseekClientOptions(userEndPointCache: cache.Object)))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync(username));
+
+                Assert.NotNull(ex);
+                Assert.IsType<UserEndPointCacheException>(ex);
+                Assert.Equal(exception, ex.InnerException);
             }
         }
     }

--- a/tests/Soulseek.Tests.Unit/Client/GetUserInfoAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserInfoAsyncTests.cs
@@ -87,7 +87,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -126,7 +126,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -162,7 +162,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -185,7 +185,7 @@ namespace Soulseek.Tests.Unit.Client
             var serverConn = new Mock<IMessageConnection>();
             var connManager = new Mock<IPeerConnectionManager>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -221,7 +221,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetUserPrivilegedAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserPrivilegedAsyncTests.cs
@@ -69,7 +69,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<bool>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -88,7 +88,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<bool>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -107,7 +107,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<int>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -130,7 +130,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetUserStatusAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserStatusAsyncTests.cs
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -97,7 +97,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var serverConn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -122,7 +122,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionException("foo"));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -148,7 +148,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -173,7 +173,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/GrantUserPrivilegesAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GrantUserPrivilegesAsyncTests.cs
@@ -89,7 +89,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -108,7 +108,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -127,7 +127,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: serverConn.Object))
+            using (var s = new SoulseekClient(serverConnection: serverConn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -150,7 +150,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait(It.Is<WaitKey>(k => k == new WaitKey(MessageCode.Server.GivePrivileges)), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: serverConn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: serverConn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
@@ -87,7 +87,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait<RoomData>(It.Is<WaitKey>(k => k.Equals(key)), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult(expectedResponse));
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -107,7 +107,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -127,7 +127,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -146,7 +146,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -216,7 +216,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait(It.Is<WaitKey>(k => k.Equals(key)), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -234,7 +234,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -254,7 +254,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -273,7 +273,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
@@ -100,7 +100,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -121,7 +121,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(listenPort: port)))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(listenPort: port)))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -145,7 +145,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(listenPort: port)))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(listenPort: port)))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -166,7 +166,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(enableDistributedNetwork: false, listenPort: port)))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object, options: new SoulseekClientOptions(enableDistributedNetwork: false, listenPort: port)))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -187,7 +187,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -210,7 +210,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -231,7 +231,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var conn = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -252,7 +252,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<Exception>(new ConnectionWriteException()));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 

--- a/tests/Soulseek.Tests.Unit/Client/PingServerAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/PingServerAsyncTests.cs
@@ -63,7 +63,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -81,7 +81,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -101,7 +101,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -124,7 +124,7 @@ namespace Soulseek.Tests.Unit.Client
             waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException(new TimeoutException()));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object, waiter: waiter.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -143,7 +143,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
@@ -248,7 +248,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -295,7 +295,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -330,7 +330,7 @@ namespace Soulseek.Tests.Unit.Client
                     .Returns(Task.CompletedTask);
 
                 using (var cts = new CancellationTokenSource(1000))
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -357,7 +357,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.CompletedTask);
 
             using (var cts = new CancellationTokenSource(1000))
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -384,7 +384,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -407,7 +407,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -428,7 +428,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new Exception("foo")));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -455,7 +455,7 @@ namespace Soulseek.Tests.Unit.Client
                 conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                     .Returns(Task.CompletedTask);
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -484,7 +484,7 @@ namespace Soulseek.Tests.Unit.Client
                 conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                     .Returns(Task.CompletedTask);
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SearchStateChanged += (sender, e) => fired = true;
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -511,7 +511,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.CompletedTask);
 
             using (var cts = new CancellationTokenSource(1000))
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -540,7 +540,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                 .Returns(Task.CompletedTask);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SearchResponseReceived += (sender, e) => fired = true;
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -568,7 +568,7 @@ namespace Soulseek.Tests.Unit.Client
                 conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -592,7 +592,7 @@ namespace Soulseek.Tests.Unit.Client
                 conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -616,7 +616,7 @@ namespace Soulseek.Tests.Unit.Client
                 conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -647,7 +647,7 @@ namespace Soulseek.Tests.Unit.Client
                 conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
-                using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+                using (var s = new SoulseekClient(serverConnection: conn.Object))
                 {
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/SendAcknowledgePrivateMessageAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendAcknowledgePrivateMessageAsyncTests.cs
@@ -72,7 +72,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -90,7 +90,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -110,7 +110,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -129,7 +129,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -197,7 +197,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -215,7 +215,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -235,7 +235,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -254,7 +254,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/SendRoomMessageAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendRoomMessageAsyncTests.cs
@@ -81,7 +81,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -99,7 +99,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -119,7 +119,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -138,7 +138,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/SetSharedCountsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SetSharedCountsAsyncTests.cs
@@ -91,7 +91,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -109,7 +109,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -129,7 +129,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -148,7 +148,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/SetUserStatusAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SetUserStatusAsyncTests.cs
@@ -59,7 +59,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 0, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -77,7 +77,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -97,7 +97,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -116,7 +116,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -314,7 +314,7 @@ namespace Soulseek.Tests.Unit.Client
             manager.Setup(m => m.GetOrAddMessageConnectionAsync(It.IsAny<string>(), endpoint, It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -344,7 +344,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Throws(new TimeoutException());
 
             using (var stream = new MemoryStream())
-            using (var s = new SoulseekClient("127.0.0.1", 1, waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
+            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -371,7 +371,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var connManager = new Mock<IPeerConnectionManager>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -402,7 +402,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -435,7 +435,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -477,7 +477,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -518,7 +518,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(conn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -558,7 +558,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -601,7 +601,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -642,7 +642,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(transferConn.Object));
 
             using (var stream = new MemoryStream())
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -693,7 +693,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(transferConn.Object));
 
             using (var stream = new MemoryStream())
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -746,7 +746,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(transferConn.Object));
 
             using (var stream = new MemoryStream(new byte[size]))
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -793,7 +793,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(transferConn.Object));
 
             using (var stream = new MemoryStream(new byte[size]))
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -837,7 +837,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -886,7 +886,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -944,7 +944,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1002,7 +1002,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1055,7 +1055,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1118,7 +1118,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1181,7 +1181,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1214,7 +1214,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, null, waiter: waiter.Object, serverConnection: conn.Object))
+            using (var s = new SoulseekClient(null, waiter: waiter.Object, serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1275,7 +1275,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1324,7 +1324,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1368,7 +1368,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1421,7 +1421,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1473,7 +1473,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1515,7 +1515,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1554,7 +1554,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<IConnection>(new ConnectionException()));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1607,7 +1607,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
@@ -1653,7 +1653,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 

--- a/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
@@ -23,7 +23,7 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "GetConnection returns the expected connection"), AutoData]
         internal void GetConneciton_Returns_The_Expected_Connection(IPEndPoint endpoint, ConnectionOptions options)
         {
-            var c = new ConnectionFactory().GetConnection(endpoint, options);
+            var c = new ConnectionFactory().GetTransferConnection(endpoint, options);
 
             Assert.Equal(endpoint.Address, c.IPEndPoint.Address);
             Assert.Equal(endpoint.Port, c.IPEndPoint.Port);

--- a/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
@@ -12,21 +12,56 @@
 
 namespace Soulseek.Tests.Unit
 {
+    using System;
     using System.Net;
     using AutoFixture.Xunit2;
     using Soulseek.Network;
+    using Soulseek.Network.Tcp;
     using Xunit;
 
     public class ConnectionFactoryTests
     {
-        [Trait("Category", "GetConnection")]
-        [Theory(DisplayName = "GetConnection returns the expected connection"), AutoData]
-        internal void GetConneciton_Returns_The_Expected_Connection(IPEndPoint endpoint, ConnectionOptions options)
+        [Trait("Category", "GetTransferConnection")]
+        [Theory(DisplayName = "GetTransferConnection returns the expected connection"), AutoData]
+        internal void GetTransferConneciton_Returns_The_Expected_Connection(IPEndPoint endpoint, ConnectionOptions options)
         {
             var c = new ConnectionFactory().GetTransferConnection(endpoint, options);
 
             Assert.Equal(endpoint.Address, c.IPEndPoint.Address);
             Assert.Equal(endpoint.Port, c.IPEndPoint.Port);
+
+            Assert.Equal(options.ReadBufferSize, c.Options.ReadBufferSize);
+            Assert.Equal(options.WriteBufferSize, c.Options.WriteBufferSize);
+            Assert.Equal(options.ConnectTimeout, c.Options.ConnectTimeout);
+            Assert.Equal(-1, c.Options.InactivityTimeout);
+        }
+
+        [Trait("Category", "GetServerConnection")]
+        [Theory(DisplayName = "GetServerConnection returns the expected connection"), AutoData]
+        internal void GetServerConneciton_Returns_The_Expected_Connection(IPEndPoint endpoint, ConnectionOptions options)
+        {
+            bool connect = false;
+            EventHandler connected = (s, a) => { connect = true;  };
+
+            bool disconnect = false;
+            EventHandler<ConnectionDisconnectedEventArgs> disconnected = (s, a) => { disconnect = true; };
+
+            bool read = false;
+            EventHandler<MessageReadEventArgs> messageRead = (s, a) => { read = true; };
+
+            var c = new ConnectionFactory().GetServerConnection(endpoint, connected, disconnected, messageRead, options);
+
+            Assert.Equal(endpoint.Address, c.IPEndPoint.Address);
+            Assert.Equal(endpoint.Port, c.IPEndPoint.Port);
+
+            c.RaiseEvent(typeof(Connection), "Connected", EventArgs.Empty);
+            Assert.True(connect);
+
+            c.RaiseEvent(typeof(Connection), "Disconnected", new ConnectionDisconnectedEventArgs("foo"));
+            Assert.True(disconnect);
+
+            c.RaiseEvent("MessageRead", new MessageReadEventArgs(Array.Empty<byte>()));
+            Assert.True(read);
 
             Assert.Equal(options.ReadBufferSize, c.Options.ReadBufferSize);
             Assert.Equal(options.WriteBufferSize, c.Options.WriteBufferSize);

--- a/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
@@ -27,7 +27,7 @@ namespace Soulseek.Tests.Unit
 
             Assert.Equal(endpoint.Address, c.IPEndPoint.Address);
             Assert.Equal(endpoint.Port, c.IPEndPoint.Port);
-            Assert.Equal(options, c.Options);
+            Assert.Equal(options.WithoutInactivityTimeout(), c.Options);
         }
 
         [Trait("Category", "GetMessageConnection")]

--- a/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/ConnectionFactoryTests.cs
@@ -27,7 +27,11 @@ namespace Soulseek.Tests.Unit
 
             Assert.Equal(endpoint.Address, c.IPEndPoint.Address);
             Assert.Equal(endpoint.Port, c.IPEndPoint.Port);
-            Assert.Equal(options.WithoutInactivityTimeout(), c.Options);
+
+            Assert.Equal(options.ReadBufferSize, c.Options.ReadBufferSize);
+            Assert.Equal(options.WriteBufferSize, c.Options.WriteBufferSize);
+            Assert.Equal(options.ConnectTimeout, c.Options.ConnectTimeout);
+            Assert.Equal(-1, c.Options.InactivityTimeout);
         }
 
         [Trait("Category", "GetMessageConnection")]
@@ -38,7 +42,11 @@ namespace Soulseek.Tests.Unit
 
             Assert.Equal(endpoint.Address, c.IPEndPoint.Address);
             Assert.Equal(endpoint.Port, c.IPEndPoint.Port);
-            Assert.Equal(options, c.Options);
+
+            Assert.Equal(options.ReadBufferSize, c.Options.ReadBufferSize);
+            Assert.Equal(options.WriteBufferSize, c.Options.WriteBufferSize);
+            Assert.Equal(options.ConnectTimeout, c.Options.ConnectTimeout);
+            Assert.Equal(options.InactivityTimeout, c.Options.InactivityTimeout);
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit.Network
         [Fact(DisplayName = "CanAcceptChildren is false if AcceptDistributedChildren is false")]
         public void CanAcceptChildren_Is_False_If_AcceptDistributedChildren_Is_False()
         {
-            using (var s = new SoulseekClient("192.168.1.1", 1, new SoulseekClientOptions(
+            using (var s = new SoulseekClient(new SoulseekClientOptions(
                 acceptDistributedChildren: false,
                 distributedChildLimit: 10)))
             {
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Network
             parent.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            using (var s = new SoulseekClient("192.168.1.1", 1, new SoulseekClientOptions(
+            using (var s = new SoulseekClient(new SoulseekClientOptions(
                 acceptDistributedChildren: true,
                 distributedChildLimit: 10)))
             {

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -100,7 +100,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             var incomingConn = GetConnectionMock(endpoint);
@@ -128,7 +128,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             var incomingConn = GetConnectionMock(endpoint);
@@ -160,7 +160,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             var incomingConn = GetConnectionMock(endpoint);
@@ -190,7 +190,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             var incomingConn = GetConnectionMock(endpoint);
@@ -213,7 +213,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             var incomingConn = GetConnectionMock(endpoint);
@@ -238,7 +238,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             var incomingConn = GetConnectionMock(endpoint);
@@ -544,7 +544,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             (IConnection Connection, int RemoteToken) newConn;
@@ -577,7 +577,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -604,7 +604,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -628,7 +628,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -651,7 +651,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -675,7 +675,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -699,7 +699,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -723,7 +723,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), null))
                 .Returns(conn.Object);
 
             using (manager)
@@ -744,7 +744,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
@@ -771,7 +771,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
@@ -796,7 +796,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
@@ -821,7 +821,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
@@ -846,7 +846,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             using (manager)
@@ -882,7 +882,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var (manager, mocks) = GetFixture();
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.IsAny<IPEndPoint>(), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(conn.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
@@ -915,9 +915,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
@@ -952,9 +952,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
@@ -989,9 +989,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
@@ -1025,9 +1025,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
@@ -1063,9 +1063,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
@@ -1102,9 +1102,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
@@ -1139,9 +1139,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))
@@ -1176,9 +1176,9 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.Username)
                 .Returns(localUsername);
 
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == directPort), It.IsAny<ConnectionOptions>(), null))
                 .Returns(direct.Object);
-            mocks.ConnectionFactory.Setup(m => m.GetConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
+            mocks.ConnectionFactory.Setup(m => m.GetTransferConnection(It.Is<IPEndPoint>(e => e.Port == indirectPort), It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
                 .Returns(indirect.Object);
 
             mocks.Waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken?>()))

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -52,7 +52,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             Assert.Equal(ConnectionState.Pending, c.State);
             Assert.NotEqual(Guid.Empty, c.Id);
             Assert.Equal(ConnectionTypes.None, c.Type);
-            Assert.NotNull(c.InactiveTime);
+            Assert.NotEqual(new TimeSpan(), c.InactiveTime);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientOptionsTests.cs
@@ -43,9 +43,17 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(autoAcknowledgePrivateMessages, o.AutoAcknowledgePrivateMessages);
             Assert.Equal(minimumDiagnosticLevel, o.MinimumDiagnosticLevel);
             Assert.Equal(startingToken, o.StartingToken);
-            Assert.Equal(serverConnectionOptions.WithoutInactivityTimeout(), o.ServerConnectionOptions);
             Assert.Equal(peerConnectionOptions, o.PeerConnectionOptions);
-            Assert.Equal(transferConnectionOptions.WithoutInactivityTimeout(), o.TransferConnectionOptions);
+
+            Assert.Equal(serverConnectionOptions.ReadBufferSize, o.ServerConnectionOptions.ReadBufferSize);
+            Assert.Equal(serverConnectionOptions.WriteBufferSize, o.ServerConnectionOptions.WriteBufferSize);
+            Assert.Equal(serverConnectionOptions.ConnectTimeout, o.ServerConnectionOptions.ConnectTimeout);
+            Assert.Equal(-1, o.ServerConnectionOptions.InactivityTimeout);
+
+            Assert.Equal(transferConnectionOptions.ReadBufferSize, o.TransferConnectionOptions.ReadBufferSize);
+            Assert.Equal(transferConnectionOptions.WriteBufferSize, o.TransferConnectionOptions.WriteBufferSize);
+            Assert.Equal(transferConnectionOptions.ConnectTimeout, o.TransferConnectionOptions.ConnectTimeout);
+            Assert.Equal(-1, o.TransferConnectionOptions.InactivityTimeout);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientOptionsTests.cs
@@ -43,9 +43,9 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(autoAcknowledgePrivateMessages, o.AutoAcknowledgePrivateMessages);
             Assert.Equal(minimumDiagnosticLevel, o.MinimumDiagnosticLevel);
             Assert.Equal(startingToken, o.StartingToken);
-            Assert.Equal(serverConnectionOptions, o.ServerConnectionOptions);
+            Assert.Equal(serverConnectionOptions.WithoutInactivityTimeout(), o.ServerConnectionOptions);
             Assert.Equal(peerConnectionOptions, o.PeerConnectionOptions);
-            Assert.Equal(transferConnectionOptions, o.TransferConnectionOptions);
+            Assert.Equal(transferConnectionOptions.WithoutInactivityTimeout(), o.TransferConnectionOptions);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -277,6 +277,58 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect throws ArgumentException on bad input")]
+        [InlineData("127.0.0.1", 1, null, "a")]
+        [InlineData("127.0.0.1", 1, "", "a")]
+        [InlineData("127.0.0.1", 1, "a", null)]
+        [InlineData("127.0.0.1", 1, "a", "")]
+        [InlineData("127.0.0.1", 1, "", "")]
+        [InlineData("127.0.0.1", 1, null, null)]
+        [InlineData(null, 1, "user", "pass")]
+        [InlineData("", 1, "user", "pass")]
+        [InlineData(" ", 1, "user", "pass")]
+        public async Task Connect_Address_Credentials_Throws_ArgumentException_On_Bad_Input(string address, int port, string username, string password)
+        {
+            using (var s = new SoulseekClient())
+            {
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(address, port, username, password));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect throws ArgumentOutOfRangeException on bad port")]
+        [InlineData(-1)]
+        [InlineData(65536)]
+        public async Task Connect_Address_Throws_ArgumentException_On_Bad_Port(int port)
+        {
+            using (var s = new SoulseekClient())
+            {
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync("127.0.0.01", port));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentOutOfRangeException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect throws ArgumentOutOfRangeException on bad port")]
+        [InlineData(-1)]
+        [InlineData(65536)]
+        public async Task Connect_Address_Credentials_Throws_ArgumentException_On_Bad_Port(int port)
+        {
+            using (var s = new SoulseekClient())
+            {
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync("127.0.0.01", port, "user", "pass"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentOutOfRangeException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
         [Theory(DisplayName = "Connect throws InvalidOperationException_When_Already_Connected"), AutoData]
         public async Task Connect_Throws_InvalidOperationException_When_Already_Connected(string username, string password)
         {

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -100,6 +100,51 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect fails if connected"), AutoData]
+        public async Task Connect_Address_Fails_If_Connected(IPAddress address, int port)
+        {
+            using (var s = new SoulseekClient())
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(address.ToString(), port));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect fails if connected"), AutoData]
+        public async Task Connect_Credentials_Fails_If_Connected(string username, string password)
+        {
+            using (var s = new SoulseekClient())
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(username, password));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect fails if connected"), AutoData]
+        public async Task Connect_Address_Credentials_Fails_If_Connected(IPAddress address, int port, string username, string password)
+        {
+            using (var s = new SoulseekClient())
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(address.ToString(), port, username, password));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
         [Fact(DisplayName = "Connect throws when TcpConnection throws")]
         public async Task Connect_Throws_When_TcpConnection_Throws()
         {
@@ -248,7 +293,7 @@ namespace Soulseek.Tests.Unit
 
         [Trait("Category", "Connect")]
         [Theory(DisplayName = "Connect connects and logs in"), AutoData]
-        public async Task Connect_Connects_And_Logs_In(IPAddress ip, int port, string username, string password)
+        public async Task Connect_Connects_And_Logs_In(string username, string password)
         {
             var c = new Mock<IMessageConnection>();
 

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -72,6 +72,18 @@ namespace Soulseek.Tests.Unit
             }
         }
 
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "IPEndPoint is null initially")]
+        public void IPEndPoint_Is_Null_Initially()
+        {
+            using (var s = new SoulseekClient())
+            {
+                Assert.Null(s.IPEndPoint);
+                Assert.Null(s.IPAddress);
+                Assert.Null(s.Port);
+            }
+        }
+
         [Trait("Category", "Connect")]
         [Fact(DisplayName = "Connect fails if connected")]
         public async Task Connect_Fails_If_Connected()

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -745,5 +745,20 @@ namespace Soulseek.Tests.Unit
                 Assert.Equal(msg, args.Message);
             }
         }
+
+        [Trait("Category", "MessageRead")]
+        [Fact(DisplayName = "MessageRead invokes HandleMessageRead")]
+        public void MessageRead_Invokes_HandleMessageRead()
+        {
+            var handlerMock = new Mock<IServerMessageHandler>();
+            var args = new MessageReadEventArgs(Array.Empty<byte>());
+
+            using (var s = new SoulseekClient(serverMessageHandler: handlerMock.Object))
+            {
+                s.InvokeMethod("ServerConnection_MessageRead", this, args);
+            }
+
+            handlerMock.Verify(m => m.HandleMessageRead(It.IsAny<object>(), args), Times.Once);
+        }
     }
 }

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -41,47 +41,6 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "Instantiation")]
-        [Fact(DisplayName = "Instantiates with defaults for minimal constructor")]
-        public void Instantiates_With_Defaults_For_Minimal_Constructor()
-        {
-            using (var s = new SoulseekClient())
-            {
-                var defaultServer = s.GetField<string>("DefaultAddress");
-                var defaultPort = s.GetField<int>("DefaultPort");
-
-                Assert.Equal(defaultServer, s.Address);
-                Assert.Equal(defaultPort, s.Port);
-                Assert.NotEqual(IPAddress.None, s.IPAddress);
-            }
-        }
-
-        [Trait("Category", "Instantiation")]
-        [Fact(DisplayName = "Instantiates with defaults given a null IPEndPoint or address")]
-        public void Instantiates_With_Defaults_Given_A_Null_IPEndPoint_Or_Address()
-        {
-            using (var s = new SoulseekClient(null))
-            {
-                var defaultServer = s.GetField<string>("DefaultAddress");
-                var defaultPort = s.GetField<int>("DefaultPort");
-
-                Assert.Equal(defaultServer, s.Address);
-                Assert.Equal(defaultPort, s.Port);
-            }
-        }
-
-        [Trait("Category", "Instantiation")]
-        [Theory(DisplayName = "Instantiates with given IPEndPoint"), AutoData]
-        public void Instantiates_With_Given_IPEndPoint(IPEndPoint endpoint)
-        {
-            using (var s = new SoulseekClient(endpoint))
-            {
-                Assert.Equal(endpoint.Address.ToString(), s.Address);
-                Assert.Equal(endpoint.Address, s.IPAddress);
-                Assert.Equal(endpoint.Port, s.Port);
-            }
-        }
-
-        [Trait("Category", "Instantiation")]
         [Fact(DisplayName = "Instantiates without exception")]
         public void Instantiates_Without_Exception()
         {
@@ -91,21 +50,6 @@ namespace Soulseek.Tests.Unit
 
             Assert.Null(ex);
             Assert.NotNull(s);
-        }
-
-        [Trait("Category", "Instantiation")]
-        [Theory(DisplayName = "Throws given a port not in range")]
-        [InlineData(-1)]
-        [InlineData(123423523)]
-        public void Throws_Given_A_Port_Not_In_Range(int port)
-        {
-            SoulseekClient s = null;
-
-            var ex = Record.Exception(() => s = new SoulseekClient("127.0.0.1", port, new SoulseekClientOptions()));
-
-            Assert.NotNull(ex);
-            Assert.IsType<ArgumentOutOfRangeException>(ex);
-            Assert.Equal("port", ((ArgumentOutOfRangeException)ex).ParamName);
         }
 
         [Trait("Category", "Instantiation")]
@@ -150,7 +94,7 @@ namespace Soulseek.Tests.Unit
             var c = new Mock<IMessageConnection>();
             c.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken>())).Throws(new ConnectionException());
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -166,7 +110,7 @@ namespace Soulseek.Tests.Unit
             var c = new Mock<IMessageConnection>();
             c.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken>())).Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -182,7 +126,7 @@ namespace Soulseek.Tests.Unit
             var c = new Mock<IMessageConnection>();
             c.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken>())).Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -197,7 +141,7 @@ namespace Soulseek.Tests.Unit
         {
             var c = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -270,7 +214,7 @@ namespace Soulseek.Tests.Unit
             w.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new LoginResponse(true, string.Empty)));
 
-            using (var s = new SoulseekClient(ip.ToString(), port, serverConnection: c.Object, waiter: w.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object, waiter: w.Object))
             {
                 await s.ConnectAsync(username, password);
 
@@ -284,7 +228,7 @@ namespace Soulseek.Tests.Unit
         [Fact(DisplayName = "Instantiation throws on a bad address")]
         public void Instantiation_Throws_On_A_Bad_Address()
         {
-            var ex = Record.Exception(() => new SoulseekClient(address: Guid.NewGuid().ToString(), port: new Random().Next(65535), options: new SoulseekClientOptions()));
+            var ex = Record.Exception(() => new SoulseekClient(options: new SoulseekClientOptions()));
 
             Assert.NotNull(ex);
             Assert.IsType<SoulseekClientException>(ex);
@@ -296,7 +240,7 @@ namespace Soulseek.Tests.Unit
         {
             var c = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 await s.ConnectAsync();
 
@@ -312,7 +256,7 @@ namespace Soulseek.Tests.Unit
         {
             var c = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 await s.ConnectAsync();
 
@@ -331,7 +275,7 @@ namespace Soulseek.Tests.Unit
 
             var c = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 s.StateChanged += (sender, e) => fired = true;
 
@@ -352,7 +296,7 @@ namespace Soulseek.Tests.Unit
         {
             var c = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -380,7 +324,7 @@ namespace Soulseek.Tests.Unit
         {
             var c = new Mock<IMessageConnection>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -406,7 +350,7 @@ namespace Soulseek.Tests.Unit
 
             var p = new Mock<IPeerConnectionManager>();
 
-            using (var s = new SoulseekClient(Guid.NewGuid().ToString(), new Random().Next(65535), serverConnection: c.Object, peerConnectionManager: p.Object))
+            using (var s = new SoulseekClient(serverConnection: c.Object, peerConnectionManager: p.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
@@ -513,7 +457,7 @@ namespace Soulseek.Tests.Unit
             f.Setup(m => m.NextToken())
                 .Returns(token);
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, tokenFactory: f.Object))
+            using (var s = new SoulseekClient(tokenFactory: f.Object))
             {
                 var t = s.GetNextToken();
 
@@ -529,7 +473,7 @@ namespace Soulseek.Tests.Unit
         {
             var handlerMock = new Mock<IServerMessageHandler>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverMessageHandler: handlerMock.Object))
+            using (var s = new SoulseekClient(serverMessageHandler: handlerMock.Object))
             {
                 bool fired = false;
                 s.KickedFromServer += (sender, args) => fired = true;
@@ -546,7 +490,7 @@ namespace Soulseek.Tests.Unit
         {
             var handlerMock = new Mock<IServerMessageHandler>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverMessageHandler: handlerMock.Object))
+            using (var s = new SoulseekClient(serverMessageHandler: handlerMock.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
                 SoulseekClientDisconnectedEventArgs e = null;
@@ -564,7 +508,7 @@ namespace Soulseek.Tests.Unit
         {
             var handlerMock = new Mock<IServerMessageHandler>();
 
-            using (var s = new SoulseekClient("127.0.0.1", 1, serverMessageHandler: handlerMock.Object))
+            using (var s = new SoulseekClient(serverMessageHandler: handlerMock.Object))
             {
                 GlobalMessageReceivedEventArgs args = default;
                 s.GlobalMessageReceived += (sender, e) => args = e;

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -94,7 +94,17 @@ namespace Soulseek.Tests.Unit
             var c = new Mock<IMessageConnection>();
             c.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken>())).Throws(new ConnectionException());
 
-            using (var s = new SoulseekClient(serverConnection: c.Object))
+            var factory = new Mock<IConnectionFactory>();
+            factory.Setup(m => m.GetServerConnection(
+                It.IsAny<IPEndPoint>(),
+                It.IsAny<EventHandler>(),
+                It.IsAny<EventHandler<ConnectionDisconnectedEventArgs>>(),
+                It.IsAny<EventHandler<MessageReadEventArgs>>(),
+                It.IsAny<ConnectionOptions>(),
+                It.IsAny<ITcpClient>()))
+                .Returns(c.Object);
+
+            using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -110,7 +120,17 @@ namespace Soulseek.Tests.Unit
             var c = new Mock<IMessageConnection>();
             c.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken>())).Throws(new TimeoutException());
 
-            using (var s = new SoulseekClient(serverConnection: c.Object))
+            var factory = new Mock<IConnectionFactory>();
+            factory.Setup(m => m.GetServerConnection(
+                It.IsAny<IPEndPoint>(),
+                It.IsAny<EventHandler>(),
+                It.IsAny<EventHandler<ConnectionDisconnectedEventArgs>>(),
+                It.IsAny<EventHandler<MessageReadEventArgs>>(),
+                It.IsAny<ConnectionOptions>(),
+                It.IsAny<ITcpClient>()))
+                .Returns(c.Object);
+
+            using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -126,7 +146,17 @@ namespace Soulseek.Tests.Unit
             var c = new Mock<IMessageConnection>();
             c.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken>())).Throws(new OperationCanceledException());
 
-            using (var s = new SoulseekClient(serverConnection: c.Object))
+            var factory = new Mock<IConnectionFactory>();
+            factory.Setup(m => m.GetServerConnection(
+                It.IsAny<IPEndPoint>(),
+                It.IsAny<EventHandler>(),
+                It.IsAny<EventHandler<ConnectionDisconnectedEventArgs>>(),
+                It.IsAny<EventHandler<MessageReadEventArgs>>(),
+                It.IsAny<ConnectionOptions>(),
+                It.IsAny<ITcpClient>()))
+                .Returns(c.Object);
+
+            using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
                 var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
 
@@ -214,7 +244,17 @@ namespace Soulseek.Tests.Unit
             w.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new LoginResponse(true, string.Empty)));
 
-            using (var s = new SoulseekClient(serverConnection: c.Object, waiter: w.Object))
+            var factory = new Mock<IConnectionFactory>();
+            factory.Setup(m => m.GetServerConnection(
+                It.IsAny<IPEndPoint>(),
+                It.IsAny<EventHandler>(),
+                It.IsAny<EventHandler<ConnectionDisconnectedEventArgs>>(),
+                It.IsAny<EventHandler<MessageReadEventArgs>>(),
+                It.IsAny<ConnectionOptions>(),
+                It.IsAny<ITcpClient>()))
+                .Returns(c.Object);
+
+            using (var s = new SoulseekClient(connectionFactory: factory.Object, waiter: w.Object))
             {
                 await s.ConnectAsync(username, password);
 
@@ -222,16 +262,6 @@ namespace Soulseek.Tests.Unit
             }
 
             c.Verify(m => m.ConnectAsync(It.IsAny<CancellationToken>()));
-        }
-
-        [Trait("Category", "Instantiation")]
-        [Fact(DisplayName = "Instantiation throws on a bad address")]
-        public void Instantiation_Throws_On_A_Bad_Address()
-        {
-            var ex = Record.Exception(() => new SoulseekClient(options: new SoulseekClientOptions()));
-
-            Assert.NotNull(ex);
-            Assert.IsType<SoulseekClientException>(ex);
         }
 
         [Trait("Category", "Disconnect")]

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -334,6 +334,20 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Connect throws ArgumentException on bad input"), AutoData]
+        public async Task Connect_Throws_ArgumentException_On_Bad_Address(string address)
+        {
+            using (var s = new SoulseekClient())
+            {
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(address, 1));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ConnectionException>(ex);
+                Assert.IsType<AddressException>(ex.InnerException);
+            }
+        }
+
+        [Trait("Category", "Connect")]
         [Theory(DisplayName = "Connect throws ArgumentException on bad input")]
         [InlineData("127.0.0.1", 1, null, "a")]
         [InlineData("127.0.0.1", 1, "", "a")]


### PR DESCRIPTION
Closes #300 
Closes #301 

Removes inactivity timeouts for server and transfer connections.  These timeouts were causing all sorts of issues with transfers in both directions.