### PR TITLE
Copy collections when instantiating public types

### DIFF
--- a/src/BrowseResponse.cs
+++ b/src/BrowseResponse.cs
@@ -27,17 +27,17 @@ namespace Soulseek
         /// <param name="lockedDirectoryList">The optional locked directory list.</param>
         public BrowseResponse(IEnumerable<Directory> directoryList = null, IEnumerable<Directory> lockedDirectoryList = null)
         {
-            DirectoryList = directoryList ?? Enumerable.Empty<Directory>();
-            DirectoryCount = DirectoryList.Count();
+            Directories = (directoryList?.ToList() ?? new List<Directory>()).AsReadOnly();
+            DirectoryCount = Directories.Count;
 
-            LockedDirectoryList = lockedDirectoryList ?? Enumerable.Empty<Directory>();
-            LockedDirectoryCount = LockedDirectoryList.Count();
+            LockedDirectories = (lockedDirectoryList?.ToList() ?? new List<Directory>()).AsReadOnly();
+            LockedDirectoryCount = LockedDirectories.Count;
         }
 
         /// <summary>
         ///     Gets the list of directories.
         /// </summary>
-        public IReadOnlyCollection<Directory> Directories => DirectoryList.ToList().AsReadOnly();
+        public IReadOnlyCollection<Directory> Directories { get; }
 
         /// <summary>
         ///     Gets the number of directories.
@@ -47,14 +47,11 @@ namespace Soulseek
         /// <summary>
         ///     Gets the list of locked directories.
         /// </summary>
-        public IReadOnlyCollection<Directory> LockedDirectories => LockedDirectoryList.ToList().AsReadOnly();
+        public IReadOnlyCollection<Directory> LockedDirectories { get; }
 
         /// <summary>
         ///     Gets the number of locked directories.
         /// </summary>
         public int LockedDirectoryCount { get; }
-
-        private IEnumerable<Directory> DirectoryList { get; }
-        private IEnumerable<Directory> LockedDirectoryList { get; }
     }
 }

--- a/src/Directory.cs
+++ b/src/Directory.cs
@@ -29,22 +29,8 @@ namespace Soulseek
         {
             DirectoryName = directoryName;
 
-            FileList = fileList ?? Enumerable.Empty<File>();
-            FileCount = FileList.Count();
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Directory"/> class.
-        /// </summary>
-        /// <param name="directoryName">The directory name.</param>
-        /// <param name="fileCount">The number of files.</param>
-        /// <param name="fileList">The optional list of <see cref="File"/> s.</param>
-        public Directory(string directoryName, int fileCount, IEnumerable<File> fileList = null)
-        {
-            DirectoryName = directoryName;
-            FileCount = fileCount;
-
-            FileList = fileList ?? Enumerable.Empty<File>();
+            Files = (fileList?.ToList() ?? new List<File>()).AsReadOnly();
+            FileCount = Files.Count;
         }
 
         /// <summary>
@@ -60,11 +46,6 @@ namespace Soulseek
         /// <summary>
         ///     Gets the collection of files contained within the directory.
         /// </summary>
-        public IReadOnlyCollection<File> Files => FileList.ToList().AsReadOnly();
-
-        /// <summary>
-        ///     Gets the list of files contained within the directory.
-        /// </summary>
-        private IEnumerable<File> FileList { get; }
+        public IReadOnlyCollection<File> Files { get; }
     }
 }

--- a/src/EventArgs/RoomTickerListReceivedEventArgs.cs
+++ b/src/EventArgs/RoomTickerListReceivedEventArgs.cs
@@ -29,7 +29,7 @@ namespace Soulseek
         public RoomTickerListReceivedEventArgs(string roomName, IEnumerable<RoomTicker> tickers)
             : base(roomName)
         {
-            Tickers = (tickers?.ToList() ?? Enumerable.Empty<RoomTicker>()).ToList().AsReadOnly();
+            Tickers = (tickers?.ToList() ?? new List<RoomTicker>()).AsReadOnly();
             TickerCount = Tickers.Count;
         }
 

--- a/src/File.cs
+++ b/src/File.cs
@@ -35,8 +35,8 @@ namespace Soulseek
             Size = size;
             Extension = extension;
 
-            AttributeList = attributeList ?? Enumerable.Empty<FileAttribute>();
-            AttributeCount = AttributeList.Count();
+            Attributes = (attributeList?.ToList() ?? new List<FileAttribute>()).AsReadOnly();
+            AttributeCount = Attributes.Count;
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the file attributes.
         /// </summary>
