### PR TITLE
Refactor WriteAsync() to use IOutgoingMessage

### DIFF
--- a/examples/Web/web/src/App.css
+++ b/examples/Web/web/src/App.css
@@ -9,7 +9,6 @@ body {
 
 .app {
     margin: auto;
-    padding-bottom: 17px !important;
     border: 0px !important;
     border-radius: 0% !important;
     box-shadow: none !important;

--- a/examples/Web/web/src/index.js
+++ b/examples/Web/web/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from "react-router-dom";
-import App from './App';
 import 'semantic-ui-css/semantic.min.css';
+import App from './App';
 
 ReactDOM.render(
     <Router>

--- a/src/Soulseek/Common/EventArgs/TransferEventArgs.cs
+++ b/src/Soulseek/Common/EventArgs/TransferEventArgs.cs
@@ -12,8 +12,6 @@
 
 namespace Soulseek
 {
-    using System;
-
     /// <summary>
     ///     Generic event arguments for transfer events.
     /// </summary>

--- a/src/Soulseek/Messaging/Handlers/DistributedMessageHandler.cs
+++ b/src/Soulseek/Messaging/Handlers/DistributedMessageHandler.cs
@@ -76,7 +76,7 @@ namespace Soulseek.Messaging.Handlers
                     case MessageCode.Distributed.Ping:
                         Diagnostic.Debug($"PING?");
                         var pingResponse = new DistributedPingResponse(SoulseekClient.GetNextToken());
-                        await connection.WriteAsync(pingResponse.ToByteArray()).ConfigureAwait(false);
+                        await connection.WriteAsync(pingResponse).ConfigureAwait(false);
                         Diagnostic.Debug($"PONG!");
                         break;
 

--- a/src/Soulseek/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Soulseek/Messaging/Handlers/PeerMessageHandler.cs
@@ -114,9 +114,7 @@ namespace Soulseek.Messaging.Handlers
                             Diagnostic.Warning($"Failed to resolve user info response: {ex.Message}", ex);
                         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
                         await connection.WriteAsync(outgoingInfo.ToByteArray()).ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
                         break;
 
                     case MessageCode.Peer.BrowseRequest:
@@ -134,9 +132,7 @@ namespace Soulseek.Messaging.Handlers
                             Diagnostic.Warning($"Failed to resolve browse response: {ex.Message}", ex);
                         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
                         await connection.WriteAsync(browseResponse.ToByteArray()).ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
                         break;
 
                     case MessageCode.Peer.FolderContentsRequest:

--- a/src/Soulseek/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Soulseek/Messaging/Handlers/PeerMessageHandler.cs
@@ -114,7 +114,9 @@ namespace Soulseek.Messaging.Handlers
                             Diagnostic.Warning($"Failed to resolve user info response: {ex.Message}", ex);
                         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
                         await connection.WriteAsync(outgoingInfo.ToByteArray()).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
                         break;
 
                     case MessageCode.Peer.BrowseRequest:
@@ -132,7 +134,9 @@ namespace Soulseek.Messaging.Handlers
                             Diagnostic.Warning($"Failed to resolve browse response: {ex.Message}", ex);
                         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
                         await connection.WriteAsync(browseResponse.ToByteArray()).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
                         break;
 
                     case MessageCode.Peer.FolderContentsRequest:
@@ -156,7 +160,7 @@ namespace Soulseek.Messaging.Handlers
                         {
                             var folderContentsResponseMessage = new FolderContentsResponse(folderContentsRequest.Token, outgoingFolderContents);
 
-                            await connection.WriteAsync(folderContentsResponseMessage.ToByteArray()).ConfigureAwait(false);
+                            await connection.WriteAsync(folderContentsResponseMessage).ConfigureAwait(false);
                         }
 
                         break;
@@ -184,7 +188,7 @@ namespace Soulseek.Messaging.Handlers
 
                         if (queueRejected)
                         {
-                            await connection.WriteAsync(new EnqueueFailedResponse(queueDownloadRequest.Filename, queueRejectionMessage).ToByteArray()).ConfigureAwait(false);
+                            await connection.WriteAsync(new EnqueueFailedResponse(queueDownloadRequest.Filename, queueRejectionMessage)).ConfigureAwait(false);
                         }
                         else
                         {
@@ -205,7 +209,7 @@ namespace Soulseek.Messaging.Handlers
                             else
                             {
                                 // reject the transfer with an empty reason.  it was probably cancelled, but we can't be sure.
-                                await connection.WriteAsync(new TransferResponse(transferRequest.Token, string.Empty).ToByteArray()).ConfigureAwait(false);
+                                await connection.WriteAsync(new TransferResponse(transferRequest.Token, string.Empty)).ConfigureAwait(false);
                             }
                         }
                         else
@@ -214,12 +218,12 @@ namespace Soulseek.Messaging.Handlers
 
                             if (transferRejected)
                             {
-                                await connection.WriteAsync(new TransferResponse(transferRequest.Token, transferRejectionMessage).ToByteArray()).ConfigureAwait(false);
-                                await connection.WriteAsync(new EnqueueFailedResponse(transferRequest.Filename, transferRejectionMessage).ToByteArray()).ConfigureAwait(false);
+                                await connection.WriteAsync(new TransferResponse(transferRequest.Token, transferRejectionMessage)).ConfigureAwait(false);
+                                await connection.WriteAsync(new EnqueueFailedResponse(transferRequest.Filename, transferRejectionMessage)).ConfigureAwait(false);
                             }
                             else
                             {
-                                await connection.WriteAsync(new TransferResponse(transferRequest.Token, "Queued").ToByteArray()).ConfigureAwait(false);
+                                await connection.WriteAsync(new TransferResponse(transferRequest.Token, "Queued")).ConfigureAwait(false);
                                 await TrySendPlaceInQueueAsync(connection, transferRequest.Filename).ConfigureAwait(false);
                             }
                         }
@@ -351,7 +355,7 @@ namespace Soulseek.Messaging.Handlers
 
             if (placeInQueue.HasValue)
             {
-                await connection.WriteAsync(new PlaceInQueueResponse(filename, placeInQueue.Value).ToByteArray()).ConfigureAwait(false);
+                await connection.WriteAsync(new PlaceInQueueResponse(filename, placeInQueue.Value)).ConfigureAwait(false);
             }
         }
     }

--- a/src/Soulseek/Messaging/Messages/Peer/BrowseResponseFactory.cs
+++ b/src/Soulseek/Messaging/Messages/Peer/BrowseResponseFactory.cs
@@ -13,7 +13,7 @@
 namespace Soulseek.Messaging.Messages
 {
     using System.Collections.Generic;
-    
+
     /// <summary>
     ///     Factory for search response messages. This class helps keep message abstractions from leaking into the public API via
     ///     <see cref="SearchResponse"/>, which is a public class.

--- a/src/Soulseek/Messaging/Messages/Peer/FolderContentsResponse.cs
+++ b/src/Soulseek/Messaging/Messages/Peer/FolderContentsResponse.cs
@@ -13,7 +13,7 @@
 namespace Soulseek.Messaging.Messages
 {
     using System.Collections.Generic;
-    
+
     /// <summary>
     ///     The response to a peer folder contents request.
     /// </summary>

--- a/src/Soulseek/Messaging/Messages/Peer/SearchResponseFactory.cs
+++ b/src/Soulseek/Messaging/Messages/Peer/SearchResponseFactory.cs
@@ -14,7 +14,7 @@ namespace Soulseek.Messaging.Messages
 {
     using System.Collections.Generic;
     using System.Linq;
-    
+
     /// <summary>
     ///     Factory for search response messages. This class helps keep message abstractions from leaking into the public API via
     ///     <see cref="SearchResponse"/>, which is a public class.

--- a/src/Soulseek/Messaging/Messages/Server/ConnectToPeerResponse.cs
+++ b/src/Soulseek/Messaging/Messages/Server/ConnectToPeerResponse.cs
@@ -14,7 +14,7 @@ namespace Soulseek.Messaging.Messages
 {
     using System;
     using System.Net;
-    
+
     /// <summary>
     ///     A server response which solicits a peer connection.
     /// </summary>

--- a/src/Soulseek/Messaging/Messages/Server/LoginResponse.cs
+++ b/src/Soulseek/Messaging/Messages/Server/LoginResponse.cs
@@ -14,7 +14,7 @@ namespace Soulseek.Messaging.Messages
 {
     using System;
     using System.Net;
-    
+
     /// <summary>
     ///     The response to a login request.
     /// </summary>

--- a/src/Soulseek/Messaging/Messages/Server/NetInfoNotification.cs
+++ b/src/Soulseek/Messaging/Messages/Server/NetInfoNotification.cs
@@ -16,7 +16,7 @@ namespace Soulseek.Messaging.Messages
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
-    
+
     /// <summary>
     ///     An incoming list of available distributed parent candidates.
     /// </summary>

--- a/src/Soulseek/Messaging/Messages/Server/PrivilegedUserListNotification.cs
+++ b/src/Soulseek/Messaging/Messages/Server/PrivilegedUserListNotification.cs
@@ -13,7 +13,7 @@
 namespace Soulseek.Messaging.Messages
 {
     using System.Collections.Generic;
-    
+
     /// <summary>
     ///     A list of the privileged users on the server.
     /// </summary>

--- a/src/Soulseek/Messaging/Messages/Server/UserAddressResponse.cs
+++ b/src/Soulseek/Messaging/Messages/Server/UserAddressResponse.cs
@@ -14,7 +14,7 @@ namespace Soulseek.Messaging.Messages
 {
     using System;
     using System.Net;
-    
+
     /// <summary>
     ///     The response to a request for a peer's address.
     /// </summary>

--- a/src/Soulseek/Network/DistributedConnectionManager.cs
+++ b/src/Soulseek/Network/DistributedConnectionManager.cs
@@ -182,7 +182,7 @@ namespace Soulseek.Network
                     await connection.ConnectAsync().ConfigureAwait(false);
 
                     var request = new PierceFirewall(r.Token);
-                    await connection.WriteAsync(request.ToByteArray()).ConfigureAwait(false);
+                    await connection.WriteAsync(request).ConfigureAwait(false);
 
                     await connection.WriteAsync(GetBranchInformation<MessageCode.Peer>()).ConfigureAwait(false);
                 }
@@ -524,7 +524,7 @@ namespace Soulseek.Network
 
                 if (isDirect)
                 {
-                    var request = new PeerInit(SoulseekClient.Username, Constants.ConnectionType.Distributed, SoulseekClient.GetNextToken()).ToByteArray();
+                    var request = new PeerInit(SoulseekClient.Username, Constants.ConnectionType.Distributed, SoulseekClient.GetNextToken());
                     await connection.WriteAsync(request, cancellationToken).ConfigureAwait(false);
                 }
                 else
@@ -585,7 +585,7 @@ namespace Soulseek.Network
                 PendingSolicitationDictionary.TryAdd(solicitationToken, username);
 
                 await SoulseekClient.ServerConnection
-                    .WriteAsync(new ConnectToPeerRequest(solicitationToken, username, Constants.ConnectionType.Distributed).ToByteArray(), cancellationToken)
+                    .WriteAsync(new ConnectToPeerRequest(solicitationToken, username, Constants.ConnectionType.Distributed), cancellationToken)
                     .ConfigureAwait(false);
 
                 using var incomingConnection = await SoulseekClient.Waiter
@@ -691,7 +691,7 @@ namespace Soulseek.Network
 
                 if (HasParent)
                 {
-                    await ParentConnection.WriteAsync(new DistributedChildDepth(ChildConnectionDictionary.Count).ToByteArray()).ConfigureAwait(false);
+                    await ParentConnection.WriteAsync(new DistributedChildDepth(ChildConnectionDictionary.Count)).ConfigureAwait(false);
                 }
 
                 var sb = new StringBuilder("Updated distributed status; ");

--- a/src/Soulseek/Network/IMessageConnection.cs
+++ b/src/Soulseek/Network/IMessageConnection.cs
@@ -82,22 +82,6 @@ namespace Soulseek.Network
         void StartReadingContinuously();
 
         /// <summary>
-        ///     Asynchronously writes the specified bytes to the connection.
-        /// </summary>
-        /// <remarks>The connection is disconnected if a <see cref="ConnectionWriteException"/> is thrown.</remarks>
-        /// <param name="bytes">The bytes to write.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A Task representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentException">Thrown when the specified <paramref name="bytes"/> array is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown when the connection state is not <see cref="ConnectionState.Connected"/>, or when the underlying TcpClient
-        ///     is not connected.
-        /// </exception>
-        /// <exception cref="ConnectionWriteException">Thrown when an unexpected error occurs.</exception>
-        [Obsolete("Use WriteAsync(IOutgoingMessage).")]
-        new Task WriteAsync(byte[] bytes, CancellationToken? cancellationToken = null);
-
-        /// <summary>
         ///     Asynchronously writes the specified <paramref name="message"/> to the connection.
         /// </summary>
         /// <param name="message">The message to write.</param>

--- a/src/Soulseek/Network/MessageConnection.cs
+++ b/src/Soulseek/Network/MessageConnection.cs
@@ -132,25 +132,6 @@ namespace Soulseek.Network
         }
 
         /// <summary>
-        ///     Asynchronously writes the specified bytes to the connection.
-        /// </summary>
-        /// <remarks>The connection is disconnected if a <see cref="ConnectionWriteException"/> is thrown.</remarks>
-        /// <param name="bytes">The bytes to write.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A Task representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentException">Thrown when the specified <paramref name="bytes"/> array is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown when the connection state is not <see cref="ConnectionState.Connected"/>, or when the underlying TcpClient
-        ///     is not connected.
-        /// </exception>
-        /// <exception cref="ConnectionWriteException">Thrown when an unexpected error occurs.</exception>
-        [Obsolete("Use WriteAsync(IOutgoingMessage).")]
-        public new Task WriteAsync(byte[] bytes, CancellationToken? cancellationToken = null)
-        {
-            return base.WriteAsync(bytes, cancellationToken);
-        }
-
-        /// <summary>
         ///     Asynchronously writes the specified <paramref name="message"/> to the connection.
         /// </summary>
         /// <param name="message">The message to write.</param>
@@ -245,7 +226,7 @@ namespace Soulseek.Network
 
         private async Task WriteMessageInternalAsync(byte[] bytes, CancellationToken cancellationToken)
         {
-            await base.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+            await WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
 
             Interlocked.CompareExchange(ref MessageWritten, null, null)?
                 .Invoke(this, new MessageEventArgs(bytes));

--- a/src/Soulseek/Network/PeerConnectionManager.cs
+++ b/src/Soulseek/Network/PeerConnectionManager.cs
@@ -334,7 +334,7 @@ namespace Soulseek.Network
                     {
                         await connection.ConnectAsync(cts.Token).ConfigureAwait(false);
 
-                        var request = new PierceFirewall(r.Token).ToByteArray();
+                        var request = new PierceFirewall(r.Token);
                         await connection.WriteAsync(request, cts.Token).ConfigureAwait(false);
                     }
                     catch
@@ -432,7 +432,7 @@ namespace Soulseek.Network
                 {
                     if (isDirect)
                     {
-                        var request = new PeerInit(SoulseekClient.Username, Constants.ConnectionType.Peer, SoulseekClient.GetNextToken()).ToByteArray();
+                        var request = new PeerInit(SoulseekClient.Username, Constants.ConnectionType.Peer, SoulseekClient.GetNextToken());
                         await connection.WriteAsync(request, cancellationToken).ConfigureAwait(false);
                     }
                     else
@@ -629,7 +629,7 @@ namespace Soulseek.Network
                 PendingSolicitationDictionary.TryAdd(solicitationToken, username);
 
                 await SoulseekClient.ServerConnection
-                    .WriteAsync(new ConnectToPeerRequest(solicitationToken, username, Constants.ConnectionType.Peer).ToByteArray(), cancellationToken)
+                    .WriteAsync(new ConnectToPeerRequest(solicitationToken, username, Constants.ConnectionType.Peer), cancellationToken)
                     .ConfigureAwait(false);
 
                 using var incomingConnection = await SoulseekClient.Waiter
@@ -698,7 +698,7 @@ namespace Soulseek.Network
                 PendingSolicitationDictionary.TryAdd(solicitationToken, username);
 
                 await SoulseekClient.ServerConnection
-                    .WriteAsync(new ConnectToPeerRequest(solicitationToken, username, Constants.ConnectionType.Transfer).ToByteArray(), cancellationToken)
+                    .WriteAsync(new ConnectToPeerRequest(solicitationToken, username, Constants.ConnectionType.Transfer), cancellationToken)
                     .ConfigureAwait(false);
 
                 using var incomingConnection = await SoulseekClient.Waiter

--- a/src/Soulseek/Network/Tcp/IConnection.cs
+++ b/src/Soulseek/Network/Tcp/IConnection.cs
@@ -17,7 +17,7 @@ namespace Soulseek.Network.Tcp
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    
+
     /// <summary>
     ///     Provides client connections for TCP network services.
     /// </summary>

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -2502,9 +2502,7 @@ namespace Soulseek
                 Searches.TryAdd(search.Token, search);
                 UpdateState(SearchStates.Requested);
 
-#pragma warning disable CS0618 // Type or member is obsolete
                 await ServerConnection.WriteAsync(message, cancellationToken).ConfigureAwait(false);
-#pragma warning restore CS0618 // Type or member is obsolete
                 UpdateState(SearchStates.InProgress);
 
                 await search.WaitForCompletion(cancellationToken).ConfigureAwait(false);

--- a/src/Soulseek/SoulseekClient.cs
+++ b/src/Soulseek/SoulseekClient.cs
@@ -927,7 +927,7 @@ namespace Soulseek
                 var waitKey = new WaitKey(MessageCode.Server.CheckPrivileges);
                 var wait = Waiter.Wait<int>(waitKey, cancellationToken: cancellationToken);
 
-                await ServerConnection.WriteAsync(new CheckPrivilegesRequest().ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new CheckPrivilegesRequest(), cancellationToken).ConfigureAwait(false);
 
                 var result = await wait.ConfigureAwait(false);
                 return result;
@@ -957,7 +957,7 @@ namespace Soulseek
             try
             {
                 var roomListWait = Waiter.Wait<IReadOnlyCollection<RoomInfo>>(new WaitKey(MessageCode.Server.RoomList), cancellationToken: cancellationToken);
-                await ServerConnection.WriteAsync(new RoomListRequest().ToByteArray(), cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new RoomListRequest(), cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
 
                 var response = await roomListWait.ConfigureAwait(false);
 
@@ -1254,7 +1254,7 @@ namespace Soulseek
             try
             {
                 var wait = Waiter.Wait(new WaitKey(MessageCode.Server.Ping), null, cancellationToken);
-                var ping = new ServerPing().ToByteArray();
+                var ping = new ServerPing();
 
                 var sw = new Stopwatch();
                 sw.Start();
@@ -1510,7 +1510,7 @@ namespace Soulseek
 
             try
             {
-                return ServerConnection.WriteAsync(new SetSharedCountsCommand(directories, files).ToByteArray(), cancellationToken ?? CancellationToken.None);
+                return ServerConnection.WriteAsync(new SetSharedCountsCommand(directories, files), cancellationToken ?? CancellationToken.None);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
             {
@@ -1537,7 +1537,7 @@ namespace Soulseek
 
             try
             {
-                return ServerConnection.WriteAsync(new SetOnlineStatusCommand(status).ToByteArray(), cancellationToken ?? CancellationToken.None);
+                return ServerConnection.WriteAsync(new SetOnlineStatusCommand(status), cancellationToken ?? CancellationToken.None);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
             {
@@ -1736,7 +1736,7 @@ namespace Soulseek
         {
             try
             {
-                await ServerConnection.WriteAsync(new AcknowledgePrivilegeNotificationCommand(privilegeNotificationId).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new AcknowledgePrivilegeNotificationCommand(privilegeNotificationId), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
             {
@@ -1749,7 +1749,7 @@ namespace Soulseek
             try
             {
                 var addUserWait = Waiter.Wait<AddUserResponse>(new WaitKey(MessageCode.Server.AddUser, username), cancellationToken: cancellationToken);
-                await ServerConnection.WriteAsync(new AddUserRequest(username).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new AddUserRequest(username), cancellationToken).ConfigureAwait(false);
 
                 var response = await addUserWait.ConfigureAwait(false);
 
@@ -1804,7 +1804,7 @@ namespace Soulseek
                     // fetch the user's address and a connection and write the browse request to the remote user
                     var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
                     var connection = await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
-                    await connection.WriteAsync(new BrowseRequest().ToByteArray(), cancellationToken).ConfigureAwait(false);
+                    await connection.WriteAsync(new BrowseRequest(), cancellationToken).ConfigureAwait(false);
 
                     // wait for the receipt of the response message. this may come back on a connection different from the one
                     // which made the request.
@@ -1857,7 +1857,7 @@ namespace Soulseek
                 var waitKey = new WaitKey(MessageCode.Server.NewPassword);
                 var wait = Waiter.Wait<string>(waitKey, cancellationToken: cancellationToken);
 
-                await ServerConnection.WriteAsync(new NewPassword(password).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new NewPassword(password), cancellationToken).ConfigureAwait(false);
 
                 response = await wait.ConfigureAwait(false);
             }
@@ -1988,7 +1988,7 @@ namespace Soulseek
                 var transferStartRequested = Waiter.WaitIndefinitely<TransferRequest>(transferStartRequestedWaitKey, cancellationToken);
 
                 // request the file
-                await peerConnection.WriteAsync(new TransferRequest(TransferDirection.Download, token, filename).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await peerConnection.WriteAsync(new TransferRequest(TransferDirection.Download, token, filename), cancellationToken).ConfigureAwait(false);
                 UpdateState(TransferStates.Requested);
 
                 var transferRequestAcknowledgement = await transferRequestAcknowledged.ConfigureAwait(false);
@@ -2043,7 +2043,7 @@ namespace Soulseek
                         .AwaitTransferConnectionAsync(download.Username, download.Filename, download.RemoteToken.Value, cancellationToken);
 
                     // initiate the connection
-                    await peerConnection.WriteAsync(new TransferResponse(download.RemoteToken.Value, download.Size ?? 0).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                    await peerConnection.WriteAsync(new TransferResponse(download.RemoteToken.Value, download.Size ?? 0), cancellationToken).ConfigureAwait(false);
 
                     try
                     {
@@ -2177,7 +2177,7 @@ namespace Soulseek
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
 
                 var connection = await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
-                await connection.WriteAsync(new FolderContentsRequest(token, directoryName).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await connection.WriteAsync(new FolderContentsRequest(token, directoryName), cancellationToken).ConfigureAwait(false);
 
                 var response = await contentsWait.ConfigureAwait(false);
 
@@ -2198,7 +2198,7 @@ namespace Soulseek
 
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
                 var connection = await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
-                await connection.WriteAsync(new PlaceInQueueRequest(filename).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await connection.WriteAsync(new PlaceInQueueRequest(filename), cancellationToken).ConfigureAwait(false);
 
                 var response = await responseWait.ConfigureAwait(false);
 
@@ -2280,7 +2280,7 @@ namespace Soulseek
                     var waitKey = new WaitKey(MessageCode.Server.GetPeerAddress, username);
                     var addressWait = Waiter.Wait<UserAddressResponse>(waitKey, cancellationToken: cancellationToken);
 
-                    await ServerConnection.WriteAsync(new UserAddressRequest(username).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                    await ServerConnection.WriteAsync(new UserAddressRequest(username), cancellationToken).ConfigureAwait(false);
 
                     var response = await addressWait.ConfigureAwait(false);
 
@@ -2308,7 +2308,7 @@ namespace Soulseek
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
 
                 var connection = await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
-                await connection.WriteAsync(new UserInfoRequest().ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await connection.WriteAsync(new UserInfoRequest(), cancellationToken).ConfigureAwait(false);
 
                 var response = await infoWait.ConfigureAwait(false);
 
@@ -2327,7 +2327,7 @@ namespace Soulseek
                 var waitKey = new WaitKey(MessageCode.Server.UserPrivileges, username);
                 var wait = Waiter.Wait<bool>(waitKey, cancellationToken: cancellationToken);
 
-                await ServerConnection.WriteAsync(new UserPrivilegesRequest(username).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new UserPrivilegesRequest(username), cancellationToken).ConfigureAwait(false);
 
                 var result = await wait.ConfigureAwait(false);
                 return result;
@@ -2343,7 +2343,7 @@ namespace Soulseek
             try
             {
                 var getStatusWait = Waiter.Wait<UserStatusResponse>(new WaitKey(MessageCode.Server.GetStatus, username), cancellationToken: cancellationToken);
-                await ServerConnection.WriteAsync(new UserStatusRequest(username).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new UserStatusRequest(username), cancellationToken).ConfigureAwait(false);
 
                 var response = await getStatusWait.ConfigureAwait(false);
 
@@ -2359,7 +2359,7 @@ namespace Soulseek
         {
             try
             {
-                await ServerConnection.WriteAsync(new GivePrivilegesCommand(username, days).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new GivePrivilegesCommand(username, days), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
             {
@@ -2372,7 +2372,7 @@ namespace Soulseek
             try
             {
                 var joinRoomWait = Waiter.Wait<RoomData>(new WaitKey(MessageCode.Server.JoinRoom, roomName), cancellationToken: cancellationToken);
-                await ServerConnection.WriteAsync(new JoinRoomRequest(roomName).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new JoinRoomRequest(roomName), cancellationToken).ConfigureAwait(false);
 
                 var response = await joinRoomWait.ConfigureAwait(false);
                 return response;
@@ -2388,7 +2388,7 @@ namespace Soulseek
             try
             {
                 var leaveRoomWait = Waiter.Wait(new WaitKey(MessageCode.Server.LeaveRoom, roomName), cancellationToken: cancellationToken);
-                await ServerConnection.WriteAsync(new LeaveRoomRequest(roomName).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new LeaveRoomRequest(roomName), cancellationToken).ConfigureAwait(false);
 
                 await leaveRoomWait.ConfigureAwait(false);
             }
@@ -2404,7 +2404,7 @@ namespace Soulseek
             {
                 var loginWait = Waiter.Wait<LoginResponse>(new WaitKey(MessageCode.Server.Login), cancellationToken: cancellationToken);
 
-                await ServerConnection.WriteAsync(new LoginRequest(username, password).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new LoginRequest(username, password), cancellationToken).ConfigureAwait(false);
 
                 var response = await loginWait.ConfigureAwait(false);
 
@@ -2417,12 +2417,12 @@ namespace Soulseek
                     {
                         // the client sends an undocumented message in the format 02/listen port/01/obfuscated port we don't
                         // support obfuscation, so we send only the listen port. it probably wouldn't hurt to send an 00 afterwards.
-                        await ServerConnection.WriteAsync(new SetListenPortCommand(Options.ListenPort.Value).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                        await ServerConnection.WriteAsync(new SetListenPortCommand(Options.ListenPort.Value), cancellationToken).ConfigureAwait(false);
                     }
 
                     if (Options.EnableDistributedNetwork)
                     {
-                        await ServerConnection.WriteAsync(new HaveNoParentsCommand(true).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                        await ServerConnection.WriteAsync(new HaveNoParentsCommand(true), cancellationToken).ConfigureAwait(false);
                     }
                 }
                 else
@@ -2502,7 +2502,9 @@ namespace Soulseek
                 Searches.TryAdd(search.Token, search);
                 UpdateState(SearchStates.Requested);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 await ServerConnection.WriteAsync(message, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
                 UpdateState(SearchStates.InProgress);
 
                 await search.WaitForCompletion(cancellationToken).ConfigureAwait(false);
@@ -2548,7 +2550,7 @@ namespace Soulseek
         {
             try
             {
-                await ServerConnection.WriteAsync(new PrivateMessageCommand(username, message).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new PrivateMessageCommand(username, message), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
             {
@@ -2560,7 +2562,7 @@ namespace Soulseek
         {
             try
             {
-                await ServerConnection.WriteAsync(new RoomMessageCommand(roomName, message).ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await ServerConnection.WriteAsync(new RoomMessageCommand(roomName, message), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
             {
@@ -2672,7 +2674,7 @@ namespace Soulseek
 
                 // request to start the upload
                 var transferRequest = new TransferRequest(TransferDirection.Upload, upload.Token, upload.Filename, length);
-                await messageConnection.WriteAsync(transferRequest.ToByteArray(), cancellationToken).ConfigureAwait(false);
+                await messageConnection.WriteAsync(transferRequest, cancellationToken).ConfigureAwait(false);
                 UpdateState(TransferStates.Requested);
 
                 var transferRequestAcknowledgement = await transferRequestAcknowledged.ConfigureAwait(false);
@@ -2839,7 +2841,7 @@ namespace Soulseek
                             .GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken)
                             .ConfigureAwait(false);
 
-                        await messageConnection.WriteAsync(new UploadFailed(filename).ToByteArray()).ConfigureAwait(false);
+                        await messageConnection.WriteAsync(new UploadFailed(filename)).ConfigureAwait(false);
                     }
                     catch
                     {

--- a/tests/Soulseek.Tests.Unit/Client/AcknowledgePrivilegeNotificationAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AcknowledgePrivilegeNotificationAsyncTests.cs
@@ -16,6 +16,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -86,7 +87,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task AcknowledgePrivilegeNotificationAsync_Throws_PrivateMessageException_When_Write_Throws()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -106,7 +107,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task AcknowledgePrivilegeNotificationAsync_Throws_TimeoutException_When_Write_Times_Out()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -125,7 +126,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task AcknowledgePrivilegeNotificationAsync_Throws_OperationCanceledException_When_Write_Is_Canceled()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/AddUserAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AddUserAsyncTests.cs
@@ -72,7 +72,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -96,7 +96,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -106,7 +106,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.AddUserAsync(username, cancellationToken);
             }
 
-            serverConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            serverConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "AddUserAsync")]
@@ -120,7 +120,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -145,7 +145,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionException("foo"));
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -171,7 +171,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -196,7 +196,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
@@ -88,7 +88,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -124,7 +124,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -142,7 +142,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.BrowseAsync(username, cancellationToken: cancellationToken);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.AtLeastOnce);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.AtLeastOnce);
         }
 
         [Trait("Category", "BrowseAsync")]
@@ -160,7 +160,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -202,7 +202,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -241,7 +241,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -275,7 +275,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -306,7 +306,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.Is<byte[]>(n => new MessageReader<MessageCode.Peer>(n).ReadCode() == MessageCode.Peer.BrowseRequest), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => new MessageReader<MessageCode.Peer>(msg.ToByteArray()).ReadCode() == MessageCode.Peer.BrowseRequest), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -335,7 +335,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.Is<byte[]>(n => new MessageReader<MessageCode.Peer>(n).ReadCode() == MessageCode.Peer.BrowseRequest), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => new MessageReader<MessageCode.Peer>(msg.ToByteArray()).ReadCode() == MessageCode.Peer.BrowseRequest), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -392,7 +392,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromException<BrowseResponse>(new ConnectionException("disconnected unexpectedly")));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Raises(m => m.Disconnected += null, conn.Object, new ConnectionDisconnectedEventArgs(string.Empty));
 
@@ -432,7 +432,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();

--- a/tests/Soulseek.Tests.Unit/Client/ChangePasswordAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ChangePasswordAsyncTests.cs
@@ -17,6 +17,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Xunit;
 
@@ -69,7 +70,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(password));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -91,7 +92,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(password));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -101,7 +102,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.ChangePasswordAsync(password, cancellationToken);
             }
 
-            serverConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            serverConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "ChangePasswordAsync")]
@@ -113,7 +114,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(password + "!"));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -137,7 +138,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(password));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new ConnectionException()));
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -161,7 +162,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(password));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -184,7 +185,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(password));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -473,7 +473,7 @@ namespace Soulseek.Tests.Unit.Client
                 await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream));
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), CancellationToken.None), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), CancellationToken.None), Times.Once);
         }
 
         [Trait("Category", "DownloadAsync")]
@@ -491,7 +491,7 @@ namespace Soulseek.Tests.Unit.Client
                 await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream, cancellationToken: cancellationToken));
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "DownloadAsync")]
@@ -507,7 +507,7 @@ namespace Soulseek.Tests.Unit.Client
                 await Record.ExceptionAsync(() => s.DownloadAsync(username, filename));
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), CancellationToken.None), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), CancellationToken.None), Times.Once);
         }
 
         [Trait("Category", "DownloadAsync")]
@@ -524,7 +524,7 @@ namespace Soulseek.Tests.Unit.Client
                 await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, cancellationToken: cancellationToken));
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "DownloadAsync")]
@@ -624,7 +624,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, endpoint)));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), CancellationToken.None))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), CancellationToken.None))
                 .Throws(new ConnectionWriteException());
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);

