### PR TITLE
Enable read-only access when uploading

### DIFF
--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -377,7 +377,7 @@
             // normally there would be an internal queue, and uploads would be handled separately.
             Task.Run(async () =>
             {
-                using (var stream = new FileStream(fileInfo.FullName, FileMode.Open))
+                using (var stream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read))
                 {
                     await Client.UploadAsync(username, fileInfo.FullName, fileInfo.Length, stream, options: topts, cancellationToken: cts.Token);
                 }


### PR DESCRIPTION
The existing `FileStream` failed to specify `FileAccess.Read` when creating the stream.  This caused the stream to be opened with read/write permissions, which throws an `Access denied` exception on read-only filesystems.