-        public IReadOnlyCollection<FileAttribute> Attributes => AttributeList.ToList().AsReadOnly();
+        public IReadOnlyCollection<FileAttribute> Attributes { get; }
 
         /// <summary>
         ///     Gets the value of the <see cref="FileAttributeType.BitDepth"/> attribute.
@@ -103,18 +103,13 @@ namespace Soulseek
         public long Size { get; }
 
         /// <summary>
-        ///     Gets the internal list of file attributes.
-        /// </summary>
-        private IEnumerable<FileAttribute> AttributeList { get; }
-
-        /// <summary>
         ///     Returns the value of the specified attribute <paramref name="type"/>.
         /// </summary>
         /// <param name="type">The attribute to return.</param>
         /// <returns>The value of the specified attribute.</returns>
         public int? GetAttributeValue(FileAttributeType type)
         {
-            return AttributeList.FirstOrDefault(a => a.Type == type)?.Value;
+            return Attributes.FirstOrDefault(a => a.Type == type)?.Value;
         }
     }
 }

--- a/src/Messaging/MessageReaderExtensions.cs
+++ b/src/Messaging/MessageReaderExtensions.cs
@@ -80,20 +80,18 @@ namespace Soulseek.Messaging
         /// <returns>The directory.</returns>
         internal static Directory ReadDirectory(this MessageReader<MessageCode.Peer> reader)
         {
-            var dir = new Directory(
-                directoryName: reader.ReadString(),
-                fileCount: reader.ReadInteger());
+            var directoryName = reader.ReadString();
+            var fileCount = reader.ReadInteger();
 
             var fileList = new List<File>();
 
-            for (int j = 0; j < dir.FileCount; j++)
+            for (int j = 0; j < fileCount; j++)
             {
                 fileList.Add(reader.ReadFile());
             }
 
             return new Directory(
-                directoryName: dir.DirectoryName,
-                fileCount: dir.FileCount,
+                directoryName: directoryName,
                 fileList: fileList);
         }
     }

--- a/src/Messaging/Messages/Peer/FolderContentsResponse.cs
+++ b/src/Messaging/Messages/Peer/FolderContentsResponse.cs
@@ -61,21 +61,7 @@ namespace Soulseek.Messaging.Messages
             reader.ReadString(); // directory name, should always match that of the first directory
             reader.ReadInteger(); // directory count, should always be 1
 
-            var dir = new Directory(
-                directoryName: reader.ReadString(),
-                fileCount: reader.ReadInteger());
-
-            var fileList = new List<File>();
-
-            for (int j = 0; j < dir.FileCount; j++)
-            {
-                fileList.Add(reader.ReadFile());
-            }
-
-            var directory = new Directory(
-                directoryName: dir.DirectoryName,
-                fileCount: dir.FileCount,
-                fileList: fileList);
+            var directory = reader.ReadDirectory();
 
             return new FolderContentsResponse(token, directory);
         }

--- a/src/RoomData.cs
+++ b/src/RoomData.cs
@@ -31,12 +31,12 @@ namespace Soulseek
         public RoomData(string name, IEnumerable<UserData> userList, bool isPrivate = false, string owner = null, IEnumerable<string> operatorList = null)
         {
             Name = name;
-            UserList = userList ?? Enumerable.Empty<UserData>();
-            UserCount = UserList.Count();
+            Users = (userList?.ToList() ?? new List<UserData>()).AsReadOnly();
+            UserCount = Users.Count;
             IsPrivate = isPrivate;
             Owner = owner;
-            OperatorList = operatorList;
-            OperatorCount = OperatorList?.Count();
+            Operators = operatorList?.ToList().AsReadOnly();
+            OperatorCount = Operators?.Count;
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the operators in the room, if private.
         /// </summary>
-        public IReadOnlyCollection<string> Operators => OperatorList?.ToList().AsReadOnly();
+        public IReadOnlyCollection<string> Operators { get; }
 
         /// <summary>
         ///     Gets the owner of the room, if private.
@@ -72,9 +72,6 @@ namespace Soulseek
         /// <summary>
         ///     Gets the users in the room.
         /// </summary>
-        public IReadOnlyCollection<UserData> Users => UserList.ToList().AsReadOnly();
-
-        private IEnumerable<string> OperatorList { get; }
-        private IEnumerable<UserData> UserList { get; }
+        public IReadOnlyCollection<UserData> Users { get; }
     }
 }