--- a/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
@@ -94,11 +94,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new TimeoutException()));
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -130,11 +130,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new OperationCanceledException()));
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -189,11 +189,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new NullReferenceException()));
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -226,7 +226,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
@@ -258,7 +258,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
@@ -279,7 +279,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Verify(
                 m =>
                 m.WriteAsync(
-                    It.Is<byte[]>(b => b.Matches(new FolderContentsRequest(token, directory).ToByteArray())),
+                    It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new FolderContentsRequest(token, directory).ToByteArray())),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -297,7 +297,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
@@ -318,7 +318,7 @@ namespace Soulseek.Tests.Unit.Client
             serverConn.Verify(
                 m =>
                 m.WriteAsync(
-                    It.IsAny<byte[]>(),
+                    It.IsAny<IOutgoingMessage>(),
                     cancellationToken),
                 Times.Once);
         }

--- a/tests/Soulseek.Tests.Unit/Client/GetDownloadPlaceInQueueAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDownloadPlaceInQueueAsyncTests.cs
@@ -139,11 +139,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -178,11 +178,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -244,11 +244,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -282,11 +282,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -320,11 +320,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();

--- a/tests/Soulseek.Tests.Unit/Client/GetPrivilegesAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetPrivilegesAsyncTests.cs
@@ -17,6 +17,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Xunit;
 
