### PR TITLE
Improve test coverage

### DIFF
--- a/src/Soulseek/Network/PeerConnectionManager.cs
+++ b/src/Soulseek/Network/PeerConnectionManager.cs
@@ -46,7 +46,7 @@ namespace Soulseek.Network
             ConnectionFactory = connectionFactory ?? new ConnectionFactory();
 
             Diagnostic = diagnosticFactory ??
-                new DiagnosticFactory(this, SoulseekClient?.Options?.MinimumDiagnosticLevel ?? new SoulseekClientOptions().MinimumDiagnosticLevel, (e) => DiagnosticGenerated?.Invoke(this, e));
+                new DiagnosticFactory(this, SoulseekClient.Options.MinimumDiagnosticLevel, (e) => DiagnosticGenerated?.Invoke(this, e));
         }
 
         /// <summary>

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -43,11 +43,6 @@ namespace Soulseek.Network.Tcp
             TcpClient.Client.ReceiveBufferSize = Options.ReadBufferSize;
             TcpClient.Client.SendBufferSize = Options.WriteBufferSize;
 
-            if (TcpClient.Client.ReceiveBufferSize != Options.ReadBufferSize)
-            {
-                throw new Exception($"what the fuck {TcpClient.Client.ReceiveBufferSize} {Options.ReadBufferSize}");
-            }
-
             if (Options.InactivityTimeout > 0)
             {
                 InactivityTimer = new SystemTimer()
@@ -556,7 +551,7 @@ namespace Soulseek.Network.Tcp
         {
             ResetInactivityTime();
 
-            var buffer = new byte[TcpClient.Client.ReceiveBufferSize];
+            var buffer = new byte[Options.ReadBufferSize];
             var totalBytesRead = 0;
 
             try
@@ -618,7 +613,7 @@ namespace Soulseek.Network.Tcp
         {
             ResetInactivityTime();
 
-            var inputBuffer = new byte[TcpClient.Client.SendBufferSize];
+            var inputBuffer = new byte[Options.WriteBufferSize];
             var totalBytesWritten = 0;
 
             try

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -393,7 +393,7 @@ namespace Soulseek.Network.Tcp
         public Task<string> WaitForDisconnect(CancellationToken? cancellationToken = null)
         {
             cancellationToken?.Register(() =>
-                DisconnectTaskCompletionSource.SetException(new OperationCanceledException("Operation cancelled")));
+                Disconnect(exception: new OperationCanceledException("Operation cancelled")));
 
             return DisconnectTaskCompletionSource.Task;
         }

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -561,7 +561,7 @@ namespace Soulseek.Network.Tcp
                     await governor(cancellationToken).ConfigureAwait(false);
 
                     var bytesRemaining = length - totalBytesRead;
-                    var bytesToRead = bytesRemaining > buffer.Length ? buffer.Length : (int)bytesRemaining; // cast to int is safe because of the check against buffer length.
+                    var bytesToRead = bytesRemaining >= buffer.Length ? buffer.Length : (int)bytesRemaining; // cast to int is safe because of the check against buffer length.
 
                     var bytesRead = await Stream.ReadAsync(buffer, 0, bytesToRead, cancellationToken).ConfigureAwait(false);
 
@@ -624,7 +624,7 @@ namespace Soulseek.Network.Tcp
 
                     var bytesRemaining = length - totalBytesWritten;
 
-                    var bytesToRead = bytesRemaining > inputBuffer.Length ? inputBuffer.Length : (int)bytesRemaining;
+                    var bytesToRead = bytesRemaining >= inputBuffer.Length ? inputBuffer.Length : (int)bytesRemaining;
                     var bytesRead = await inputStream.ReadAsync(inputBuffer, 0, bytesToRead, cancellationToken).ConfigureAwait(false);
 
                     await Stream.WriteAsync(inputBuffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -613,7 +613,6 @@ namespace Soulseek.Network.Tcp
         {
             ResetInactivityTime();
 
-            var sendBufferSize = TcpClient.Client.SendBufferSize;
             var inputBuffer = new byte[TcpClient.Client.SendBufferSize];
             var totalBytesWritten = 0;
 
@@ -625,7 +624,7 @@ namespace Soulseek.Network.Tcp
 
                     var bytesRemaining = length - totalBytesWritten;
 
-                    var bytesToRead = bytesRemaining > sendBufferSize ? sendBufferSize : (int)bytesRemaining;
+                    var bytesToRead = bytesRemaining > inputBuffer.Length ? inputBuffer.Length : (int)bytesRemaining;
                     var bytesRead = await inputStream.ReadAsync(inputBuffer, 0, bytesToRead, cancellationToken).ConfigureAwait(false);
 
                     await Stream.WriteAsync(inputBuffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -43,6 +43,11 @@ namespace Soulseek.Network.Tcp
             TcpClient.Client.ReceiveBufferSize = Options.ReadBufferSize;
             TcpClient.Client.SendBufferSize = Options.WriteBufferSize;
 
+            if (TcpClient.Client.ReceiveBufferSize != Options.ReadBufferSize)
+            {
+                throw new Exception($"what the fuck {TcpClient.Client.ReceiveBufferSize} {Options.ReadBufferSize}");
+            }
+
             if (Options.InactivityTimeout > 0)
             {
                 InactivityTimer = new SystemTimer()

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -270,7 +270,7 @@ namespace Soulseek.Network.Tcp
                 ChangeState(ConnectionState.Disconnecting, message);
 
                 InactivityTimer?.Stop();
-                WatchdogTimer?.Stop();
+                WatchdogTimer.Stop();
                 Stream?.Close();
                 TcpClient?.Close();
 
@@ -529,7 +529,7 @@ namespace Soulseek.Network.Tcp
                 {
                     Disconnect("Connection is being disposed", new ObjectDisposedException(GetType().Name));
                     InactivityTimer?.Dispose();
-                    WatchdogTimer?.Dispose();
+                    WatchdogTimer.Dispose();
                     Stream?.Dispose();
                     TcpClient?.Dispose();
                 }

--- a/src/Soulseek/Network/Tcp/Connection.cs
+++ b/src/Soulseek/Network/Tcp/Connection.cs
@@ -387,10 +387,14 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Waits for the connection to disconnect, returning the message or throwing the Exception which caused the disconnect.
         /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The message describing the reason for the disconnect.</returns>
         /// <exception cref="Exception">Thrown when the connection is disconnected as the result of an Exception.</exception>
-        public Task<string> WaitForDisconnect()
+        public Task<string> WaitForDisconnect(CancellationToken? cancellationToken = null)
         {
+            cancellationToken?.Register(() =>
+                DisconnectTaskCompletionSource.SetException(new OperationCanceledException("Operation cancelled")));
+
             return DisconnectTaskCompletionSource.Task;
         }
 

--- a/src/Soulseek/Network/Tcp/ConnectionKey.cs
+++ b/src/Soulseek/Network/Tcp/ConnectionKey.cs
@@ -57,9 +57,7 @@ namespace Soulseek.Network.Tcp
         /// <returns>A value indicating whether the specified ConnectionKey is equal to this instance.</returns>
         public bool Equals(ConnectionKey other)
         {
-            return Username == other.Username &&
-                IPEndPoint?.Address?.ToString() == other.IPEndPoint?.Address?.ToString() &&
-                IPEndPoint?.Port == other.IPEndPoint?.Port;
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -85,9 +83,10 @@ namespace Soulseek.Network.Tcp
         /// <returns>The hash code of this instance.</returns>
         public override int GetHashCode()
         {
-            var u = Username?.GetHashCode(StringComparison.InvariantCulture) ?? 0;
-            var i = IPEndPoint?.Address?.ToString().GetHashCode(StringComparison.InvariantCulture) ?? 0;
-            return u ^ i ^ IPEndPoint?.Port.GetHashCode() ?? 0;
+            var u = (Username ?? string.Empty).GetHashCode(StringComparison.InvariantCulture);
+            var i = (IPEndPoint?.Address.ToString() ?? string.Empty).GetHashCode(StringComparison.InvariantCulture);
+            var p = (IPEndPoint?.Port.GetHashCode() ?? -1).GetHashCode();
+            return u ^ i ^ p;
         }
     }
 }

--- a/src/Soulseek/Network/Tcp/ConnectionKey.cs
+++ b/src/Soulseek/Network/Tcp/ConnectionKey.cs
@@ -83,10 +83,8 @@ namespace Soulseek.Network.Tcp
         /// <returns>The hash code of this instance.</returns>
         public override int GetHashCode()
         {
-            var u = (Username ?? string.Empty).GetHashCode(StringComparison.InvariantCulture);
-            var i = (IPEndPoint?.Address.ToString() ?? string.Empty).GetHashCode(StringComparison.InvariantCulture);
-            var p = (IPEndPoint?.Port.GetHashCode() ?? -1).GetHashCode();
-            return u ^ i ^ p;
+            var str = $"{Username}:{IPEndPoint?.Address}:{IPEndPoint?.Port}";
+            return str.GetHashCode(StringComparison.CurrentCulture);
         }
     }
 }

--- a/src/Soulseek/Network/Tcp/IConnection.cs
+++ b/src/Soulseek/Network/Tcp/IConnection.cs
@@ -154,9 +154,10 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Waits for the connection to disconnect, returning the message or throwing the Exception which caused the disconnect.
         /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The message describing the reason for the disconnect.</returns>
         /// <exception cref="Exception">Thrown when the connection is disconnected as the result of an Exception.</exception>
-        Task<string> WaitForDisconnect();
+        Task<string> WaitForDisconnect(CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Asynchronously writes the specified bytes to the connection.

--- a/src/Soulseek/Network/Tcp/IConnection.cs
+++ b/src/Soulseek/Network/Tcp/IConnection.cs
@@ -152,6 +152,13 @@ namespace Soulseek.Network.Tcp
         Task ReadAsync(long length, Stream outputStream, Func<CancellationToken, Task> governor, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        ///     Waits for the connection to disconnect, returning the message or throwing the Exception which caused the disconnect.
+        /// </summary>
+        /// <returns>The message describing the reason for the disconnect.</returns>
+        /// <exception cref="Exception">Thrown when the connection is disconnected as the result of an Exception.</exception>
+        Task<string> WaitForDisconnect();
+
+        /// <summary>
         ///     Asynchronously writes the specified bytes to the connection.
         /// </summary>
         /// <remarks>The connection is disconnected if a <see cref="ConnectionWriteException"/> is thrown.</remarks>

--- a/src/Soulseek/SearchInternal.cs
+++ b/src/Soulseek/SearchInternal.cs
@@ -127,18 +127,35 @@ namespace Soulseek
         {
             // ensure the search is still active, the token matches and that the response meets basic filtering criteria we check
             // the slim response for fitness prior to extracting the file list from it for performance reasons.
-            if (!Disposed && State.HasFlag(SearchStates.InProgress) && slimResponse.Token == Token && SlimResponseMeetsOptionCriteria(slimResponse))
+            if (!Disposed && State.HasFlag(SearchStates.InProgress) && slimResponse.Token == Token)
             {
-                // extract the file list from the response and filter it
-                var fullResponse = SearchResponseFactory.FromSlimResponse(slimResponse);
-                var filteredFiles = fullResponse.Files.Where(f => Options.FileFilter?.Invoke(f) ?? true);
-
-                fullResponse = new SearchResponse(fullResponse.Username, fullResponse.Token, filteredFiles.Count(), fullResponse.FreeUploadSlots, fullResponse.UploadSpeed, fullResponse.QueueLength, filteredFiles);
-
-                // ensure the filtered file count still meets the response criteria
-                if ((Options.FilterResponses && fullResponse.FileCount < Options.MinimumResponseFileCount) || !(Options.ResponseFilter?.Invoke(fullResponse) ?? true))
+                // apply basic filters on the slim response
+                if (!SlimResponseMeetsOptionCriteria(slimResponse))
                 {
                     return;
+                }
+
+                // extract the file list from the response
+                var fullResponse = SearchResponseFactory.FromSlimResponse(slimResponse);
+
+                if (Options.FilterResponses)
+                {
+                    // apply custom filter
+                    if (!(Options.ResponseFilter?.Invoke(fullResponse) ?? true))
+                    {
+                        return;
+                    }
+
+                    // apply individual file filter
+                    var filteredFiles = fullResponse.Files.Where(f => Options.FileFilter?.Invoke(f) ?? true);
+
+                    fullResponse = new SearchResponse(fullResponse.Username, fullResponse.Token, filteredFiles.Count(), fullResponse.FreeUploadSlots, fullResponse.UploadSpeed, fullResponse.QueueLength, filteredFiles);
+
+                    // ensure the filtered file count still meets the response criteria
+                    if (fullResponse.FileCount < Options.MinimumResponseFileCount)
+                    {
+                        return;
+                    }
                 }
 
                 Interlocked.Increment(ref responseCount);

--- a/src/Soulseek/SearchInternal.cs
+++ b/src/Soulseek/SearchInternal.cs
@@ -88,7 +88,7 @@ namespace Soulseek
 
         private bool Disposed { get; set; } = false;
         private SystemTimer SearchTimeoutTimer { get; set; }
-        private TaskCompletionSource<int> TaskCompletionSource { get; set; } = new TaskCompletionSource<int>();
+        private TaskCompletionSource<int> TaskCompletionSource { get; } = new TaskCompletionSource<int>();
 
         /// <summary>
         ///     Cancels the search.

--- a/src/Soulseek/SearchOptions.cs
+++ b/src/Soulseek/SearchOptions.cs
@@ -62,10 +62,10 @@ namespace Soulseek
             MinimumPeerFreeUploadSlots = minimumPeerFreeUploadSlots;
             MaximumPeerQueueLength = maximumPeerQueueLength;
             MinimumPeerUploadSpeed = minimumPeerUploadSpeed;
-            StateChanged = stateChanged;
-            ResponseReceived = responseReceived;
             ResponseFilter = responseFilter;
             FileFilter = fileFilter;
+            StateChanged = stateChanged;
+            ResponseReceived = responseReceived;
         }
 
         /// <summary>

--- a/tests/Soulseek.Tests.Unit/Client/AcknowledgePrivilegeNotificationAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AcknowledgePrivilegeNotificationAsyncTests.cs
@@ -29,7 +29,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(-1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(-1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -42,7 +42,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(1));
 
                 Assert.Null(ex);
             }
@@ -94,7 +94,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(1, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(1, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<PrivilegeNotificationException>(ex);
@@ -114,7 +114,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(1, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(1, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -133,7 +133,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivilegeNotificationAsync(1, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivilegeNotificationAsync(1, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/AddUserAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AddUserAsyncTests.cs
@@ -36,7 +36,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AddUserAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.AddUserAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -55,7 +55,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AddUserAsync("a"));
+                var ex = await Record.ExceptionAsync(() => s.AddUserAsync("a"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
@@ -37,7 +37,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.BrowseAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.BrowseAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -50,7 +50,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.BrowseAsync("foo"));
+                var ex = await Record.ExceptionAsync(() => s.BrowseAsync("foo"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -66,7 +66,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.BrowseAsync("foo"));
+                var ex = await Record.ExceptionAsync(() => s.BrowseAsync("foo"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/ChangePasswordAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ChangePasswordAsyncTests.cs
@@ -35,7 +35,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.ChangePasswordAsync(password));
+                var ex = await Record.ExceptionAsync(() => s.ChangePasswordAsync(password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -54,7 +54,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.ChangePasswordAsync("a"));
+                var ex = await Record.ExceptionAsync(() => s.ChangePasswordAsync("a"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -38,7 +38,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", outputStream: null));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", outputStream: null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
@@ -54,7 +54,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -72,7 +72,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync(username, "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, "filename"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -89,7 +89,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync(username, "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, "filename", stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -105,7 +105,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", filename));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -164,7 +164,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -179,7 +179,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -195,7 +195,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -212,7 +212,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -233,7 +233,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", 0, 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", 0, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -255,7 +255,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", stream, 0, 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream, 0, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -276,7 +276,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync(username, filename, 0, 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, 0, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -298,7 +298,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync(username, filename, stream, 0, 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream, 0, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -326,7 +326,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserOfflineException>(ex);
@@ -355,7 +355,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -385,7 +385,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -420,7 +420,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferException>(ex);
@@ -452,7 +452,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -485,7 +485,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -519,7 +519,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -567,7 +567,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -608,7 +608,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -1257,7 +1257,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferException>(ex);
@@ -1320,7 +1320,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -1353,7 +1353,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -1409,7 +1409,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferException>(ex);
@@ -1465,7 +1465,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -1519,7 +1519,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<byte[]>>("DownloadToByteArrayAsync", username, filename, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
@@ -37,7 +37,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDirectoryContentsAsync(username, "foo"));
+                var ex = await Record.ExceptionAsync(() => s.GetDirectoryContentsAsync(username, "foo"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -56,7 +56,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDirectoryContentsAsync("foo", directory));
+                var ex = await Record.ExceptionAsync(() => s.GetDirectoryContentsAsync("foo", directory));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -75,7 +75,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDirectoryContentsAsync("a", "b"));
+                var ex = await Record.ExceptionAsync(() => s.GetDirectoryContentsAsync("a", "b"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetDownloadPlaceInQueueAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDownloadPlaceInQueueAsyncTests.cs
@@ -38,7 +38,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync(username, "a"));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync(username, "a"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync("a", filename));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync("a", filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync("a", "b"));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync("a", "b"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -91,7 +91,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync(username, filename));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync(username, filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferNotFoundException>(ex);
@@ -157,7 +157,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", dict);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync(username, filename));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync(username, filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserOfflineException>(ex);
@@ -195,7 +195,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", dict);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync(username, filename));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync(username, filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DownloadPlaceInQueueException>(ex);
@@ -233,7 +233,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", dict);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync(username, filename));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync(username, filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -271,7 +271,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Downloads", dict);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetDownloadPlaceInQueueAsync(username, filename));
+                var ex = await Record.ExceptionAsync(() => s.GetDownloadPlaceInQueueAsync(username, filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetPrivilegesAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetPrivilegesAsyncTests.cs
@@ -35,7 +35,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetPrivilegesAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetPrivilegesAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -54,7 +54,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetPrivilegesAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetPrivilegesAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -73,7 +73,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetPrivilegesAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetPrivilegesAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -92,7 +92,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetPrivilegesAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetPrivilegesAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<PrivilegeCheckException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetRoomListAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetRoomListAsyncTests.cs
@@ -32,7 +32,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.GetRoomListAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetRoomListAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -47,7 +47,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetRoomListAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetRoomListAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -91,7 +91,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetRoomListAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetRoomListAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<RoomListException>(ex);
@@ -111,7 +111,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetRoomListAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetRoomListAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -130,7 +130,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetRoomListAsync());
+                var ex = await Record.ExceptionAsync(() => s.GetRoomListAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
@@ -38,7 +38,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserEndPointAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserEndPointAsync("a"));
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync("a"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserEndPointAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -95,7 +95,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserEndPointAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -114,7 +114,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserEndPointAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserEndPointException>(ex);
@@ -137,7 +137,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserEndPointAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserEndPointAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserOfflineException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetUserInfoAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserInfoAsyncTests.cs
@@ -37,7 +37,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserInfoAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserInfoAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -56,7 +56,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserInfoAsync("a"));
+                var ex = await Record.ExceptionAsync(() => s.GetUserInfoAsync("a"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetUserPrivilegedAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserPrivilegedAsyncTests.cs
@@ -35,7 +35,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserPrivilegedAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserPrivilegedAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -54,7 +54,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserPrivilegedAsync("foo"));
+                var ex = await Record.ExceptionAsync(() => s.GetUserPrivilegedAsync("foo"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -73,7 +73,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserPrivilegedAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserPrivilegedAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -92,7 +92,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserPrivilegedAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserPrivilegedAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -111,7 +111,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserPrivilegedAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserPrivilegedAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<PrivilegeCheckException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GetUserStatusAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserStatusAsyncTests.cs
@@ -36,7 +36,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserStatusAsync(username));
+                var ex = await Record.ExceptionAsync(() => s.GetUserStatusAsync(username));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -55,7 +55,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GetUserStatusAsync("a"));
+                var ex = await Record.ExceptionAsync(() => s.GetUserStatusAsync("a"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/GrantUserPrivilegesAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GrantUserPrivilegesAsyncTests.cs
@@ -36,7 +36,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GrantUserPrivilegesAsync(username, 1));
+                var ex = await Record.ExceptionAsync(() => s.GrantUserPrivilegesAsync(username, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -54,7 +54,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GrantUserPrivilegesAsync("foo", days));
+                var ex = await Record.ExceptionAsync(() => s.GrantUserPrivilegesAsync("foo", days));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -74,7 +74,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", state);
 
-                var ex = await Record.ExceptionAsync(async () => await s.GrantUserPrivilegesAsync("a", 1));
+                var ex = await Record.ExceptionAsync(() => s.GrantUserPrivilegesAsync("a", 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
@@ -32,7 +32,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.JoinRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.JoinRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -47,7 +47,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.JoinRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.JoinRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -65,7 +65,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.JoinRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.JoinRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -111,7 +111,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.JoinRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.JoinRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<RoomJoinException>(ex);
@@ -131,7 +131,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.JoinRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.JoinRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -150,7 +150,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.JoinRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.JoinRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -163,7 +163,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.LeaveRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.LeaveRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -178,7 +178,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LeaveRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.LeaveRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -196,7 +196,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LeaveRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.LeaveRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -238,7 +238,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LeaveRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.LeaveRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<RoomLeaveException>(ex);
@@ -258,7 +258,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LeaveRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.LeaveRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -277,7 +277,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LeaveRoomAsync(roomName));
+                var ex = await Record.ExceptionAsync(() => s.LeaveRoomAsync(roomName));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
@@ -32,7 +32,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync(null, Guid.NewGuid().ToString()));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync(null, Guid.NewGuid().ToString()));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -53,7 +53,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync(username, password));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync(username, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -68,7 +68,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync("a", "b"));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync("a", "b"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -83,7 +83,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Disconnected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync("a", "b"));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync("a", "b"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -191,7 +191,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync(user, password));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync(user, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<LoginRejectedException>(ex);
@@ -214,7 +214,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync(user, password));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync(user, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -235,7 +235,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync(user, password));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync(user, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -256,7 +256,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.LoginAsync(user, password));
+                var ex = await Record.ExceptionAsync(() => s.LoginAsync(user, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<LoginException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
@@ -113,8 +113,10 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "LoginAsync")]
         [Theory(DisplayName = "LoginAsync sets listen port on success if set"), AutoData]
-        public async Task LoginAsync_Sets_Listen_Port_On_Success_If_Set(string user, string password, int port)
+        public async Task LoginAsync_Sets_Listen_Port_On_Success_If_Set(string user, string password)
         {
+            var port = 50000;
+
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new LoginResponse(true, string.Empty)));
@@ -137,8 +139,10 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "LoginAsync")]
         [Theory(DisplayName = "LoginAsync writes HaveNoParent on success if enabled"), AutoData]
-        public async Task LoginAsync_Writes_HaveNoParent_On_Success_If_Enabled(string user, string password, int port)
+        public async Task LoginAsync_Writes_HaveNoParent_On_Success_If_Enabled(string user, string password)
         {
+            var port = 50000;
+
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new LoginResponse(true, string.Empty)));
@@ -158,8 +162,10 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "LoginAsync")]
         [Theory(DisplayName = "LoginAsync does not write HaveNoParent on success if disabled"), AutoData]
-        public async Task LoginAsync_Does_Not_Write_HaveNoParent_On_Success_If_Disabled(string user, string password, int port)
+        public async Task LoginAsync_Does_Not_Write_HaveNoParent_On_Success_If_Disabled(string user, string password)
         {
+            var port = 50000;
+
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new LoginResponse(true, string.Empty)));

--- a/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
@@ -24,6 +24,13 @@ namespace Soulseek.Tests.Unit.Client
 
     public class LoginAsyncTests
     {
+        private static readonly Random RNG = new Random();
+
+        private static int GetPort()
+        {
+            return 50000 + RNG.Next(1, 9999);
+        }
+
         [Trait("Category", "LoginAsync")]
         [Fact(DisplayName = "LoginAsync throws ArgumentException on null username")]
         public async Task LoginAsync_Throws_ArgumentException_On_Null_Username()
@@ -115,7 +122,7 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "LoginAsync sets listen port on success if set"), AutoData]
         public async Task LoginAsync_Sets_Listen_Port_On_Success_If_Set(string user, string password)
         {
-            var port = 50000;
+            var port = GetPort();
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
@@ -141,7 +148,7 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "LoginAsync writes HaveNoParent on success if enabled"), AutoData]
         public async Task LoginAsync_Writes_HaveNoParent_On_Success_If_Enabled(string user, string password)
         {
-            var port = 50000;
+            var port = GetPort();
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
@@ -164,7 +171,7 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "LoginAsync does not write HaveNoParent on success if disabled"), AutoData]
         public async Task LoginAsync_Does_Not_Write_HaveNoParent_On_Success_If_Disabled(string user, string password)
         {
-            var port = 50000;
+            var port = GetPort();
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<LoginResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))

--- a/tests/Soulseek.Tests.Unit/Client/PingServerAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/PingServerAsyncTests.cs
@@ -29,7 +29,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync());
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -44,7 +44,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync());
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -67,7 +67,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync());
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync());
 
                 Assert.Null(ex);
             }
@@ -85,7 +85,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync(CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync(CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<PingException>(ex);
@@ -105,7 +105,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync(CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync(CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -128,7 +128,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync(CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync(CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -147,7 +147,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.PingServerAsync(CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.PingServerAsync(CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
@@ -35,7 +35,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText("foo"), token: 0, cancellationToken: CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText("foo"), token: 0, cancellationToken: CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -49,7 +49,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText("foo"), (r) => { }, token: 0, cancellationToken: CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText("foo"), (r) => { }, token: 0, cancellationToken: CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -65,7 +65,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText("foo"), token: 0));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText("foo"), token: 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -81,7 +81,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText("foo"), (r) => { }, token: 0));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText("foo"), (r) => { }, token: 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -100,7 +100,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText(search), token: 0));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText(search), token: 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -116,7 +116,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(null, token: 0));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(null, token: 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
@@ -135,7 +135,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText(search), (r) => { }, token: 0));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText(search), (r) => { }, token: 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -151,7 +151,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(null, (r) => { }, token: 0));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(null, (r) => { }, token: 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
@@ -167,7 +167,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText("foo"), responseReceived: null));
+                var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText("foo"), responseReceived: null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
@@ -189,7 +189,7 @@ namespace Soulseek.Tests.Unit.Client
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
                     s.SetProperty("Searches", dict);
 
-                    var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText(text), token: token));
+                    var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText(text), token: token));
 
                     Assert.NotNull(ex);
                     Assert.IsType<DuplicateTokenException>(ex);
