### PR TITLE
Remove redundant count parameters in constructors accepting collections

### DIFF
--- a/src/EventArgs/RoomTickerListReceivedEventArgs.cs
+++ b/src/EventArgs/RoomTickerListReceivedEventArgs.cs
@@ -29,8 +29,8 @@ namespace Soulseek
         public RoomTickerListReceivedEventArgs(string roomName, IEnumerable<RoomTicker> tickers)
             : base(roomName)
         {
-            TickerCount = tickers.Count();
-            Tickers = tickers.ToList().AsReadOnly();
+            Tickers = (tickers?.ToList() ?? Enumerable.Empty<RoomTicker>()).ToList().AsReadOnly();
+            TickerCount = Tickers.Count;
         }
 
         /// <summary>

--- a/src/File.cs
+++ b/src/File.cs
@@ -27,17 +27,16 @@ namespace Soulseek
         /// <param name="filename">The file name.</param>
         /// <param name="size">The file size in bytes.</param>
         /// <param name="extension">The file extension.</param>
-        /// <param name="attributeCount">The number of file <see cref="FileAttribute"/> s.</param>
         /// <param name="attributeList">The optional list of <see cref="FileAttribute"/> s.</param>
-        public File(int code, string filename, long size, string extension, int attributeCount, IEnumerable<FileAttribute> attributeList = null)
+        public File(int code, string filename, long size, string extension, IEnumerable<FileAttribute> attributeList = null)
         {
             Code = code;
             Filename = filename;
             Size = size;
             Extension = extension;
-            AttributeCount = attributeCount;
 
             AttributeList = attributeList ?? Enumerable.Empty<FileAttribute>();
+            AttributeCount = AttributeList.Count();
         }
 
         /// <summary>

--- a/src/Messaging/MessageReaderExtensions.cs
+++ b/src/Messaging/MessageReaderExtensions.cs
@@ -33,12 +33,12 @@ namespace Soulseek.Messaging
                 code: reader.ReadByte(),
                 filename: reader.ReadString(),
                 size: reader.ReadLong(),
-                extension: reader.ReadString(),
-                attributeCount: reader.ReadInteger());
+                extension: reader.ReadString());
 
+            var attributeCount = reader.ReadInteger();
             var attributeList = new List<FileAttribute>();
 
-            for (int i = 0; i < file.AttributeCount; i++)
+            for (int i = 0; i < attributeCount; i++)
             {
                 var attribute = new FileAttribute(
                     type: (FileAttributeType)reader.ReadInteger(),
@@ -52,7 +52,6 @@ namespace Soulseek.Messaging
                 filename: file.Filename,
                 size: file.Size,
                 extension: file.Extension,
-                attributeCount: file.AttributeCount,
                 attributeList: attributeList);
         }
 

--- a/src/Messaging/Messages/Server/JoinRoomResponse.cs
+++ b/src/Messaging/Messages/Server/JoinRoomResponse.cs
@@ -110,7 +110,7 @@ namespace Soulseek.Messaging.Messages
                 }
             }
 
-            return new RoomData(roomName, userCount, users, owner != null, owner, operatorCount, operatorList);
+            return new RoomData(roomName, users, owner != null, owner, operatorList);
         }
     }
 }

--- a/src/Messaging/Messages/Server/PrivateRoomOwnedListNotification.cs
+++ b/src/Messaging/Messages/Server/PrivateRoomOwnedListNotification.cs
@@ -44,7 +44,7 @@ namespace Soulseek.Messaging.Messages
                 userList.Add(reader.ReadString());
             }
 
-            return new RoomInfo(roomName, userCount, userList);
+            return new RoomInfo(roomName, userList);
         }
     }
 }

--- a/src/Messaging/Messages/Server/PrivateRoomUserListNotification.cs
+++ b/src/Messaging/Messages/Server/PrivateRoomUserListNotification.cs
@@ -44,7 +44,7 @@ namespace Soulseek.Messaging.Messages
                 userList.Add(reader.ReadString());
             }
 
-            return new RoomInfo(roomName, userCount, userList);
+            return new RoomInfo(roomName, userList);
         }
     }
 }