@@ -107,7 +108,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(days));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))

--- a/tests/Soulseek.Tests.Unit/Client/GetRoomListAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetRoomListAsyncTests.cs
@@ -19,6 +19,7 @@ namespace Soulseek.Tests.Unit.Client
     using AutoFixture.Xunit2;
     using Moq;
     using Soulseek.Messaging;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -102,7 +103,7 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.Equal(rooms, response);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "GetRoomListAsync")]
@@ -110,7 +111,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GetRoomListAsync_Throws_RoomListException_When_Write_Throws()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -130,7 +131,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GetRoomListAsync_Throws_TimeoutException_On_Timeout()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -149,7 +150,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GetRoomListAsync_Throws_OperationCanceledException_On_Cancellation()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserEndPointAsyncTests.cs
@@ -129,7 +129,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("0.0.0.0"), 0)));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
@@ -152,7 +152,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, ip, port)));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
@@ -235,7 +235,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var cache = new Mock<IUserEndPointCache>();

--- a/tests/Soulseek.Tests.Unit/Client/GetUserInfoAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserInfoAsyncTests.cs
@@ -75,11 +75,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -115,11 +115,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -133,7 +133,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.GetUserInfoAsync(username, cancellationToken);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "GetUserInfoAsync")]
@@ -149,11 +149,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new TimeoutException()));
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -185,11 +185,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new OperationCanceledException()));
 
             var connManager = new Mock<IPeerConnectionManager>();