@@ -211,7 +211,7 @@ namespace Soulseek.Tests.Unit.Client
                     s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
                     s.SetProperty("Searches", dict);
 
-                    var ex = await Record.ExceptionAsync(async () => await s.SearchAsync(SearchQuery.FromText(text), (r) => { }, token: token));
+                    var ex = await Record.ExceptionAsync(() => s.SearchAsync(SearchQuery.FromText(text), (r) => { }, token: token));
 
                     Assert.NotNull(ex);
                     Assert.IsType<DuplicateTokenException>(ex);
@@ -340,7 +340,7 @@ namespace Soulseek.Tests.Unit.Client
 
                     cts.Cancel();
 
-                    await Record.ExceptionAsync(async () => await task); // swallow the cancellation exception
+                    await Record.ExceptionAsync(() => task); // swallow the cancellation exception
 
                     Assert.Single(active);
                     Assert.Contains(active, kvp => kvp.Key == token);
@@ -367,7 +367,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 cts.Cancel();
 
-                await Record.ExceptionAsync(async () => await task); // swallow the cancellation exception
+                await Record.ExceptionAsync(() => task); // swallow the cancellation exception
 
                 Assert.Single(active);
                 Assert.Contains(active, kvp => kvp.Value.SearchText == searchText);
@@ -522,7 +522,7 @@ namespace Soulseek.Tests.Unit.Client
                 searches.FirstOrDefault(r => r.Key == token).Value.ResponseReceived.Invoke(response);
 
                 cts.Cancel();