--- a/src/RoomData.cs
+++ b/src/RoomData.cs
@@ -24,21 +24,19 @@ namespace Soulseek
         ///     Initializes a new instance of the <see cref="RoomData"/> class.
         /// </summary>
         /// <param name="name">The name of the room that was joined.</param>
-        /// <param name="userCount">The number of users in the room.</param>
         /// <param name="userList">The users in the room.</param>
         /// <param name="isPrivate">A value indicating whether the room is private.</param>
         /// <param name="owner">The owner of the room, if private.</param>
-        /// <param name="operatorCount">The number of operators in the room, if private.</param>
         /// <param name="operatorList">The operators in the room, if private.</param>
-        public RoomData(string name, int userCount, IEnumerable<UserData> userList, bool isPrivate = false, string owner = null, int? operatorCount = null, IEnumerable<string> operatorList = null)
+        public RoomData(string name, IEnumerable<UserData> userList, bool isPrivate = false, string owner = null, IEnumerable<string> operatorList = null)
         {
             Name = name;
-            UserCount = userCount;
             UserList = userList ?? Enumerable.Empty<UserData>();
+            UserCount = UserList.Count();
             IsPrivate = isPrivate;
             Owner = owner;
-            OperatorCount = operatorCount;
-            OperatorList = operatorList ?? Enumerable.Empty<string>();
+            OperatorList = operatorList;
+            OperatorCount = OperatorList?.Count();
         }
 
         /// <summary>
@@ -59,7 +57,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the operators in the room, if private.
         /// </summary>
-        public IReadOnlyCollection<string> Operators => OperatorList.ToList().AsReadOnly();
+        public IReadOnlyCollection<string> Operators => OperatorList?.ToList().AsReadOnly();
 
         /// <summary>
         ///     Gets the owner of the room, if private.

--- a/src/RoomInfo.cs
+++ b/src/RoomInfo.cs
@@ -28,6 +28,7 @@ namespace Soulseek
         public RoomInfo(string name, int userCount)
         {
             Name = name;
+            UserList = Enumerable.Empty<string>();
             UserCount = userCount;
         }
 

--- a/src/RoomInfo.cs
+++ b/src/RoomInfo.cs
@@ -25,12 +25,22 @@ namespace Soulseek
         /// </summary>
         /// <param name="name">The room name.</param>
         /// <param name="userCount">The number of users in the room.</param>
-        /// <param name="userList">The users in the room, if available.</param>
-        public RoomInfo(string name, int userCount, IEnumerable<string> userList = null)
+        public RoomInfo(string name, int userCount)
         {
             Name = name;
             UserCount = userCount;
-            UserList = userList;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RoomInfo"/> class.
+        /// </summary>
+        /// <param name="name">The room name.</param>
+        /// <param name="userList">The users in the room, if available.</param>
+        public RoomInfo(string name, IEnumerable<string> userList)
+        {
+            Name = name;
+            UserList = userList ?? Enumerable.Empty<string>();
+            UserCount = UserList.Count();
         }
 
         /// <summary>

--- a/src/RoomInfo.cs
+++ b/src/RoomInfo.cs
@@ -57,7 +57,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the users in the room, if available.
         /// </summary>
-        public IReadOnlyCollection<string> Users => UserList?.ToList().AsReadOnly();
+        public IReadOnlyCollection<string> Users => UserList.ToList().AsReadOnly();
 
         private IEnumerable<string> UserList { get; }
     }

--- a/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/JoinLeaveRoomAsyncTests.cs
@@ -80,7 +80,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            var expectedResponse = new RoomData(roomName, 0, Enumerable.Empty<UserData>(), false, null, null, null);
+            var expectedResponse = new RoomData(roomName, Enumerable.Empty<UserData>(), false, null, null);
 
             var key = new WaitKey(MessageCode.Server.JoinRoom, roomName);
             var waiter = new Mock<IWaiter>();