@@ -244,11 +244,11 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new ConnectionException("foo")));
 
             var connManager = new Mock<IPeerConnectionManager>();

--- a/tests/Soulseek.Tests.Unit/Client/GetUserPrivilegedAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserPrivilegedAsyncTests.cs
@@ -17,6 +17,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Xunit;
 
@@ -126,7 +127,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(privileged));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
@@ -150,7 +151,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(privileged));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))
@@ -162,7 +163,7 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.Equal(privileged, result);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken));
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken));
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Client/GetUserStatusAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetUserStatusAsyncTests.cs
@@ -72,7 +72,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -98,7 +98,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -108,7 +108,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.GetUserStatusAsync(username, cancellationToken);
             }
 
-            serverConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken));
+            serverConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken));
         }
 
         [Trait("Category", "GetUserStatusAsync")]
@@ -143,7 +143,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionException("foo"));
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -169,7 +169,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))
@@ -194,7 +194,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(result));
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: serverConn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/GrantUserPrivilegesAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GrantUserPrivilegesAsyncTests.cs
@@ -18,6 +18,7 @@ namespace Soulseek.Tests.Unit.Client
     using AutoFixture.Xunit2;
     using Moq;
     using Soulseek.Messaging;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Xunit;
 
@@ -85,7 +86,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GrantUserPrivilegesAsync_Throws_TimeoutException_On_Timeout(string username, int days)
         {
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: serverConn.Object))
@@ -104,7 +105,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GrantUserPrivilegesAsync_Throws_OperationCanceledException_On_Cancel(string username, int days)
         {
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: serverConn.Object))
@@ -123,7 +124,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GrantUserPrivilegesAsync_Throws_PrivilegeGrantException_On_Throw(string username, int days)
         {
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             using (var s = new SoulseekClient(serverConnection: serverConn.Object))
@@ -142,7 +143,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task GrantUserPrivilegesAsync_Does_Not_Throw_On_Wait_Completion(string username, int days)
         {
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var waiter = new Mock<IWaiter>();
@@ -166,7 +167,7 @@ namespace Soulseek.Tests.Unit.Client
             var cancellationToken = new CancellationToken();
 
             var serverConn = new Mock<IMessageConnection>();
-            serverConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken))
+            serverConn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken))
                 .Returns(Task.CompletedTask);
 
             var waiter = new Mock<IWaiter>();