-                await Record.ExceptionAsync(async () => await task); // swallow the cancellation exception
+                await Record.ExceptionAsync(() => task); // swallow the cancellation exception
 
                 Assert.True(fired);
             }

--- a/tests/Soulseek.Tests.Unit/Client/SendAcknowledgePrivateMessageAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendAcknowledgePrivateMessageAsyncTests.cs
@@ -29,7 +29,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(-1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(-1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -42,7 +42,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(1));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(1));
 
                 Assert.Null(ex);
             }
@@ -94,7 +94,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(1, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(1, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<PrivateMessageException>(ex);
@@ -114,7 +114,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(1, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(1, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -133,7 +133,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.AcknowledgePrivateMessageAsync(1, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.AcknowledgePrivateMessageAsync(1, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -146,7 +146,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync("foo", "bar"));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync("foo", "bar"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -161,7 +161,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync("foo", "bar"));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync("foo", "bar"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -182,7 +182,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync(username, message));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync(username, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -201,7 +201,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync("foo", "bar"));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync("foo", "bar"));
 
                 Assert.Null(ex);
             }
@@ -219,7 +219,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync("foo", "bar"));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync("foo", "bar"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<PrivateMessageException>(ex);
@@ -239,7 +239,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync("foo", "bar"));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync("foo", "bar"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -258,7 +258,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendPrivateMessageAsync("foo", "bar"));
+                var ex = await Record.ExceptionAsync(() => s.SendPrivateMessageAsync("foo", "bar"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/SendRoomMessageAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendRoomMessageAsyncTests.cs
@@ -30,7 +30,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -45,7 +45,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -66,7 +66,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -85,7 +85,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.Null(ex);
             }
@@ -103,7 +103,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<RoomMessageException>(ex);
@@ -123,7 +123,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -142,7 +142,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SendRoomMessageAsync(roomName, message));
+                var ex = await Record.ExceptionAsync(() => s.SendRoomMessageAsync(roomName, message));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/SetSharedCountsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SetSharedCountsAsyncTests.cs
@@ -29,7 +29,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, 0));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -44,7 +44,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, 0));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -59,7 +59,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(-1, 0));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(-1, 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -75,7 +75,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, -1));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, -1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -95,7 +95,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, 0));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, 0));
 
                 Assert.Null(ex);
             }