@@ -109,7 +109,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
-            var expectedResponse = new RoomData(roomName, 0, Enumerable.Empty<UserData>(), false, null, null, null);
+            var expectedResponse = new RoomData(roomName, Enumerable.Empty<UserData>(), false, null, null);
 
             var key = new WaitKey(MessageCode.Server.JoinRoom, roomName);
             var waiter = new Mock<IWaiter>();

--- a/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
@@ -684,7 +684,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             var fired = false;
             var options = new SearchOptions(searchTimeout: 1000, fileLimit: 1, responseReceived: (e) => fired = true);
-            var response = new SearchResponse("username", token, 1, 1, 1, new List<File>() { new File(1, "foo", 1, "bar", 0) });
+            var response = new SearchResponse("username", token, 1, 1, 1, new List<File>() { new File(1, "foo", 1, "bar") });
 
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
@@ -714,7 +714,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             var fired = false;
             var options = new SearchOptions(searchTimeout: 1000, fileLimit: 1);
-            var response = new SearchResponse("username", token, 1, 1, 1, new List<File>() { new File(1, "foo", 1, "bar", 0) });
+            var response = new SearchResponse("username", token, 1, 1, 1, new List<File>() { new File(1, "foo", 1, "bar") });
 
             var conn = new Mock<IMessageConnection>();
             conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))

--- a/tests/Soulseek.Tests.Unit/Diagnostics/DirectoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Diagnostics/DirectoryTests.cs
@@ -43,7 +43,7 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "Instantiates with given File list given list"), AutoData]
         public void Instantiates_With_Given_File_List_Given_List(string directoryname, int fileCount)
         {
-            var files = new List<File>() { new File(1, "a", 2, "b", 0) };
+            var files = new List<File>() { new File(1, "a", 2, "b") };
 
             var d = new Directory(directoryname, fileCount, files);
 

--- a/tests/Soulseek.Tests.Unit/EventArgs/RoomTickerEventArgs.cs
+++ b/tests/Soulseek.Tests.Unit/EventArgs/RoomTickerEventArgs.cs
@@ -56,6 +56,18 @@ namespace Soulseek.Tests.Unit
 
         [Trait("Category", "Instantiation")]
         [Trait("Class", "RoomTickerListReceivedEventArgs")]
+        [Theory(DisplayName = "Instantiates with expected values given null tickers"), AutoData]
+        public void RoomTickerListReceivedEventArgs_Instantiates_With_Expected_Values_Given_Null_Tickers(string roomName)
+        {
+            var x = new RoomTickerListReceivedEventArgs(roomName, null);
+
+            Assert.Equal(roomName, x.RoomName);
+            Assert.Equal(0, x.TickerCount);
+            Assert.Empty(x.Tickers);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Trait("Class", "RoomTickerListReceivedEventArgs")]
         [Theory(DisplayName = "Instantiates with expected values"), AutoData]
         public void RoomTickerListReceivedEventArgs_Instantiates_With_FromNotification(string roomName, IEnumerable<RoomTicker> tickers)
         {

--- a/tests/Soulseek.Tests.Unit/FileTests.cs
+++ b/tests/Soulseek.Tests.Unit/FileTests.cs
@@ -21,11 +21,11 @@ namespace Soulseek.Tests.Unit
     {
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName ="Instantiates with the given data"), AutoData]
-        public void Instantiates_With_The_Given_Data(int code, string filename, long size, string extension, int attributeCount, List<FileAttribute> attributeList)
+        public void Instantiates_With_The_Given_Data(int code, string filename, long size, string extension, List<FileAttribute> attributeList)
         {
             var f = default(File);
 
-            var ex = Record.Exception(() => f = new File(code, filename, size, extension, attributeCount, attributeList));
+            var ex = Record.Exception(() => f = new File(code, filename, size, extension, attributeList));
 
             Assert.Null(ex);
 
@@ -33,17 +33,17 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(filename, f.Filename);
             Assert.Equal(size, f.Size);
             Assert.Equal(extension, f.Extension);
-            Assert.Equal(attributeCount, f.AttributeCount);
+            Assert.Equal(attributeList.Count, f.AttributeCount);
             Assert.Equal(attributeList, f.Attributes);
         }
 
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with empty Attributes given no attributeList"), AutoData]
-        public void Instantiates_With_Empty_Attributes_Given_No_AttributeList(int code, string filename, long size, string extension, int attributeCount)
+        public void Instantiates_With_Empty_Attributes_Given_No_AttributeList(int code, string filename, long size, string extension)
         {
             var f = default(File);
 
-            var ex = Record.Exception(() => f = new File(code, filename, size, extension, attributeCount));
+            var ex = Record.Exception(() => f = new File(code, filename, size, extension));
 
             Assert.Null(ex);
 
@@ -57,7 +57,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, value) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Equal(list[0], f.Attributes.ToList()[0]);
             Assert.Equal(value, f.BitDepth);
@@ -67,7 +67,7 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "BitDepth attribute returns null when no value"), AutoData]
         public void BitDepth_Attribute_Returns_Null_When_No_Value(int code, string filename, long size, string extension)
         {
-            var f = new File(code, filename, size, extension, 0);
+            var f = new File(code, filename, size, extension);
 
             Assert.Empty(f.Attributes);
             Assert.Null(f.BitDepth);
@@ -79,7 +79,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, value) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Equal(list[0], f.Attributes.ToList()[0]);
             Assert.Equal(value, f.BitRate);