@@ -180,7 +181,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.GrantUserPrivilegesAsync(username, days, cancellationToken);
             }
 
-            serverConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            serverConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
@@ -19,6 +19,7 @@ namespace Soulseek.Tests.Unit.Client
     using AutoFixture.Xunit2;
     using Moq;
     using Soulseek.Messaging;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -126,7 +127,7 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.Equal(expectedResponse, response);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "JoinRoomAsync")]
@@ -134,7 +135,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task JoinRoomAsync_Throws_RoomJoinException_When_Write_Throws(string roomName)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -154,7 +155,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task JoinRoomAsync_Throws_TimeoutException_On_Timeout(string roomName)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -173,7 +174,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task JoinRoomAsync_Throws_OperationCanceledException_On_Cancellation(string roomName)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -280,7 +281,7 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.Null(ex);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "LeaveRoomAsync")]
@@ -288,7 +289,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task LeaveRoomAsync_Throws_RoomLeaveException_When_Write_Throws(string roomName)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -308,7 +309,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task LeaveRoomAsync_Throws_TimeoutException_On_Timeout(string roomName)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -327,7 +328,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task LeaveRoomAsync_Throws_OperationCanceledException_On_Cancellation(string roomName)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/LoginAsyncTests.cs
@@ -140,7 +140,7 @@ namespace Soulseek.Tests.Unit.Client
             }
 
             var expectedBytes = new SetListenPortCommand(port).ToByteArray();
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "LoginAsync")]
@@ -165,7 +165,7 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.Equal(user, s.Username);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.AtLeastOnce);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.AtLeastOnce);
         }
 
         [Trait("Category", "LoginAsync")]
@@ -188,7 +188,7 @@ namespace Soulseek.Tests.Unit.Client
             }
 
             var expectedBytes = new HaveNoParentsCommand(true).ToByteArray();
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "LoginAsync")]
@@ -211,7 +211,7 @@ namespace Soulseek.Tests.Unit.Client
             }
 
             var expectedBytes = new HaveNoParentsCommand(true).ToByteArray();
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedBytes)), It.IsAny<CancellationToken?>()), Times.Never);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()), Times.Never);
         }
 
         [Trait("Category", "LoginAsync")]
@@ -286,7 +286,7 @@ namespace Soulseek.Tests.Unit.Client
             var waiter = new Mock<IWaiter>();
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<Exception>(new ConnectionWriteException()));
 
             using (var s = new SoulseekClient(serverConnection: conn.Object, waiter: waiter.Object))

--- a/tests/Soulseek.Tests.Unit/Client/PingServerAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/PingServerAsyncTests.cs
@@ -16,6 +16,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -77,7 +78,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task PingServerAsync_Throws_PrivateMessageException_When_Write_Throws()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -97,7 +98,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task PingServerAsync_Throws_TimeoutException_When_Write_Times_Out()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -116,7 +117,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task PingServerAsync_Throws_TimeoutException_When_Wait_Times_Out()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             var waiter = new Mock<IWaiter>();
@@ -139,7 +140,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task PingServerAsync_Throws_OperationCanceledException_When_Write_Is_Canceled()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
@@ -405,7 +405,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions(searchTimeout: 1);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
                 .Returns(Task.CompletedTask);
 
             var msg = new SearchRequest(expected, 0);
@@ -417,7 +417,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.SearchAsync(SearchQuery.FromText(searchText), token: 0, options: options);
             }
 
-            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(msg.ToByteArray())), It.IsAny<CancellationToken>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(msg.ToByteArray())), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Trait("Category", "SearchAsync")]
@@ -584,7 +584,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions();
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -605,7 +605,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions(searchTimeout: 1000);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new Exception("foo")));
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -745,7 +745,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -756,7 +756,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.Default, token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 
@@ -769,7 +769,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -780,7 +780,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.Room(room), token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 
@@ -793,7 +793,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -804,7 +804,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.User(user), token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 
@@ -824,7 +824,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -835,7 +835,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.User(users), token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
     }

--- a/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
@@ -374,7 +374,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Build();
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -405,7 +405,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions(searchTimeout: 1);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             var msg = new SearchRequest(expected, 0);
@@ -417,7 +417,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.SearchAsync(SearchQuery.FromText(searchText), token: 0, options: options);
             }
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(s => s.Matches(msg.ToByteArray())), It.IsAny<CancellationToken>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(msg.ToByteArray())), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Trait("Category", "SearchAsync")]
@@ -446,7 +446,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Build();
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -480,7 +480,7 @@ namespace Soulseek.Tests.Unit.Client
             })
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                     .Returns(Task.CompletedTask);
 
                 using (var cts = new CancellationTokenSource(1000))