@@ -113,7 +113,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, 0));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, 0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SharedCountsException>(ex);
@@ -133,7 +133,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, 0, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, 0, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -152,7 +152,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetSharedCountsAsync(0, 0, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SetSharedCountsAsync(0, 0, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/SetUserStatusAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SetUserStatusAsyncTests.cs
@@ -29,7 +29,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.SetStatusAsync(UserPresence.Online));
+                var ex = await Record.ExceptionAsync(() => s.SetStatusAsync(UserPresence.Online));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -44,7 +44,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetStatusAsync(UserPresence.Online));
+                var ex = await Record.ExceptionAsync(() => s.SetStatusAsync(UserPresence.Online));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -63,7 +63,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetStatusAsync(UserPresence.Online));
+                var ex = await Record.ExceptionAsync(() => s.SetStatusAsync(UserPresence.Online));
 
                 Assert.Null(ex);
             }
@@ -81,7 +81,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetStatusAsync(UserPresence.Online, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SetStatusAsync(UserPresence.Online, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserStatusException>(ex);
@@ -101,7 +101,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetStatusAsync(UserPresence.Online, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SetStatusAsync(UserPresence.Online, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -120,7 +120,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.SetStatusAsync(UserPresence.Online, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => s.SetStatusAsync(UserPresence.Online, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -39,7 +39,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync(username, "filename", new byte[] { 0x0 }));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, "filename", new byte[] { 0x0 }));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync(username, "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, "filename", 1, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -74,7 +74,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", filename, new byte[] { 0x0 }));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", filename, new byte[] { 0x0 }));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -92,7 +92,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", filename, 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", filename, 1, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -108,7 +108,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", data));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", data));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -126,7 +126,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", length, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", length, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -140,7 +140,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", new byte[] { 0x0 }));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -154,7 +154,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", 1, null));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
@@ -169,7 +169,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new UnReadableWriteableStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -185,7 +185,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", new byte[] { 0x0 }));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -202,7 +202,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -223,7 +223,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Uploads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", new byte[] { 0x0 }, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -245,7 +245,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Uploads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", 1, stream, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -266,7 +266,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Uploads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync(username, filename, new byte[] { 0x0 }, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, new byte[] { 0x0 }, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -288,7 +288,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("Uploads", queued);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync(username, filename, 1, stream, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, 1, stream, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -318,7 +318,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", new byte[] { 0x0 }));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -348,7 +348,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.UploadAsync("username", "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -406,7 +406,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -439,7 +439,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -522,7 +522,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -1066,7 +1066,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferException>(ex);
@@ -1129,7 +1129,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferException>(ex);
@@ -1192,7 +1192,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -1225,7 +1225,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -1279,7 +1279,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferException>(ex);
@@ -1425,7 +1425,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -1477,7 +1477,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(async () => await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);

--- a/tests/Soulseek.Tests.Unit/Network/MessageConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/MessageConnectionTests.cs
@@ -100,7 +100,7 @@ namespace Soulseek.Tests.Unit.Network
             {
                 c.SetProperty("State", ConnectionState.Disconnected);
 
-                var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(msg));
+                var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -119,7 +119,7 @@ namespace Soulseek.Tests.Unit.Network
             {
                 c.SetProperty("State", ConnectionState.Disconnecting);
 
-                var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(msg));
+                var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -179,7 +179,7 @@ namespace Soulseek.Tests.Unit.Network
 
                 using (var c = new MessageConnection(endpoint, tcpClient: tcpMock.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(msg));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionWriteException>(ex);
@@ -312,7 +312,7 @@ namespace Soulseek.Tests.Unit.Network
                 {
                     var a = c.ReadingContinuously;
 
-                    await Record.ExceptionAsync(async () => await c.InvokeMethod<Task>("ReadContinuouslyAsync"));
+                    await Record.ExceptionAsync(() => c.InvokeMethod<Task>("ReadContinuouslyAsync"));
 
                     Assert.False(a);
                     Assert.True(b);

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -45,6 +45,32 @@ namespace Soulseek.Tests.Unit.Network
             Assert.Equal(0, c.MessageConnections.Count);
         }
 
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Throws if no SoulseekClient given")]
+        public void Throws_If_SoulseekClient_Given()
+        {
+            var ex = Record.Exception(() => _ = new PeerConnectionManager(null));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentNullException>(ex);
+            Assert.Equal("soulseekClient", ((ArgumentNullException)ex).ParamName);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Ensures Diagnostic given null")]
+        public void Ensures_Diagnostic_Given_Null()
+        {
+            using (var client = new SoulseekClient(options: null))
+            {
+                PeerConnectionManager c = default;
+
+                var ex = Record.Exception(() => c = new PeerConnectionManager(client));
+
+                Assert.Null(ex);
+                Assert.NotNull(c.GetProperty<IDiagnosticFactory>("Diagnostic"));
+            }
+        }
+
         [Trait("Category", "Dispose")]
         [Fact(DisplayName = "Disposes without throwing")]
         public void Disposes_Without_Throwing()

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -185,7 +185,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.AddTransferConnectionAsync(username, token, incomingConn.Object));
+                var ex = await Record.ExceptionAsync(() => manager.AddTransferConnectionAsync(username, token, incomingConn.Object));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -217,7 +217,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.AddTransferConnectionAsync(username, token, incomingConn.Object));
+                var ex = await Record.ExceptionAsync(() => manager.AddTransferConnectionAsync(username, token, incomingConn.Object));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -632,7 +632,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetTransferConnectionAsync(ctpr));
+                var ex = await Record.ExceptionAsync(() => manager.GetTransferConnectionAsync(ctpr));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -661,7 +661,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetTransferConnectionAsync(ctpr));
+                var ex = await Record.ExceptionAsync(() => manager.GetTransferConnectionAsync(ctpr));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -712,7 +712,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.GetTransferConnectionAsync(ctpr));
+                await Record.ExceptionAsync(() => manager.GetTransferConnectionAsync(ctpr));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish an inbound indirect transfer connection"))), Times.Once);
@@ -735,7 +735,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundDirectAsync", endpoint, token, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundDirectAsync", endpoint, token, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.Equal(expectedException, ex);
@@ -830,7 +830,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundDirectAsync", endpoint, token, CancellationToken.None));
+                await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundDirectAsync", endpoint, token, CancellationToken.None));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish a direct transfer connection"))), Times.Once);
@@ -881,7 +881,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundIndirectAsync", username, token, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundIndirectAsync", username, token, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.Equal(expectedException, ex);
@@ -992,7 +992,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundIndirectAsync", username, token, CancellationToken.None));
+                await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IConnection>>("GetTransferConnectionOutboundIndirectAsync", username, token, CancellationToken.None));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish an indirect transfer connection"))), Times.Once);
@@ -1129,7 +1129,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetTransferConnectionAsync(username, dendpoint, token, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetTransferConnectionAsync(username, dendpoint, token, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -1203,7 +1203,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.GetTransferConnectionAsync(username, dendpoint, token, CancellationToken.None));
+                await Record.ExceptionAsync(() => manager.GetTransferConnectionAsync(username, dendpoint, token, CancellationToken.None));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish a direct or indirect transfer connection"))), Times.Once);
@@ -1242,7 +1242,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.GetTransferConnectionAsync(username, dendpoint, token, CancellationToken.None));
+                await Record.ExceptionAsync(() => manager.GetTransferConnectionAsync(username, dendpoint, token, CancellationToken.None));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to negotiate transfer connection"))), Times.Once);
@@ -1474,7 +1474,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundDirectAsync", username, endpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundDirectAsync", username, endpoint, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.Equal(expectedEx, ex);
@@ -1519,7 +1519,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundDirectAsync", username, endpoint, CancellationToken.None));
+                await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundDirectAsync", username, endpoint, CancellationToken.None));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish a direct message connection"))), Times.Once);
@@ -1574,7 +1574,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundIndirectAsync", username, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundIndirectAsync", username, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.Equal(expectedException, ex);
@@ -1725,7 +1725,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                await Record.ExceptionAsync(async () => await manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundIndirectAsync", username, CancellationToken.None));
+                await Record.ExceptionAsync(() => manager.InvokeMethod<Task<IMessageConnection>>("GetMessageConnectionOutboundIndirectAsync", username, CancellationToken.None));
             }
 
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish an indirect message connection"))), Times.Once);
@@ -1832,7 +1832,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(ctpr));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(ctpr));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -1862,7 +1862,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(ctpr));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(ctpr));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -2211,7 +2211,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -2391,7 +2391,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -2429,7 +2429,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -2461,7 +2461,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -2495,7 +2495,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -2527,7 +2527,7 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                var ex = await Record.ExceptionAsync(async () => await manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
+                var ex = await Record.ExceptionAsync(() => manager.GetOrAddMessageConnectionAsync(username, dendpoint, CancellationToken.None));
 
                 var dict = manager.GetProperty<ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>>("MessageConnectionDictionary");
 

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -2567,6 +2567,37 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish a direct or indirect transfer connection"))));
         }
 