--- a/src/RoomInfo.cs
+++ b/src/RoomInfo.cs
@@ -28,7 +28,7 @@ namespace Soulseek
         public RoomInfo(string name, int userCount)
         {
             Name = name;
-            UserList = Enumerable.Empty<string>();
+            Users = new List<string>().AsReadOnly();
             UserCount = userCount;
         }
 
@@ -40,8 +40,8 @@ namespace Soulseek
         public RoomInfo(string name, IEnumerable<string> userList)
         {
             Name = name;
-            UserList = userList ?? Enumerable.Empty<string>();
-            UserCount = UserList.Count();
+            Users = (userList?.ToList() ?? new List<string>()).AsReadOnly();
+            UserCount = Users.Count;
         }
 
         /// <summary>
@@ -57,8 +57,6 @@ namespace Soulseek
         /// <summary>
         ///     Gets the users in the room, if available.
         /// </summary>
-        public IReadOnlyCollection<string> Users => UserList.ToList().AsReadOnly();
-
-        private IEnumerable<string> UserList { get; }
+        public IReadOnlyCollection<string> Users { get; }
     }
 }

--- a/src/RoomList.cs
+++ b/src/RoomList.cs
@@ -33,14 +33,17 @@ namespace Soulseek
             IEnumerable<RoomInfo> ownedList,
             IEnumerable<string> moderatedRoomNameList)
         {
-            PublicList = publicList ?? Enumerable.Empty<RoomInfo>();
-            PublicCount = PublicList.Count();
-            PrivateList = privateList ?? Enumerable.Empty<RoomInfo>();
-            PrivateCount = PrivateList.Count();
-            OwnedList = ownedList ?? Enumerable.Empty<RoomInfo>();
-            OwnedCount = OwnedList.Count();
-            ModeratedRoomNameList = moderatedRoomNameList ?? Enumerable.Empty<string>();
-            ModeratedRoomNameCount = ModeratedRoomNameList.Count();
+            Public = (publicList?.ToList() ?? new List<RoomInfo>()).AsReadOnly();
+            PublicCount = Public.Count;
+
+            Private = (privateList?.ToList() ?? new List<RoomInfo>()).AsReadOnly();
+            PrivateCount = Private.Count;
+
+            Owned = (ownedList?.ToList() ?? new List<RoomInfo>()).AsReadOnly();
+            OwnedCount = Owned.Count;
+
+            ModeratedRoomNames = (moderatedRoomNameList?.ToList() ?? new List<string>()).AsReadOnly();
+            ModeratedRoomNameCount = ModeratedRoomNames.Count;
         }
 
         /// <summary>
@@ -66,26 +69,21 @@ namespace Soulseek
         /// <summary>
         ///     Gets the list of public rooms.
         /// </summary>
-        public IReadOnlyCollection<RoomInfo> Public => PublicList.ToList().AsReadOnly();
+        public IReadOnlyCollection<RoomInfo> Public { get; }
 
         /// <summary>
         ///     Gets the list of private rooms.
         /// </summary>
-        public IReadOnlyCollection<RoomInfo> Private => PrivateList.ToList().AsReadOnly();
+        public IReadOnlyCollection<RoomInfo> Private { get; }
 
         /// <summary>
         ///     Gets the list of rooms owned by the currently logged in user.
         /// </summary>
-        public IReadOnlyCollection<RoomInfo> Owned => OwnedList.ToList().AsReadOnly();
+        public IReadOnlyCollection<RoomInfo> Owned { get; }
 
         /// <summary>
         ///     Gets the list of room names in which the currently logged in user has moderator status.
         /// </summary>
-        public IReadOnlyCollection<string> ModeratedRoomNames => ModeratedRoomNameList.ToList().AsReadOnly();
-
-        private IEnumerable<RoomInfo> PublicList { get; }
-        private IEnumerable<RoomInfo> PrivateList { get; }
-        private IEnumerable<RoomInfo> OwnedList { get; }
-        private IEnumerable<string> ModeratedRoomNameList { get; }
+        public IReadOnlyCollection<string> ModeratedRoomNames { get; }
     }
 }