@@ -507,7 +507,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SearchInternalAsync_Creates_Token_When_Not_Given(string searchText)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var cts = new CancellationTokenSource(1000))
@@ -533,7 +533,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SearchInternalAsync_Delegate_Creates_Token_When_Not_Given(string searchText)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var cts = new CancellationTokenSource(1000))
@@ -561,7 +561,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions();
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -584,7 +584,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions();
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -605,7 +605,7 @@ namespace Soulseek.Tests.Unit.Client
             var options = new SearchOptions(searchTimeout: 1000);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new Exception("foo")));
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -632,7 +632,7 @@ namespace Soulseek.Tests.Unit.Client
             })
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                     .Returns(Task.CompletedTask);
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -661,7 +661,7 @@ namespace Soulseek.Tests.Unit.Client
             })
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                     .Returns(Task.CompletedTask);
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -687,7 +687,7 @@ namespace Soulseek.Tests.Unit.Client
             var response = new SearchResponse("username", token, 1, 1, 1, new List<File>() { new File(1, "foo", 1, "bar", 0) });
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var cts = new CancellationTokenSource(1000))
@@ -717,7 +717,7 @@ namespace Soulseek.Tests.Unit.Client
             var response = new SearchResponse("username", token, 1, 1, 1, new List<File>() { new File(1, "foo", 1, "bar", 0) });
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), null))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                 .Returns(Task.CompletedTask);
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -745,7 +745,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -756,7 +756,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.Default, token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 
@@ -769,7 +769,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -780,7 +780,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.Room(room), token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 
@@ -793,7 +793,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -804,7 +804,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.User(user), token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 
@@ -824,7 +824,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var cts = new CancellationTokenSource(1000))
             {
                 var conn = new Mock<IMessageConnection>();
-                conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+                conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                     .Callback(() => cts.Cancel());
 
                 using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -835,7 +835,7 @@ namespace Soulseek.Tests.Unit.Client
                         s.SearchAsync(SearchQuery.FromText(searchText), SearchScope.User(users), token, cancellationToken: cts.Token));
                 }
 
-                conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
     }

--- a/tests/Soulseek.Tests.Unit/Client/SendAcknowledgePrivateMessageAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendAcknowledgePrivateMessageAsyncTests.cs
@@ -224,7 +224,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.SendPrivateMessageAsync("foo", "bar", cancellationToken);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "SendPrivateMessageAsync")]
@@ -232,7 +232,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SendPrivateMessageAsync_Throws_PrivateMessageException_When_Write_Throws()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -252,7 +252,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SendPrivateMessageAsync_Throws_TimeoutException_On_Timeout()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -271,7 +271,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SendPrivateMessageAsync_Throws_OperationCanceledException_On_Cancellation()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/SendRoomMessageAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendRoomMessageAsyncTests.cs
@@ -17,6 +17,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -107,7 +108,7 @@ namespace Soulseek.Tests.Unit.Client
                 await s.SendRoomMessageAsync(roomName, message, cancellationToken);
             }
 
-            conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), cancellationToken), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
         }
 
         [Trait("Category", "SendRoomMessageAsync")]
@@ -115,7 +116,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SendRoomMessageAsync_Throws_RoomMessageException_When_Write_Throws(string roomName, string message)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -135,7 +136,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SendRoomMessageAsync_Throws_TimeoutException_On_Timeout(string roomName, string message)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -154,7 +155,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SendRoomMessageAsync_Throws_OperationCanceledException_On_Cancellation(string roomName, string message)
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/SetSharedCountsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SetSharedCountsAsyncTests.cs
@@ -16,6 +16,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -105,7 +106,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SetSharedCountsAsync_Throws_Exception_When_Write_Throws()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -125,7 +126,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SetSharedCountsAsync_Throws_TimeoutException_When_Write_Times_Out()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -144,7 +145,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SetSharedCountsAsync_Throws_OperationCanceledException_When_Write_Is_Canceled()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/SetUserStatusAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SetUserStatusAsyncTests.cs
@@ -16,6 +16,7 @@ namespace Soulseek.Tests.Unit.Client
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
+    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Soulseek.Network.Tcp;
     using Xunit;
@@ -73,7 +74,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SetUserStatusAsync_Throws_Exception_When_Write_Throws()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new ConnectionWriteException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -93,7 +94,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SetUserStatusAsync_Throws_TimeoutException_When_Write_Times_Out()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new TimeoutException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))
@@ -112,7 +113,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task SetUserStatusAsync_Throws_OperationCanceledException_When_Write_Is_Canceled()
         {
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Throws(new OperationCanceledException());
 
             using (var s = new SoulseekClient(serverConnection: conn.Object))

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -602,7 +602,7 @@ namespace Soulseek.Tests.Unit.Client
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<Task>(new OperationCanceledException()));
 
             var transferConn = new Mock<IConnection>();
@@ -1896,7 +1896,7 @@ namespace Soulseek.Tests.Unit.Client
             }
 
             var expectedBytes = new UploadFailed(filename).ToByteArray();
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "UploadFromByteArrayAsync")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
@@ -93,7 +93,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Diagnostic.Setup(m => m.Debug(It.IsAny<string>()));
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(new Exception());
 
             var msg = new MessageBuilder()
@@ -335,7 +335,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Once);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => Encoding.UTF8.GetString(msg.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -362,8 +362,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(conn.Object, message);
             handler.HandleMessageRead(conn.Object, message);
 
-            // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -391,7 +390,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(conn.Object, message);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Exactly(2));
+            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => Encoding.UTF8.GetString(msg.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Exactly(2));
         }
 
         [Trait("Category", "Message")]
@@ -453,7 +452,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Once);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Once);
 
-            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -481,7 +480,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Never);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Never);
 
-            peerConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), null), Times.Never);
+            peerConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null), Times.Never);
         }
 
         [Trait("Category", "Message")]
@@ -512,7 +511,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Never);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Never);
 
-            peerConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), null), Times.Never);
+            peerConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null), Times.Never);
         }
 
         [Trait("Category", "Message")]
@@ -541,7 +540,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Never);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Never);
 
-            peerConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), null), Times.Never);
+            peerConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null), Times.Never);
         }
 
         [Trait("Category", "HandleChildMessageRead")]
@@ -559,7 +558,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleChildMessageRead(conn.Object, message);
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(new DistributedPingResponse(token).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new DistributedPingResponse(token).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "HandleChildMessageRead")]
@@ -577,7 +576,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleChildMessageRead(conn.Object, new MessageEventArgs(message));
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(new DistributedPingResponse(token).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new DistributedPingResponse(token).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "HandleChildMessageRead")]
@@ -590,7 +589,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
                 .Returns(token);
 
             var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException(new Exception()));
 
             var message = new DistributedPingRequest().ToByteArray();

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
@@ -335,7 +335,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Once);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => Encoding.UTF8.GetString(msg.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -362,7 +362,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(conn.Object, message);
             handler.HandleMessageRead(conn.Object, message);
 
-            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -390,7 +390,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(conn.Object, message);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => Encoding.UTF8.GetString(msg.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Exactly(2));
+            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(response.ToByteArray())), null), Times.Exactly(2));
         }
 
         [Trait("Category", "Message")]
@@ -452,7 +452,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Once);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Once);
 
-            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
@@ -17,7 +17,6 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -420,7 +420,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == defaultMessage), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == defaultMessage), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -437,7 +437,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
             mocks.PeerConnection.Verify(
-                m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+                m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Diagnostic")]
@@ -485,7 +485,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
             mocks.PeerConnection.Verify(
-                m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+                m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Diagnostic")]
@@ -529,7 +529,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
             mocks.PeerConnection.Verify(
-                m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+                m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Diagnostic")]
@@ -585,7 +585,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
             mocks.PeerConnection
-                .Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
+                .Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -603,7 +603,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
             mocks.PeerConnection
-                .Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Never);
+                .Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Never);
         }
 
         [Trait("Category", "Diagnostic")]
@@ -637,7 +637,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(expected)), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(expected)), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -655,7 +655,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
             mocks.PeerConnection
-                .Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
+                .Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -673,7 +673,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
             mocks.PeerConnection
-                .Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
+                .Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -691,7 +691,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
             mocks.PeerConnection
-                .Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Never);
+                .Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Never);
         }
 
         [Trait("Category", "Message")]
@@ -709,7 +709,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
             mocks.PeerConnection
-                .Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Never);
+                .Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(new PlaceInQueueResponse(filename, placeInQueue).ToByteArray())), It.IsAny<CancellationToken?>()), Times.Never);
         }
 
         [Trait("Category", "Diagnostic")]