+        [Trait("Category", "Diagnostic")]
+        [Fact(DisplayName = "Diagnostic raises DiagnosticGenerated")]
+        internal void Diagnostic_Raises_DiagnosticGenerated()
+        {
+            using (var client = new SoulseekClient())
+            using (var manager = new PeerConnectionManager(client))
+            {
+                bool fired = false;
+                manager.DiagnosticGenerated += (o, e) => fired = true;
+
+                var diag = manager.GetProperty<IDiagnosticFactory>("Diagnostic");
+                diag.Info("test");
+
+                Assert.True(fired);
+            }
+        }
+
+        [Trait("Category", "Diagnostic")]
+        [Fact(DisplayName = "Diagnostic does not throw if DiagnosticGenerated not subscribed")]
+        internal void Diagnostic_Does_Not_Throw_If_DiagnosticGenerated_Not_Subscribed()
+        {
+            using (var client = new SoulseekClient())
+            using (var manager = new PeerConnectionManager(client))
+            {
+                var diag = manager.GetProperty<IDiagnosticFactory>("Diagnostic");
+                var ex = Record.Exception(() => diag.Info("test"));
+
+                Assert.Null(ex);
+            }
+        }
+
         private (PeerConnectionManager Manager, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
         {
             var mocks = new Mocks(options);

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionKeyTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionKeyTests.cs
@@ -76,7 +76,57 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         public void GetHashCode_Does_Not_Match_If_Key_Differs()
         {
             var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("b", new IPEndPoint(new IPAddress(0x1), 2));
+
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Trait("Category", "Hash Code")]
+        [Fact(DisplayName = "GetHashCode does not match if Username differs")]
+        public void GetHashCode_Does_Not_Match_If_Username_Differs()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
             var b = new ConnectionKey("b", new IPEndPoint(new IPAddress(0x0), 1));
+
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Trait("Category", "Hash Code")]
+        [Fact(DisplayName = "GetHashCode does not match if IPAddress differs")]
+        public void GetHashCode_Does_Not_Match_If_IPAddress_Differs()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x1), 1));
+
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Trait("Category", "Hash Code")]
+        [Fact(DisplayName = "GetHashCode does not match if Port differs")]
+        public void GetHashCode_Does_Not_Match_If_Port_Differs()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 2));
+
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Trait("Category", "Hash Code")]
+        [Fact(DisplayName = "GetHashCode does not match if nulls differ")]
+        public void GetHashCode_Does_Not_Match_If_Nulls_Differ()
+        {
+            var a = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", null);
+
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+
+            a = new ConnectionKey(null, null);
+            b = new ConnectionKey("a", null);
+
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+
+            a = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+            b = new ConnectionKey(null, null);
 
             Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
         }