@@ -89,7 +89,7 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "BitRate attribute returns null when no value"), AutoData]
         public void BitRate_Attribute_Returns_Null_When_No_Value(int code, string filename, long size, string extension)
         {
-            var f = new File(code, filename, size, extension, 0);
+            var f = new File(code, filename, size, extension);
 
             Assert.Empty(f.Attributes);
             Assert.Null(f.BitRate);
@@ -101,7 +101,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(FileAttributeType.SampleRate, value) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Equal(list[0], f.Attributes.ToList()[0]);
             Assert.Equal(value, f.SampleRate);
@@ -111,7 +111,7 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "SampleRate attribute returns null when no value"), AutoData]
         public void SampleRate_Attribute_Returns_Null_When_No_Value(int code, string filename, long size, string extension)
         {
-            var f = new File(code, filename, size, extension, 0);
+            var f = new File(code, filename, size, extension);
 
             Assert.Empty(f.Attributes);
             Assert.Null(f.SampleRate);
@@ -123,7 +123,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(FileAttributeType.Length, value) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Equal(list[0], f.Attributes.ToList()[0]);
             Assert.Equal(value, f.Length);
@@ -133,7 +133,7 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "Length attribute returns null when no value"), AutoData]
         public void Length_Attribute_Returns_Null_When_No_Value(int code, string filename, long size, string extension)
         {
-            var f = new File(code, filename, size, extension, 0);
+            var f = new File(code, filename, size, extension);
 
             Assert.Empty(f.Attributes);
             Assert.Null(f.Length);
@@ -145,7 +145,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Null(f.GetAttributeValue(FileAttributeType.BitDepth));
         }
@@ -156,7 +156,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(type, value) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Equal(value, f.GetAttributeValue(type));
         }
@@ -167,7 +167,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(FileAttributeType.VariableBitRate, 1) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.True(f.IsVariableBitRate);
         }
@@ -178,7 +178,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { new FileAttribute(FileAttributeType.VariableBitRate, 0) };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.False(f.IsVariableBitRate);
         }
@@ -189,7 +189,7 @@ namespace Soulseek.Tests.Unit
         {
             var list = new List<FileAttribute>() { };
 
-            var f = new File(code, filename, size, extension, 1, list);
+            var f = new File(code, filename, size, extension, list);
 
             Assert.Null(f.IsVariableBitRate);
         }

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
@@ -311,7 +311,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Responds to SearchRequest"), AutoData]
         public void Responds_To_SearchRequest(string username, int token, string query)
         {
-            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1", 0) });
+            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1") });
             var options = new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult(response));
             var (handler, mocks) = GetFixture(options);
 