@@ -744,8 +744,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(expectedTransferResponse)), null), Times.Once);
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(expectedQueueFailedResponse)), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(expectedTransferResponse)), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(expectedQueueFailedResponse)), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -761,8 +761,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(mocks.PeerConnection.Object, message);
 
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(expectedTransferResponse)), null), Times.Once);
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(expectedQueueFailedResponse)), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(expectedTransferResponse)), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(expectedQueueFailedResponse)), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -832,7 +832,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             var expected = new TransferResponse(token, string.Empty).ToByteArray();
 
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected)), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expected)), null), Times.Once);
         }
 
         [Trait("Category", "HandleMessageReceived")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -412,7 +412,6 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             var defaultResponse = await new SoulseekClientOptions()
                 .UserInfoResponseResolver(null, null).ConfigureAwait(false);
-            var defaultMessage = Encoding.UTF8.GetString(defaultResponse.ToByteArray());
 
             var (handler, mocks) = GetFixture(options: options);
 
@@ -420,7 +419,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
-            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == defaultMessage), null), Times.Once);
+            mocks.PeerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(defaultResponse.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -437,7 +436,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
             mocks.PeerConnection.Verify(
-                m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+                m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Diagnostic")]
@@ -485,7 +484,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
             mocks.PeerConnection.Verify(
-                m => m.WriteAsync(It.Is<IOutgoingMessage>(o => Encoding.UTF8.GetString(o.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+                m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Diagnostic")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -1176,8 +1176,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Once);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Once);
 
-            // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => Encoding.UTF8.GetString(msg.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(msg => msg.Matches(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -1177,7 +1177,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Once);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => Encoding.UTF8.GetString(b) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
+            peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => Encoding.UTF8.GetString(msg.ToByteArray()) == Encoding.UTF8.GetString(response.ToByteArray())), null), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -1206,7 +1206,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Never);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), null), Times.Never);
+            peerConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null), Times.Never);
         }
 
         [Trait("Category", "Message")]
@@ -1236,7 +1236,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Never);
 
             // cheap hack here to compare the contents of the resulting byte arrays, since they are distinct arrays but contain the same bytes
-            peerConn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), null), Times.Never);
+            peerConn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null), Times.Never);
         }
 
         [Trait("Category", "Message")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -17,7 +17,6 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/OutgoingTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/OutgoingTests.cs
@@ -21,6 +21,34 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
     public class OutgoingTests
     {
         [Trait("Category", "Instantiation")]
+        [Trait("Request", "PrivateMessageCommand")]
+        [Theory(DisplayName = "PrivateMessageCommand instantiates properly"), AutoData]
+        public void PrivateMessageCommand_Instantiates_Properly(string message, string username)
+        {
+            var msg = new PrivateMessageCommand(username, message);
+
+            Assert.Equal(message, msg.Message);
+            Assert.Equal(username, msg.Username);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Trait("Request", "PrivateMessageCommand")]
+        [Theory(DisplayName = "PrivateMessageCommand constructs the correct message"), AutoData]
+        public void PrivateMessageCommand_Constructs_The_Correct_Message(string message, string username)
+        {
+            var msg = new PrivateMessageCommand(username, message).ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Server>(msg);
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Server.PrivateMessage, code);
+
+            Assert.Equal(4 + 4 + 4 + username.Length + 4 + message.Length, msg.Length);
+            Assert.Equal(username, reader.ReadString());
+            Assert.Equal(message, reader.ReadString());
+        }
+
+        [Trait("Category", "Instantiation")]
         [Trait("Request", "AcknowledgePrivateMessage")]
         [Fact(DisplayName = "AcknowledgePrivateMessage instantiates properly")]
         public void AcknowledgePrivateMessage_Instantiates_Properly()

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -241,8 +241,8 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.BroadcastMessageAsync(bytes, CancellationToken.None);
             }
 
-            c1.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(bytes)), It.IsAny<CancellationToken?>()));
-            c2.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c1.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c2.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "BroadcastMessageAsync")]
@@ -253,7 +253,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var c1 = new Mock<IMessageConnection>();
             var c2 = new Mock<IMessageConnection>();
-            c2.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            c2.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(new Exception("foo"));
 
             var dict = manager.GetProperty<ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>>("ChildConnectionDictionary");
@@ -265,9 +265,9 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.BroadcastMessageAsync(bytes, CancellationToken.None);
             }
 
-            c1.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c1.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
 
-            c2.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c2.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
             c2.Verify(m => m.Dispose(), Times.AtLeastOnce);
         }
 
@@ -400,7 +400,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.AddChildConnectionAsync(ctpr);
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -599,7 +599,7 @@ namespace Soulseek.Tests.Unit.Network
             expected.AddRange(new DistributedBranchLevel(manager.BranchLevel + 1).ToByteArray());
             expected.AddRange(new DistributedBranchRoot(manager.BranchRoot).ToByteArray());
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -710,7 +710,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             mocks.ConnectionFactory.Setup(m => m.GetMessageConnection(username, endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
@@ -741,7 +741,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             mocks.ConnectionFactory.Setup(m => m.GetMessageConnection(username, endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
@@ -780,7 +780,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.AddChildConnectionAsync(username, GetMessageConnectionMock(username, endpoint).Object);
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -909,7 +909,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             mocks.ConnectionFactory.Setup(m => m.GetMessageConnection(username, endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
@@ -951,7 +951,7 @@ namespace Soulseek.Tests.Unit.Network
             expected.AddRange(new DistributedBranchLevel(manager.BranchLevel + 1).ToByteArray());
             expected.AddRange(new DistributedBranchRoot(manager.BranchRoot).ToByteArray());
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -1025,7 +1025,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(new Exception("foo"));
 
             mocks.Client.Setup(m => m.State)
@@ -1065,7 +1065,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.InvokeMethod<Task>("UpdateStatusAsync");
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Never);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Never);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1089,7 +1089,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.InvokeMethod<Task>("UpdateStatusAsync");
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Never);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Never);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1115,7 +1115,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.InvokeMethod<Task>("UpdateStatusAsync");
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1139,7 +1139,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.InvokeMethod<Task>("UpdateStatusAsync");
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1173,7 +1173,7 @@ namespace Soulseek.Tests.Unit.Network
             bytes.AddRange(new DistributedBranchLevel(manager.BranchLevel + 1).ToByteArray());
             bytes.AddRange(new DistributedBranchRoot(manager.BranchRoot).ToByteArray());
 
-            child.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(bytes.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            child.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1196,7 +1196,7 @@ namespace Soulseek.Tests.Unit.Network
             }
 
             var expectedBytes = new DistributedChildDepth(0).ToByteArray();
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedBytes)), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1232,7 +1232,7 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.State)
                 .Returns(SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException(expectedEx));
 
             var conn = GetMessageConnectionMock("foo", null);
@@ -1259,7 +1259,7 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.State)
                 .Returns(SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException(expectedEx))
                 .Callback(() => mocks.Client.Setup(m => m.State).Returns(SoulseekClientStates.Disconnected));
 
@@ -1729,7 +1729,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var peerInit = new PeerInit(localUser, Constants.ConnectionType.Distributed, token).ToByteArray();
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(peerInit)), It.IsAny<CancellationToken>()));
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(peerInit)), It.IsAny<CancellationToken>()));
         }
 
         [Trait("Category", "GetParentCandidateConnectionAsync")]
@@ -2238,7 +2238,7 @@ namespace Soulseek.Tests.Unit.Network
             }
 
             mocks.Diagnostic.Verify(m => m.Warning("Failed to connect to any of the available parent candidates", It.IsAny<Exception>()), Times.Once);
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()));
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "AddParentConnectionAsync")]

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -241,8 +241,8 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.BroadcastMessageAsync(bytes, CancellationToken.None);
             }
 
-            c1.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
-            c2.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c1.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c2.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(bytes)), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "BroadcastMessageAsync")]
@@ -253,7 +253,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var c1 = new Mock<IMessageConnection>();
             var c2 = new Mock<IMessageConnection>();
-            c2.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            c2.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(new Exception("foo"));
 
             var dict = manager.GetProperty<ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>>("ChildConnectionDictionary");
@@ -265,9 +265,9 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.BroadcastMessageAsync(bytes, CancellationToken.None);
             }
 
-            c1.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c1.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(bytes)), It.IsAny<CancellationToken?>()));
 
-            c2.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes)), It.IsAny<CancellationToken?>()));
+            c2.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(bytes)), It.IsAny<CancellationToken?>()));
             c2.Verify(m => m.Dispose(), Times.AtLeastOnce);
         }
 