@@ -93,11 +143,44 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         }
 
         [Trait("Category", "Equals")]
-        [Fact(DisplayName = "Equals returns false when not equal")]
-        public void Equals_Returns_False_When_Not_Equal()
+        [Fact(DisplayName = "Equals returns false when IPAddress differs")]
+        public void Equals_Returns_False_When_IPAddress_Differs()
         {
             var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
             var b = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x1), 1));
+
+            Assert.False(a.Equals(b));
+            Assert.False(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals returns false when IPAddress and Port differ")]
+        public void Equals_Returns_False_When_IPAddress_And_Port_Differ()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x1), 2));
+
+            Assert.False(a.Equals(b));
+            Assert.False(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals returns false when Username, IPAddress and Port differ")]
+        public void Equals_Returns_False_When_Username_IPAddress_And_Port_Differ()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("b", new IPEndPoint(new IPAddress(0x1), 2));
+
+            Assert.False(a.Equals(b));
+            Assert.False(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals returns false when Port differs")]
+        public void Equals_Returns_False_When_Port_Differs()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 2));
 
             Assert.False(a.Equals(b));
             Assert.False(b.Equals(a));
@@ -123,6 +206,91 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             Assert.True(a.Equals((object)b));
             Assert.True(b.Equals((object)a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles null")]
+        public void Equals_Handles_Null()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            ConnectionKey b = null;
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles null IPEndPoint")]
+        public void Equals_Handles_Null_IPEndPoint()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", null);
+
+            Assert.False(a.Equals(b));
+            Assert.False(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles null Username")]
+        public void Equals_Handles_Null_Username()
+        {
+            var a = new ConnectionKey("a", new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+
+            Assert.False(a.Equals(b));
+            Assert.False(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles both null IPEndPoints")]
+        public void Equals_Handles_Both_Null_IPEndPoints()
+        {
+            var a = new ConnectionKey("a", null);
+            var b = new ConnectionKey("a", null);
+
+            Assert.True(a.Equals(b));
+            Assert.True(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles both null Usernames")]
+        public void Equals_Handles_Both_Null_Usernames()
+        {
+            var a = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+
+            Assert.True(a.Equals(b));
+            Assert.True(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles null Username and IPEndPoint")]
+        public void Equals_Handles_Null_Username_And_IPEndPoint()
+        {
+            var a = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+            var b = new ConnectionKey("a", null);
+
+            Assert.False(a.Equals(b));
+            Assert.False(b.Equals(a));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles null and null IPEndPoint")]
+        public void Equals_Handles_Null_And_Null_IPEndPoint()
+        {
+            var a = new ConnectionKey(null, new IPEndPoint(new IPAddress(0x0), 1));
+            ConnectionKey b = null;
+
+            Assert.False(a.Equals(b));
+        }
+
+        [Trait("Category", "Equals")]
+        [Fact(DisplayName = "Equals handles null and null Username")]
+        public void Equals_Handles_Null_And_Null_Username()
+        {
+            var a = new ConnectionKey("a", null);
+            ConnectionKey b = null;
+
+            Assert.False(a.Equals(b));
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -1,8 +1,8 @@
 ﻿// <copyright file="ConnectionTests.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
-//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
-//     published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+//     as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 //
 //     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
 //     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public License for more details.

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -926,13 +926,11 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 t.Setup(m => m.Connected).Returns(true);
                 t.Setup(m => m.GetStream()).Returns(s.Object);
 
-                var cancellationToken = CancellationToken.None;
-
                 using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(writeBufferSize: 5)))
                 {
-                    await c.WriteAsync(10, stream, (ct) => Task.CompletedTask, cancellationToken);
+                    await c.WriteAsync(10, stream, (ct) => Task.CompletedTask);
 
-                    s.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), cancellationToken), Times.Exactly(2));
+                    s.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
                 }
             }
         }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -254,7 +254,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             {
                 c.SetProperty("State", ConnectionState.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await c.ConnectAsync());
+                var ex = await Record.ExceptionAsync(() => c.ConnectAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -272,7 +272,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ConnectAsync());
+                    var ex = await Record.ExceptionAsync(() => c.ConnectAsync());
 
                     Assert.Null(ex);
                     Assert.Equal(ConnectionState.Connected, c.State);
@@ -296,7 +296,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 var o = new ConnectionOptions(connectTimeout: 0);
                 using (var c = new Connection(endpoint, options: o, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ConnectAsync());
+                    var ex = await Record.ExceptionAsync(() => c.ConnectAsync());
 
                     Assert.NotNull(ex);
                     Assert.IsType<TimeoutException>(ex);
@@ -328,7 +328,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                     using (var cts = new CancellationTokenSource())
                     {
                         cts.Cancel();
-                        ex = await Record.ExceptionAsync(async () => await c.ConnectAsync(cts.Token));
+                        ex = await Record.ExceptionAsync(() => c.ConnectAsync(cts.Token));
                     }
 
                     Assert.NotNull(ex);
@@ -354,7 +354,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ConnectAsync());
+                    var ex = await Record.ExceptionAsync(() => c.ConnectAsync());
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionException>(ex);
@@ -499,7 +499,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             using (var c = new Connection(endpoint))
             {
-                var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(null));
+                var ex = await Record.ExceptionAsync(() => c.WriteAsync(null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -518,7 +518,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(Array.Empty<byte>()));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(Array.Empty<byte>()));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentException>(ex);
@@ -543,7 +543,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(length, stream, (ct) => Task.CompletedTask));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentException>(ex);
@@ -563,7 +563,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(1, null, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(1, null, (ct) => Task.CompletedTask));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentNullException>(ex);
@@ -584,7 +584,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(1, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(1, stream, (ct) => Task.CompletedTask));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -605,7 +605,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(new byte[] { 0x0, 0x1 }));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(new byte[] { 0x0, 0x1 }));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -627,7 +627,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(length, stream, governor));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(length, stream, governor));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -650,7 +650,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 {
                     c.SetProperty("State", ConnectionState.Disconnected);
 
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(new byte[] { 0x0, 0x1 }));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(new byte[] { 0x0, 0x1 }));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -674,7 +674,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 {
                     c.SetProperty("State", ConnectionState.Disconnected);
 
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(length, stream, governor));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(length, stream, governor));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -700,7 +700,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(new byte[] { 0x0, 0x1 }));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(new byte[] { 0x0, 0x1 }));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionWriteException>(ex);
@@ -731,7 +731,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(new byte[] { 0x0, 0x1 }));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(new byte[] { 0x0, 0x1 }));
 
                     Assert.NotNull(ex);
                     Assert.IsType<TimeoutException>(ex);