--- a/src/SearchQuery.cs
+++ b/src/SearchQuery.cs
@@ -31,8 +31,8 @@ namespace Soulseek
         /// <param name="exclusions">The list of excluded terms.</param>
         public SearchQuery(IEnumerable<string> terms, IEnumerable<string> exclusions = null)
         {
-            TermList = terms ?? Enumerable.Empty<string>();
-            ExclusionList = exclusions ?? Enumerable.Empty<string>();
+            Terms = (terms?.ToList() ?? new List<string>()).AsReadOnly();
+            Exclusions = (exclusions?.ToList() ?? new List<string>()).AsReadOnly();
         }
 
         /// <summary>
@@ -54,20 +54,20 @@ namespace Soulseek
             IEnumerable<string> tokens = searchText?.Split(' ') ?? Enumerable.Empty<string>();
 
             var excludedTokens = tokens.Where(t => t.StartsWith("-", IgnoreCase));
-            ExclusionList = excludedTokens.Select(t => t.TrimStart('-')).Distinct();
+            Exclusions = excludedTokens.Select(t => t.TrimStart('-')).Distinct().ToList().AsReadOnly();
 
-            TermList = tokens.Except(excludedTokens);
+            Terms = tokens.Except(excludedTokens).ToList().AsReadOnly();
         }
 
         /// <summary>
         ///     Gets the list of excluded terms.
         /// </summary>
-        public IReadOnlyCollection<string> Exclusions => ExclusionList.ToList().AsReadOnly();
+        public IReadOnlyCollection<string> Exclusions { get; }
 
         /// <summary>
         ///     Gets the query text, concatenated from <see cref="Terms"/>.
         /// </summary>
-        public string Query => string.Join(" ", TermList);
+        public string Query => string.Join(" ", Terms);
 
         /// <summary>
         ///     Gets the full search text, including both <see cref="Terms"/> and <see cref="Exclusions"/>.
@@ -77,10 +77,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the list of search terms.
         /// </summary>
-        public IReadOnlyCollection<string> Terms => TermList.ToList().AsReadOnly();
-
-        private IEnumerable<string> ExclusionList { get; }
-        private IEnumerable<string> TermList { get; }
+        public IReadOnlyCollection<string> Terms { get; }
 
         /// <summary>
         ///     Returns a new instance of <see cref="SearchQuery"/> from the specified search text.

--- a/src/SearchResponse.cs
+++ b/src/SearchResponse.cs
@@ -38,11 +38,11 @@ namespace Soulseek
             UploadSpeed = uploadSpeed;
             QueueLength = queueLength;
 
-            FileList = fileList ?? Enumerable.Empty<File>();
-            FileCount = FileList.Count();
+            Files = (fileList?.ToList() ?? new List<File>()).AsReadOnly();
+            FileCount = Files.Count;
 
-            LockedFileList = lockedFileList ?? Enumerable.Empty<File>();
-            LockedFileCount = LockedFileList.Count();
+            LockedFiles = (lockedFileList?.ToList() ?? new List<File>()).AsReadOnly();
+            LockedFileCount = LockedFiles.Count;
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the list of files.
         /// </summary>
-        public IReadOnlyCollection<File> Files => FileList.ToList().AsReadOnly();
+        public IReadOnlyCollection<File> Files { get; }
 
         /// <summary>
         ///     Gets the number of free upload slots for the peer.
@@ -81,7 +81,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the list of locked files.
         /// </summary>
-        public IReadOnlyCollection<File> LockedFiles => LockedFileList.ToList().AsReadOnly();
+        public IReadOnlyCollection<File> LockedFiles { get; }
 
         /// <summary>
         ///     Gets the length of the peer's upload queue.
@@ -102,8 +102,5 @@ namespace Soulseek
         ///     Gets the username of the responding peer.
         /// </summary>
         public string Username { get; }
-
-        private IEnumerable<File> FileList { get; }
-        private IEnumerable<File> LockedFileList { get; }
     }
 }

