### PR TITLE
Add Json config and suppress hot reload

### DIFF
--- a/examples/Web/api/Program.cs
+++ b/examples/Web/api/Program.cs
@@ -17,6 +17,7 @@
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
                     config.AddEnvironmentVariables(prefix: "SLSK_");
+                    config.AddJsonFile("config.json", optional: true, reloadOnChange: false);
                 })
                 .ConfigureLogging((context, logging) =>
                 {


### PR DESCRIPTION
Relates to #315 

I'm hoping that explicitly specifying `reloadOnChange: false` will suppress the setup of the filesystem watcher which is raising the error.