@@ -761,7 +761,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(new byte[] { 0x0, 0x1 }));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(new byte[] { 0x0, 0x1 }));
 
                     Assert.NotNull(ex);
                     Assert.IsType<OperationCanceledException>(ex);
@@ -788,7 +788,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(new byte[] { 0x0, 0x1 }));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(new byte[] { 0x0, 0x1 }));
 
                     Assert.Null(ex);
 
@@ -842,7 +842,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.WriteAsync(data.Length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(data.Length, stream, (ct) => Task.CompletedTask));
 
                     Assert.Null(ex);
 
@@ -897,7 +897,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -919,7 +919,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1, stream, governor));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1, stream, governor));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -943,7 +943,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                     t.Setup(m => m.Client).Returns(socket);
                     c.SetProperty("State", ConnectionState.Disconnected);
 
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -968,7 +968,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                     t.Setup(m => m.Client).Returns(socket);
                     c.SetProperty("State", ConnectionState.Disconnected);
 
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1, stream, governor));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1, stream, governor));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -994,7 +994,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(length));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length));
 
                     Assert.Null(ex);
                 }
@@ -1020,7 +1020,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(length, stream, governor));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, governor));
 
                     Assert.Null(ex);
                 }
@@ -1045,7 +1045,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.Null(ex);
 
@@ -1073,7 +1073,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1, stream, (ct) => Task.CompletedTask));
 
                     Assert.Null(ex);
 
@@ -1151,7 +1151,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionReadException>(ex);
@@ -1182,7 +1182,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     Assert.IsType<TimeoutException>(ex);
@@ -1212,7 +1212,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     Assert.IsType<OperationCanceledException>(ex);
@@ -1237,7 +1237,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(0));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(0));
 
                     Assert.Null(ex);
                 }
@@ -1280,7 +1280,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(length));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentException>(ex);
@@ -1305,7 +1305,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, (ct) => Task.CompletedTask));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentException>(ex);
@@ -1326,7 +1326,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(length, null, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, null, (ct) => Task.CompletedTask));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentNullException>(ex);
@@ -1348,7 +1348,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, (ct) => Task.CompletedTask));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -1374,7 +1374,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionReadException>(ex);
@@ -1473,7 +1473,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 {
                     c.GetProperty<System.Timers.Timer>("InactivityTimer").Interval = 100;
 
-                    var ex = await Record.ExceptionAsync(async () => await c.ReadAsync(1));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1));
 
                     Assert.NotNull(ex);
                     output(ex.Message);

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -380,6 +380,38 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             }
         }
 
