### PR TITLE
Handle 4-byte queue length in legacy search responses

### DIFF
--- a/src/Soulseek/Messaging/MessageReader.cs
+++ b/src/Soulseek/Messaging/MessageReader.cs
@@ -62,6 +62,11 @@ namespace Soulseek.Messaging
         public bool HasMoreData => Position < Payload.Length;
 
         /// <summary>
+        ///     Gets the Message payload length.
+        /// </summary>
+        public int Length => Payload.Length;
+
+        /// <summary>
         ///     Gets the Message payload.
         /// </summary>
         public Memory<byte> Payload { get; private set; }
@@ -70,6 +75,11 @@ namespace Soulseek.Messaging
         ///     Gets the current position of the head of the reader.
         /// </summary>
         public int Position { get; private set; } = 0;
+
+        /// <summary>
+        ///     Gets the length of the remaining payload data.
+        /// </summary>
+        public int Remaining => Length - Position;
 
         private int CodeLength { get; }
         private bool Decompressed { get; set; } = false;

--- a/src/Soulseek/Messaging/Messages/SearchResponseFactory.cs
+++ b/src/Soulseek/Messaging/Messages/SearchResponseFactory.cs
@@ -47,7 +47,17 @@ namespace Soulseek.Messaging.Messages
 
             var freeUploadSlots = reader.ReadByte();
             var uploadSpeed = reader.ReadInteger();
-            var queueLength = reader.ReadLong();
+
+            long queueLength;
+
+            if (reader.Remaining == 4)
+            {
+                queueLength = reader.ReadInteger();
+            }
+            else
+            {
+                queueLength = reader.ReadLong();
+            }
 
             IEnumerable<File> lockedFileList = Enumerable.Empty<File>();
 

--- a/tests/Soulseek.Tests.Unit/Messaging/MessageReaderTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/MessageReaderTests.cs
@@ -82,8 +82,8 @@ namespace Soulseek.Tests.Unit.Messaging
             Assert.Equal(MessageCode.Peer.BrowseRequest, code);
             Assert.Equal(BitConverter.GetBytes(num), reader.Payload.ToArray());
             Assert.Equal(0, reader.Position);
-            Assert.Equal(num, reader.ReadInteger());
-            Assert.Equal(4, reader.Position);
+            Assert.Equal(4, reader.Length);
+            Assert.Equal(4, reader.Remaining);
         }
 
         [Trait("Category", "Instantiation")]
@@ -537,6 +537,54 @@ namespace Soulseek.Tests.Unit.Messaging
             reader.ReadInteger();
 
             Assert.False(reader.HasMoreData);
+        }
+
+        [Trait("Category", "Remaining")]
+        [Fact(DisplayName = "Remaining property returns remaining length to be read")]
+        public void Remaining_Property_Returns_Remaining_Length_To_Be_Read()
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Peer.BrowseRequest)
+                .WriteInteger(1)
+                .WriteInteger(2)
+                .Build();
+
+            var reader = new MessageReader<MessageCode.Peer>(msg);
+            reader.ReadCode();
+
+            Assert.Equal(8, reader.Remaining);
+
+            reader.ReadInteger();
+
+            Assert.Equal(4, reader.Remaining);
+
+            reader.ReadInteger();
+
+            Assert.Equal(0, reader.Remaining);
+        }
+
+        [Trait("Category", "Position")]
+        [Fact(DisplayName = "Position property returns number of bytes read")]
+        public void Position_Property_Returns_Number_Of_Bytes_Read()
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Peer.BrowseRequest)
+                .WriteInteger(1)
+                .WriteInteger(2)
+                .Build();
+
+            var reader = new MessageReader<MessageCode.Peer>(msg);
+            reader.ReadCode();
+
+            Assert.Equal(0, reader.Position);
+
+            reader.ReadInteger();
+
+            Assert.Equal(4, reader.Position);
+
+            reader.ReadInteger();
+
+            Assert.Equal(8, reader.Position);
         }
 
         [Trait("Category", "ReadCode")]


### PR DESCRIPTION
Closes #358 