--- a/tests/Soulseek.Tests.Unit/BrowseResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/BrowseResponseTests.cs
@@ -36,7 +36,7 @@ namespace Soulseek.Tests.Unit
         [Fact(DisplayName = "Instantiates with the given directory list")]
         public void Instantiates_With_The_Given_Directory_List()
         {
-            var dir = new Directory("foo", 1);
+            var dir = new Directory("foo");
             var list = new List<Directory>(new[] { dir });
 
             var a = new BrowseResponse(list);
@@ -51,7 +51,7 @@ namespace Soulseek.Tests.Unit
         [Fact(DisplayName = "Instantiates with the given locked directory list")]
         public void Instantiates_With_The_Given_Locked_Directory_List()
         {
-            var dir = new Directory("foo", 1);
+            var dir = new Directory("foo");
             var list = new List<Directory>(new[] { dir });
 
             var a = new BrowseResponse(lockedDirectoryList: list);

--- a/tests/Soulseek.Tests.Unit/Diagnostics/DirectoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Diagnostics/DirectoryTests.cs
@@ -20,20 +20,10 @@ namespace Soulseek.Tests.Unit
     public class DirectoryTests
     {
         [Trait("Category", "Instantiation")]
-        [Theory(DisplayName = "Instantiates with the given data"), AutoData]
-        public void Instantiates_With_The_Given_Data(string directoryname, int fileCount)
-        {
-            var d = new Directory(directoryname, fileCount);
-
-            Assert.Equal(directoryname, d.DirectoryName);
-            Assert.Equal(fileCount, d.FileCount);
-        }
-
-        [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with empty File list given no list"), AutoData]
-        public void Instantiates_With_Empty_File_List_Given_No_List(string directoryname, int fileCount)
+        public void Instantiates_With_Empty_File_List_Given_No_List(string directoryname)
         {
-            var d = new Directory(directoryname, fileCount);
+            var d = new Directory(directoryname);
 
             Assert.NotNull(d.Files);
             Assert.Empty(d.Files);
@@ -41,11 +31,11 @@ namespace Soulseek.Tests.Unit
 
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with given File list given list"), AutoData]
-        public void Instantiates_With_Given_File_List_Given_List(string directoryname, int fileCount)
+        public void Instantiates_With_Given_File_List_Given_List(string directoryname)
         {
             var files = new List<File>() { new File(1, "a", 2, "b") };
 
-            var d = new Directory(directoryname, fileCount, files);
+            var d = new Directory(directoryname, files);
 
             Assert.NotNull(d.Files);
             Assert.Single(d.Files);

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -470,8 +470,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             IEnumerable<Directory> dirs = new List<Directory>()
             {
-                new Directory("1", 2, files),
-                new Directory("2", 2, files),
+                new Directory("1", files),
+                new Directory("2", files),
             };
 
             var response = new BrowseResponse(dirs);
@@ -516,7 +516,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
                 new File(2, "2", 2, "2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
-            var dir = new Directory(dirname, 2, files);
+            var dir = new Directory(dirname, files);
 
             var response = new FolderContentsResponse(token, dir);
             var options = new SoulseekClientOptions(directoryContentsResponseResolver: (u, i, t, d) => Task.FromResult(dir));

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/BrowseResponseFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/BrowseResponseFactoryTests.cs
@@ -354,8 +354,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             var dirs = new List<Directory>()
             {
-                new Directory("dir1", 2, list),
-                new Directory("dir2", 2, list),
+                new Directory("dir1", list),
+                new Directory("dir2", list),
             };
 
             var r = new BrowseResponse(dirs);
@@ -405,7 +405,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             var dirs = new List<Directory>()
             {
-                new Directory("dir1", 2, list),
+                new Directory("dir1", list),
             };
 
             var r = new BrowseResponse(lockedDirectoryList: dirs);
@@ -506,7 +506,6 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             return new Directory(
                 directoryName: Guid.NewGuid().ToString(),
-                fileCount: fileCount,
                 fileList: fileList);
         }
     }

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
@@ -216,7 +216,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
-            var dir = new Directory(dirname, 2, list);
+            var dir = new Directory(dirname, list);
 
             var r = new FolderContentsResponse(token, dir);
 
@@ -305,7 +305,6 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             return new Directory(
                 directoryName: Guid.NewGuid().ToString(),
-                fileCount: fileCount,
                 fileList: fileList);
         }
     }


### PR DESCRIPTION
EventArgs and other public types (Directory, File, etc) that accept lists previously would store the given list as an `IEnumerable<>` and would expose an `IReadOnlyCollection` like so:

`Things => ThingList.ToList().AsReadOnly()`

This would cause `ThingList` to be copied each time `Things` was referenced, which is extremely wasteful and creates the risk that the containing type would not behave as though it was immutable (if the passed enumerable changed).

This PR updates these classes to copy the given `IEnumerable` using `.ToList().AsReadOnly()` in the constructor, which solves both issues.