+        [Trait("Category", "WaitForDisconnect")]
+        [Theory(DisplayName = "WaitForDisconnect waits for disconnect"), AutoData]
+        public async Task WaitForDisconnect_Waits_For_Disconnect(IPEndPoint endpoint, string message)
+        {
+            using (var c = new Connection(endpoint))
+            {
+                c.SetProperty("State", ConnectionState.Connected);
+                c.Disconnect(message);
+
+                var actualMessage = await c.WaitForDisconnect();
+
+                Assert.Equal(message, actualMessage);
+            }
+        }
+
+        [Trait("Category", "WaitForDisconnect")]
+        [Theory(DisplayName = "WaitForDisconnect throws OperationCanceledException when cancelled"), AutoData]
+        public async Task WaitForDisconnect_Throws_OperationCanceledException_When_Canceled(IPEndPoint endpoint, string message)
+        {
+            using (var c = new Connection(endpoint))
+            {
+                c.SetProperty("State", ConnectionState.Connected);
+
+                var ct = new CancellationToken(canceled: true);
+
+                var ex = await Record.ExceptionAsync(() => c.WaitForDisconnect(ct));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+
         [Trait("Category", "Watchdog")]
         [Theory(DisplayName = "Watchdog disconnects when TcpClient disconnects"), AutoData]
         public async Task Watchdog_Disconnects_When_TcpClient_Disconnects(IPEndPoint endpoint)

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -1,8 +1,8 @@
 ﻿// <copyright file="ConnectionTests.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
-//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
-//     as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as
+//     published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 //
 //     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
 //     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU General Public License for more details.
@@ -20,7 +20,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
     using System.Threading;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
-    using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
     using Moq;
     using Soulseek.Exceptions;
     using Soulseek.Network.Tcp;

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -913,7 +913,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var s = new Mock<INetworkStream>();
             s.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(5));
+                .Returns(Task.CompletedTask);
 
             var t = new Mock<ITcpClient>();
 

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -917,7 +917,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             var t = new Mock<ITcpClient>();
 
-            var data = new byte[] { 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0 };
+            var data = new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 
             using (var stream = new MemoryStream(data))
             using (var socket = new Socket(SocketType.Stream, ProtocolType.IP))
@@ -930,7 +930,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 {
                     await c.WriteAsync(10, stream, (ct) => Task.CompletedTask);
 
-                    s.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+                    s.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), 5, It.IsAny<CancellationToken>()), Times.Exactly(2));
                 }
             }
         }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -914,7 +914,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var s = new Mock<INetworkStream>();
             s.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(2));
+                .Returns(Task.FromResult(1));
 
             var t = new Mock<ITcpClient>();
 

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -913,11 +913,11 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var s = new Mock<INetworkStream>();
             s.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(1));
+                .Returns(Task.FromResult(5));
 
             var t = new Mock<ITcpClient>();
 
-            var data = new byte[] { 0x0, 0x1 };
+            var data = new byte[] { 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0 };
 
             using (var stream = new MemoryStream(data))
             using (var socket = new Socket(SocketType.Stream, ProtocolType.IP))
@@ -928,9 +928,9 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 var cancellationToken = CancellationToken.None;
 
-                using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(writeBufferSize: 1)))
+                using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(writeBufferSize: 5)))
                 {
-                    await c.WriteAsync(2, stream, (ct) => Task.CompletedTask, cancellationToken);
+                    await c.WriteAsync(10, stream, (ct) => Task.CompletedTask, cancellationToken);
 
                     s.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), cancellationToken), Times.Exactly(2));
                 }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -1332,7 +1332,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var s = new Mock<INetworkStream>();
             s.Setup(m => m.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.Run(() => 10));
+                .Returns(Task.Run(() => 5));
 
             var t = new Mock<ITcpClient>();
 
@@ -1343,11 +1343,11 @@ namespace Soulseek.Tests.Unit.Network.Tcp
                 t.Setup(m => m.Connected).Returns(true);
                 t.Setup(m => m.GetStream()).Returns(s.Object);
 
-                using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(readBufferSize: 10)))
+                using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(readBufferSize: 5)))
                 {
-                    await c.ReadAsync(20, stream, (ct) => Task.CompletedTask);
+                    await c.ReadAsync(10, stream, (ct) => Task.CompletedTask);
 
-                    s.Verify(m => m.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+                    s.Verify(m => m.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), 5, It.IsAny<CancellationToken>()), Times.Exactly(2));
                 }
             }
         }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -12,17 +12,25 @@
 
 namespace Soulseek.Tests.Unit.Network.Tcp
 {
+    using System;
     using AutoFixture.Xunit2;
     using Soulseek.Network.Tcp;
     using Xunit;
 
     public class ListenerTests
     {
+        private static readonly Random RNG = new Random();
+
+        private static int GetPort()
+        {
+            return 50000 + RNG.Next(1, 9999);
+        }
+
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates properly"), AutoData]
         public void Instantiates_Properly(ConnectionOptions options)
         {
-            var port = 50000;
+            var port = GetPort();
 
             var l = new Listener(port, options);
 
@@ -36,7 +44,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         [Theory(DisplayName = "Start starts listening"), AutoData]
         public void Start_Starts_Listening(ConnectionOptions options)
         {
-            var port = 50000;
+            var port = GetPort();
 
             var l = new Listener(port, options);
 
@@ -52,7 +60,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         [Theory(DisplayName = "Stop stops listening"), AutoData]
         public void Stop_Stops_Listening(ConnectionOptions options)
         {
-            var port = 50000;
+            var port = GetPort();
 
             var l = new Listener(port, options);
 

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -20,8 +20,10 @@ namespace Soulseek.Tests.Unit.Network.Tcp
     {
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates properly"), AutoData]
-        public void Instantiates_Properly(int port, ConnectionOptions options)
+        public void Instantiates_Properly(ConnectionOptions options)
         {
+            var port = 50000;
+
             var l = new Listener(port, options);
 
             Assert.Equal(port, l.Port);
@@ -32,8 +34,10 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Start")]
         [Theory(DisplayName = "Start starts listening"), AutoData]
-        public void Start_Starts_Listening(int port, ConnectionOptions options)
+        public void Start_Starts_Listening(ConnectionOptions options)
         {
+            var port = 50000;
+
             var l = new Listener(port, options);
 
             var first = l.Listening;
@@ -46,8 +50,10 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Stop")]
         [Theory(DisplayName = "Stop stops listening"), AutoData]
-        public void Stop_Stops_Listening(int port, ConnectionOptions options)
+        public void Stop_Stops_Listening(ConnectionOptions options)
         {
+            var port = 50000;
+
             var l = new Listener(port, options);
 
             l.Start();

--- a/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
@@ -12,6 +12,7 @@
 
 namespace Soulseek.Tests.Unit
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -34,6 +35,9 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(options, s.Options);
 
             Assert.Equal(SearchStates.None, s.State);
+
+            Assert.Equal(0, s.FileCount);
+            Assert.Equal(0, s.ResponseCount);
 
             s.Dispose();
         }
@@ -473,6 +477,21 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(filename, addResponse.Files.ToList()[0].Filename);
 
             s.Dispose();
+        }
+
+        [Trait("Category", "Cancel")]
+        [Fact(DisplayName = "Cancel cancels")]
+        public async Task Cancel_Cancels()
+        {
+            using (var s = new SearchInternal("foo", 1))
+            {
+                s.Cancel();
+
+                var ex = await Record.ExceptionAsync(() => s.WaitForCompletion(CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -93,7 +93,7 @@ namespace Soulseek.Tests.Unit
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -108,7 +108,7 @@ namespace Soulseek.Tests.Unit
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port));
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -123,7 +123,7 @@ namespace Soulseek.Tests.Unit
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(username, password));
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(username, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -138,7 +138,7 @@ namespace Soulseek.Tests.Unit
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port, username, password));
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port, username, password));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -164,7 +164,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<ConnectionException>(ex);
@@ -190,7 +190,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -216,7 +216,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync());
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -231,7 +231,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(serverConnection: c.Object))
             {
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync());
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync());
 
                 Assert.Null(ex);
             }
@@ -255,7 +255,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(connectionFactory: factory.Object))
             {
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port));
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port));
 
                 Assert.Null(ex);
             }
@@ -285,7 +285,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(connectionFactory: factory.Object, waiter: waiter.Object))
             {
-                var ex = await Record.ExceptionAsync(async () => await s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port, username, password));
+                var ex = await Record.ExceptionAsync(() => s.ConnectAsync(endpoint.Address.ToString(), endpoint.Port, username, password));
 
                 Assert.Null(ex);
             }


### PR DESCRIPTION
Slight refactoring of `ConnectionKey` to improve outcomes of `Equals()` and `GetHashCode()`