@@ -341,7 +341,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Deduplicates SearchRequest when deduplicate option is set"), AutoData]
         public void Deduplicates_SearchRequest_When_Deduplicate_Option_Is_Set(string username, int token, string query)
         {
-            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1", 0) });
+            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1") });
             var options = new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult(response), deduplicateSearchRequests: true);
             var (handler, mocks) = GetFixture(options);
 
@@ -368,7 +368,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not deduplicate SearchRequest when deduplicate option is unset"), AutoData]
         public void Does_Not_Deduplicate_SearchRequest_When_Deduplicate_Option_Is_Unset(string username, int token, string query)
         {
-            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1", 0) });
+            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1") });
             var options = new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult(response), deduplicateSearchRequests: false);
             var (handler, mocks) = GetFixture(options);
 
@@ -396,7 +396,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Generates diagnostic on failure to send search results"), AutoData]
         public void Generates_Diagnostic_On_Failure_To_Send_Search_Results(string username, int token, string query)
         {
-            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1", 0) });
+            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1") });
             var options = new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult(response));
             var (handler, mocks) = GetFixture(options);
 
@@ -423,7 +423,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Responds to ServerSearchRequest"), AutoData]
         public void Responds_To_ServerSearchRequest(string username, int token, string query)
         {
-            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1", 0) });
+            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1") });
             var options = new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult(response));
             var (handler, mocks) = GetFixture(options);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -464,8 +464,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         {
             var files = new List<File>()
             {
-                new File(1, "1", 1, "1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
-                new File(2, "2", 2, "2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(1, "1", 1, "1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(2, "2", 2, "2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             IEnumerable<Directory> dirs = new List<Directory>()
@@ -512,8 +512,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         {
             var files = new List<File>()
             {
-                new File(1, "1", 1, "1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
-                new File(2, "2", 2, "2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(1, "1", 1, "1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(2, "2", 2, "2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             var dir = new Directory(dirname, 2, files);

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -1636,7 +1636,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Responds to SearchRequest"), AutoData]
         public void Responds_To_SearchRequest(string username, int token, string query)
         {
-            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1", 0) });
+            var response = new SearchResponse("foo", token, 1, 1, 1, new List<File>() { new File(1, "1", 1, "1") });
             var options = new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult(response));
             var (handler, mocks) = GetFixture(options);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/BrowseResponseFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/BrowseResponseFactoryTests.cs
@@ -348,8 +348,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         {
             var list = new List<File>()
             {
-                new File(1, "1", 1, ".1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
-                new File(2, "2", 2, ".2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(1, "1", 1, ".1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             var dirs = new List<Directory>()
@@ -399,8 +399,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         {
             var list = new List<File>()
             {
-                new File(1, "1", 1, ".1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
-                new File(2, "2", 2, ".2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(1, "1", 1, ".1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             var dirs = new List<Directory>()
@@ -492,7 +492,6 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 filename: Guid.NewGuid().ToString(),
                 size: Random.Next(),
                 extension: Guid.NewGuid().ToString(),
-                attributeCount: attributeCount,
                 attributeList: attributeList);
         }
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
@@ -212,8 +212,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         {
             var list = new List<File>()
             {
-                new File(1, "1", 1, ".1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
-                new File(2, "2", 2, ".2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(1, "1", 1, ".1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             var dir = new Directory(dirname, 2, list);
@@ -291,7 +291,6 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 filename: Guid.NewGuid().ToString(),
                 size: Random.Next(),
                 extension: Guid.NewGuid().ToString(),
-                attributeCount: attributeCount,
                 attributeList: attributeList);
         }
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/SearchResponseFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/SearchResponseFactoryTests.cs
@@ -422,8 +422,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         {
             var list = new List<File>()
             {
-                new File(1, "1", 1, ".1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
-                new File(2, "2", 2, ".2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(1, "1", 1, ".1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             var s = new SearchResponse(username, token, freeUploadSlots, uploadSpeed, queueLength, list);
@@ -466,12 +466,12 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         {
             var list = new List<File>()
             {
-                new File(1, "1", 1, ".1", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
+                new File(1, "1", 1, ".1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
             };
 
             var locked = new List<File>()
             {
-                new File(2, "2", 2, ".2", 1, new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
+                new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
             var s = new SearchResponse(username, token, freeUploadSlots, uploadSpeed, queueLength, list, locked);

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/PrivateRoomOwnedListNotificationTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/PrivateRoomOwnedListNotificationTests.cs
@@ -12,6 +12,7 @@
 
 namespace Soulseek.Tests.Unit.Messaging.Messages
 {
+    using System.Collections.Generic;
     using System.Linq;
     using AutoFixture.Xunit2;
     using Soulseek.Messaging;
@@ -51,20 +52,20 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "Parse")]
         [Theory(DisplayName = "Parse returns expected data"), AutoData]
-        public void Parse_Returns_Expected_Data(RoomInfo room)
+        public void Parse_Returns_Expected_Data(string roomName, List<string> users)
         {
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOwned);
 
-            builder.WriteString(room.Name);
-            builder.WriteInteger(room.Users.Count);
-            room.Users.ToList().ForEach(user => builder.WriteString(user));
+            builder.WriteString(roomName);
+            builder.WriteInteger(users.Count);
+            users.ToList().ForEach(user => builder.WriteString(user));
 
             var response = PrivateRoomOwnedListNotification.FromByteArray(builder.Build());
 
-            Assert.Equal(room.Users.Count, response.UserCount);
+            Assert.Equal(users.Count, response.UserCount);
 
-            foreach (var user in room.Users)
+            foreach (var user in users)
             {
                 Assert.Contains(response.Users, u => u == user);
             }

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/PrivateRoomUserListNotificationTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/PrivateRoomUserListNotificationTests.cs
@@ -12,6 +12,7 @@
 
 namespace Soulseek.Tests.Unit.Messaging.Messages
 {
+    using System.Collections.Generic;
     using System.Linq;
     using AutoFixture.Xunit2;
     using Soulseek.Messaging;
@@ -51,20 +52,20 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "Parse")]
         [Theory(DisplayName = "Parse returns expected data"), AutoData]
-        public void Parse_Returns_Expected_Data(RoomInfo room)
+        public void Parse_Returns_Expected_Data(string roomName, List<string> users)
         {
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomUsers);
 
-            builder.WriteString(room.Name);
-            builder.WriteInteger(room.Users.Count);
-            room.Users.ToList().ForEach(user => builder.WriteString(user));
+            builder.WriteString(roomName);
+            builder.WriteInteger(users.Count);
+            users.ToList().ForEach(user => builder.WriteString(user));
 
             var response = PrivateRoomUserListNotification.FromByteArray(builder.Build());
 
-            Assert.Equal(room.Users.Count, response.UserCount);
+            Assert.Equal(users.Count, response.UserCount);
 
-            foreach (var user in room.Users)
+            foreach (var user in users)
             {
                 Assert.Contains(response.Users, u => u == user);
             }

--- a/tests/Soulseek.Tests.Unit/RoomDataTests.cs
+++ b/tests/Soulseek.Tests.Unit/RoomDataTests.cs
@@ -21,18 +21,19 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "RoomData uses empty list if one is omitted"), AutoData]
         public void RoomData_Users_Uses_Empty_List_If_One_Is_Omitted(string roomName)
         {
-            var data = new RoomData(roomName, 0, null, false, null, null, null);
+            var data = new RoomData(roomName, null, false, null, null);
 
             Assert.NotNull(data.Users);
         }
 
         [Trait("Category", "RoomData")]
-        [Theory(DisplayName = "RoomData uses empty list if one is omitted"), AutoData]
-        public void RoomData_Operators_Uses_Empty_List_If_One_Is_Omitted(string roomName)
+        [Theory(DisplayName = "RoomData uses null list if one is omitted"), AutoData]
+        public void RoomData_Operators_Uses_Null_List_If_One_Is_Omitted(string roomName)
         {
-            var data = new RoomData(roomName, 0, null, false, null, null, null);
+            var data = new RoomData(roomName, null, false, null, null);
 
-            Assert.NotNull(data.Operators);
+            Assert.Null(data.Operators);
+            Assert.Null(data.OperatorCount);
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/RoomInfoTests.cs
+++ b/tests/Soulseek.Tests.Unit/RoomInfoTests.cs
@@ -30,14 +30,25 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "RoomInfo")]
-        [Theory(DisplayName = "RoomInfo instantiates with null user list if none is given"), AutoData]
-        public void RoomInfo_Instantiates_With_Null_User_List_If_Not_Given(string roomName, int count)
+        [Theory(DisplayName = "RoomInfo instantiates properly with count only"), AutoData]
+        public void RoomInfo_Instantiates_Properly_With_Count_Only(string roomName, int count)
         {
             var info = new RoomInfo(roomName, count);
 
             Assert.Equal(roomName, info.Name);
             Assert.Equal(count, info.UserCount);
-            Assert.Null(info.Users);
+            Assert.Empty(info.Users);
+        }
+
+        [Trait("Category", "RoomInfo")]
+        [Theory(DisplayName = "RoomInfo instantiates with null user list if none is given"), AutoData]
+        public void RoomInfo_Instantiates_With_Null_User_List_If_Not_Given(string roomName)
+        {
+            var info = new RoomInfo(roomName, userList: null);
+
+            Assert.Equal(roomName, info.Name);
+            Assert.Equal(0, info.UserCount);
+            Assert.Empty(info.Users);
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/RoomInfoTests.cs
+++ b/tests/Soulseek.Tests.Unit/RoomInfoTests.cs
@@ -20,12 +20,12 @@ namespace Soulseek.Tests.Unit
     {
         [Trait("Category", "RoomInfo")]
         [Theory(DisplayName = "RoomInfo instantiates properly"), AutoData]
-        public void RoomInfo_Instantiates_Properly(string roomName, int count, List<string> users)
+        public void RoomInfo_Instantiates_Properly(string roomName, List<string> users)
         {
-            var info = new RoomInfo(roomName, count, users);
+            var info = new RoomInfo(roomName, users);
 
             Assert.Equal(roomName, info.Name);
-            Assert.Equal(count, info.UserCount);
+            Assert.Equal(users.Count, info.UserCount);
             Assert.Equal(users, info.Users);
         }
 

--- a/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
@@ -253,7 +253,7 @@ namespace Soulseek.Tests.Unit
                 State = SearchStates.InProgress,
             };
 
-            s.TryAddResponse(new SearchResponse("bar", 42, 1, 1, 1, new List<File>() { new File(1, "a", 1, "b", 0) }));
+            s.TryAddResponse(new SearchResponse("bar", 42, 1, 1, 1, new List<File>() { new File(1, "a", 1, "b") }));
 
             var invoked = false;
             s.ResponseReceived = (r) => invoked = true;
@@ -274,7 +274,7 @@ namespace Soulseek.Tests.Unit
                 State = SearchStates.InProgress,
             };
 
-            s.TryAddResponse(new SearchResponse("bar", 42, 1, 1, 1, null, lockedFileList: new List<File>() { new File(1, "a", 1, "b", 0) }));
+            s.TryAddResponse(new SearchResponse("bar", 42, 1, 1, 1, null, lockedFileList: new List<File>() { new File(1, "a", 1, "b") }));
 
             var invoked = false;
             s.ResponseReceived = (r) => invoked = true;

--- a/tests/Soulseek.Tests.Unit/SearchResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponseTests.cs
@@ -59,7 +59,7 @@ namespace Soulseek.Tests.Unit
         {
             var r1 = new SearchResponse(username, token, freeUploadSlots, uploadSpeed, queueLength, null);
 
-            var r2 = new SearchResponse(r1, new List<File>() { new File(1, "foo", 2, "ext", 0) });
+            var r2 = new SearchResponse(r1, new List<File>() { new File(1, "foo", 2, "ext") });
 
             Assert.Empty(r1.Files);
             Assert.Single(r2.Files);


### PR DESCRIPTION
The protocol separates these two because it needs to.  This is represented in Message classes, but isn't useful in public types, as it may lead to counts that don't agree with the contents of the corresponding lists.