@@ -400,7 +400,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.AddChildConnectionAsync(ctpr);
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -599,7 +599,7 @@ namespace Soulseek.Tests.Unit.Network
             expected.AddRange(new DistributedBranchLevel(manager.BranchLevel + 1).ToByteArray());
             expected.AddRange(new DistributedBranchRoot(manager.BranchRoot).ToByteArray());
 
-            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -710,7 +710,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             mocks.ConnectionFactory.Setup(m => m.GetMessageConnection(username, endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
@@ -741,7 +741,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             mocks.ConnectionFactory.Setup(m => m.GetMessageConnection(username, endpoint, It.IsAny<ConnectionOptions>(), It.IsAny<ITcpClient>()))
@@ -780,7 +780,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.AddChildConnectionAsync(username, GetMessageConnectionMock(username, endpoint).Object);
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -951,7 +951,7 @@ namespace Soulseek.Tests.Unit.Network
             expected.AddRange(new DistributedBranchLevel(manager.BranchLevel + 1).ToByteArray());
             expected.AddRange(new DistributedBranchRoot(manager.BranchRoot).ToByteArray());
 
-            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(expected.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "AddChildConnectionAsync")]
@@ -1025,7 +1025,7 @@ namespace Soulseek.Tests.Unit.Network
             var (manager, mocks) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(new Exception("foo"));
 
             mocks.Client.Setup(m => m.State)
@@ -1115,7 +1115,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.InvokeMethod<Task>("UpdateStatusAsync");
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1139,7 +1139,7 @@ namespace Soulseek.Tests.Unit.Network
                 await manager.InvokeMethod<Task>("UpdateStatusAsync");
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(expectedPayload)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1173,7 +1173,7 @@ namespace Soulseek.Tests.Unit.Network
             bytes.AddRange(new DistributedBranchLevel(manager.BranchLevel + 1).ToByteArray());
             bytes.AddRange(new DistributedBranchRoot(manager.BranchRoot).ToByteArray());
 
-            child.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(bytes.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
+            child.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(bytes.ToArray())), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "UpdateStatusAsync")]
@@ -1232,7 +1232,7 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.State)
                 .Returns(SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException(expectedEx));
 
             var conn = GetMessageConnectionMock("foo", null);
@@ -1259,7 +1259,7 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Client.Setup(m => m.State)
                 .Returns(SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            mocks.ServerConnection.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromException(expectedEx))
                 .Callback(() => mocks.Client.Setup(m => m.State).Returns(SoulseekClientStates.Disconnected));
 

--- a/tests/Soulseek.Tests.Unit/Network/MessageConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/MessageConnectionTests.cs
@@ -152,15 +152,15 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "WriteAsync bytes throws InvalidOperationException when disconnected"), AutoData]
         public async Task WriteAsync_Bytes_Throws_InvalidOperationException_When_Disconnected(string username, IPEndPoint endpoint)
         {
-            var msg = new MessageBuilder()
-                .WriteCode(MessageCode.Peer.BrowseRequest)
-                .Build();
+            var msg = new BrowseRequest().ToByteArray();
 
             using (var c = new MessageConnection(username, endpoint))
             {
                 c.SetProperty("State", ConnectionState.Disconnected);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -226,15 +226,15 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "WriteAsync bytes throws InvalidOperationException when disconnected"), AutoData]
         public async Task WriteAsync_Bytes_Throws_InvalidOperationException_When_Disconnecting(string username, IPEndPoint endpoint)
         {
-            var msg = new MessageBuilder()
-                .WriteCode(MessageCode.Peer.BrowseRequest)
-                .Build();
+            var msg = new BrowseRequest().ToByteArray();
 
             using (var c = new MessageConnection(username, endpoint))
             {
                 c.SetProperty("State", ConnectionState.Disconnecting);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -274,13 +274,13 @@ namespace Soulseek.Tests.Unit.Network
                 tcpMock.Setup(s => s.Connected).Returns(true);
                 tcpMock.Setup(s => s.GetStream()).Returns(streamMock.Object);
 
-                var msg = new MessageBuilder()
-                    .WriteCode(MessageCode.Peer.BrowseRequest)
-                    .Build();
+                var msg = new BrowseRequest().ToByteArray();
 
                 using (var c = new MessageConnection(username, endpoint, tcpClient: tcpMock.Object))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     await c.WriteAsync(msg);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     streamMock.Verify(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
                 }
@@ -391,13 +391,13 @@ namespace Soulseek.Tests.Unit.Network
                 tcpMock.Setup(s => s.Connected).Returns(true);
                 tcpMock.Setup(s => s.GetStream()).Returns(streamMock.Object);
 
-                var msg = new MessageBuilder()
-                    .WriteCode(MessageCode.Peer.BrowseRequest)
-                    .Build();
+                var msg = new BrowseRequest().ToByteArray();
 
                 using (var c = new MessageConnection(endpoint, tcpClient: tcpMock.Object))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionWriteException>(ex);

--- a/tests/Soulseek.Tests.Unit/Network/MessageConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/MessageConnectionTests.cs
@@ -158,9 +158,7 @@ namespace Soulseek.Tests.Unit.Network
             {
                 c.SetProperty("State", ConnectionState.Disconnected);
 
-#pragma warning disable CS0618 // Type or member is obsolete
                 var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -232,9 +230,7 @@ namespace Soulseek.Tests.Unit.Network
             {
                 c.SetProperty("State", ConnectionState.Disconnecting);
 
-#pragma warning disable CS0618 // Type or member is obsolete
                 var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -278,9 +274,7 @@ namespace Soulseek.Tests.Unit.Network
 
                 using (var c = new MessageConnection(username, endpoint, tcpClient: tcpMock.Object))
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
                     await c.WriteAsync(msg);
-#pragma warning restore CS0618 // Type or member is obsolete
 
                     streamMock.Verify(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
                 }
@@ -395,9 +389,7 @@ namespace Soulseek.Tests.Unit.Network
 
                 using (var c = new MessageConnection(endpoint, tcpClient: tcpMock.Object))
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
                     var ex = await Record.ExceptionAsync(() => c.WriteAsync(msg));
-#pragma warning restore CS0618 // Type or member is obsolete
 
                     Assert.NotNull(ex);
                     Assert.IsType<ConnectionWriteException>(ex);

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -857,7 +857,7 @@ namespace Soulseek.Tests.Unit.Network
                 Assert.Equal(conn.Object, newConn);
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => true), CancellationToken.None));
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(b => true), CancellationToken.None));
         }
 
         [Trait("Category", "GetTransferConnectionOutboundIndirectAsync")]
@@ -1548,7 +1548,7 @@ namespace Soulseek.Tests.Unit.Network
                 Assert.Equal(msgConn.Object, newConn);
             }
 
-            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<byte[]>(b => true), CancellationToken.None));
+            mocks.ServerConnection.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(b => true), CancellationToken.None));
         }
 
         [Trait("Category", "GetMessageConnectionOutboundIndirectAsync")]
@@ -1764,7 +1764,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -1796,7 +1796,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -1851,7 +1851,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             var (manager, mocks) = GetFixture();
@@ -1881,7 +1881,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -1894,7 +1894,7 @@ namespace Soulseek.Tests.Unit.Network
                 (await manager.GetOrAddMessageConnectionAsync(ctpr)).Dispose();
             }
 
-            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(expectedMessage)), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedMessage)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "GetOrAddMessageConnectionAsync")]
@@ -1906,7 +1906,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -2010,7 +2010,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -2069,7 +2069,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -2374,7 +2374,7 @@ namespace Soulseek.Tests.Unit.Network
                 .Returns(ConnectionTypes.Direct);
             direct.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            direct.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            direct.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(new ConnectionException());
 
             var (manager, mocks) = GetFixture();
@@ -2412,7 +2412,7 @@ namespace Soulseek.Tests.Unit.Network
                 .Returns(ConnectionTypes.Direct);
             direct.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            direct.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
+            direct.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
                 .Throws(exception);
 
             var (manager, mocks) = GetFixture();
@@ -2574,7 +2574,7 @@ namespace Soulseek.Tests.Unit.Network
                 Assert.Equal(direct.Object, newConn);
                 Assert.Equal(ConnectionTypes.Direct, newConn.Type);
 
-                direct.Verify(m => m.WriteAsync(It.Is<byte[]>(b => b.Matches(peerInit)), It.IsAny<CancellationToken?>()), Times.Once);
+                direct.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(peerInit)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 


### PR DESCRIPTION
Closes #411

Ended up removing the deprecation on the `WriteAsync(byte[])` overload, as it is necessary in a few cases.