### PR TITLE
Tweak handling of initialization messages (PeerInit, PierceFirewall)

### DIFF
--- a/src/Messaging/Messages/IInitializationMessage.cs
+++ b/src/Messaging/Messages/IInitializationMessage.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="IInitializationMessage.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Messaging.Messages
+{
+    /// <summary>
+    ///     An initialization message, used to negotiate peer connections.
+    /// </summary>
+    internal interface IInitializationMessage
+    {
+    }
+}

--- a/src/Messaging/Messages/Initialization/PeerInit.cs
+++ b/src/Messaging/Messages/Initialization/PeerInit.cs
@@ -20,7 +20,7 @@ namespace Soulseek.Messaging.Messages
     /// <summary>
     ///     Initiates a peer connection.
     /// </summary>
-    internal sealed class PeerInit : IIncomingMessage, IOutgoingMessage
+    internal sealed class PeerInit : IInitializationMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="PeerInit"/> class.

--- a/src/Messaging/Messages/Initialization/PierceFirewall.cs
+++ b/src/Messaging/Messages/Initialization/PierceFirewall.cs
@@ -20,7 +20,7 @@ namespace Soulseek.Messaging.Messages
     /// <summary>
     ///     Pierces the local firewall to initiate a connection.
     /// </summary>
-    internal sealed class PierceFirewall : IIncomingMessage, IOutgoingMessage
+    internal sealed class PierceFirewall : IInitializationMessage
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="PierceFirewall"/> class.

--- a/src/Messaging/Messages/Server/CannotConnect.cs
+++ b/src/Messaging/Messages/Server/CannotConnect.cs
@@ -82,7 +82,7 @@ namespace Soulseek.Messaging.Messages
                 .WriteCode(MessageCode.Server.CannotConnect)
                 .WriteInteger(Token);
 
-            if (!string.IsNullOrEmpty(Username)) 
+            if (!string.IsNullOrEmpty(Username))
             {
                 builder.WriteString(Username);
             }

--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -188,7 +188,7 @@ namespace Soulseek.Network
                     await connection.ConnectAsync().ConfigureAwait(false);
 
                     var request = new PierceFirewall(r.Token);
-                    await connection.WriteAsync(request).ConfigureAwait(false);
+                    await connection.WriteAsync(request.ToByteArray()).ConfigureAwait(false);
 
                     await connection.WriteAsync(GetBranchInformation<MessageCode.Peer>()).ConfigureAwait(false);
                 }
@@ -531,7 +531,7 @@ namespace Soulseek.Network
                 if (isDirect)
                 {
                     var request = new PeerInit(SoulseekClient.Username, Constants.ConnectionType.Distributed, SoulseekClient.GetNextToken());
-                    await connection.WriteAsync(request, cancellationToken).ConfigureAwait(false);
+                    await connection.WriteAsync(request.ToByteArray(), cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/Network/PeerConnectionManager.cs
+++ b/src/Network/PeerConnectionManager.cs
@@ -341,7 +341,7 @@ namespace Soulseek.Network
                         await connection.ConnectAsync(cts.Token).ConfigureAwait(false);
 
                         var request = new PierceFirewall(r.Token);
-                        await connection.WriteAsync(request, cts.Token).ConfigureAwait(false);
+                        await connection.WriteAsync(request.ToByteArray(), cts.Token).ConfigureAwait(false);
                     }
                     catch
                     {
@@ -439,7 +439,7 @@ namespace Soulseek.Network
                     if (isDirect)
                     {
                         var request = new PeerInit(SoulseekClient.Username, Constants.ConnectionType.Peer, SoulseekClient.GetNextToken());
-                        await connection.WriteAsync(request, cancellationToken).ConfigureAwait(false);
+                        await connection.WriteAsync(request.ToByteArray(), cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -1734,7 +1734,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var peerInit = new PeerInit(localUser, Constants.ConnectionType.Distributed, token).ToByteArray();
 
-            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(peerInit)), It.IsAny<CancellationToken>()));
+            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(peerInit)), It.IsAny<CancellationToken>()));
         }
 
         [Trait("Category", "GetParentCandidateConnectionAsync")]

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -1856,7 +1856,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(expectedEx);
 
             var (manager, mocks) = GetFixture();
@@ -1886,7 +1886,7 @@ namespace Soulseek.Tests.Unit.Network
             var conn = GetMessageConnectionMock(username, endpoint);
             conn.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            conn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
 
             var (manager, mocks) = GetFixture();
@@ -1899,7 +1899,7 @@ namespace Soulseek.Tests.Unit.Network
                 (await manager.GetOrAddMessageConnectionAsync(ctpr)).Dispose();
             }
 
-            conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(expectedMessage)), It.IsAny<CancellationToken?>()), Times.Once);
+            conn.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(expectedMessage)), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Trait("Category", "GetOrAddMessageConnectionAsync")]
@@ -2379,7 +2379,7 @@ namespace Soulseek.Tests.Unit.Network
                 .Returns(ConnectionTypes.Direct);
             direct.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            direct.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            direct.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(new ConnectionException());
 
             var (manager, mocks) = GetFixture();
@@ -2417,7 +2417,7 @@ namespace Soulseek.Tests.Unit.Network
                 .Returns(ConnectionTypes.Direct);
             direct.Setup(m => m.ConnectAsync(It.IsAny<CancellationToken?>()))
                 .Returns(Task.CompletedTask);
-            direct.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken?>()))
+            direct.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()))
                 .Throws(exception);
 
             var (manager, mocks) = GetFixture();
@@ -2579,7 +2579,7 @@ namespace Soulseek.Tests.Unit.Network
                 Assert.Equal(direct.Object, newConn);
                 Assert.Equal(ConnectionTypes.Direct, newConn.Type);
 
-                direct.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(o => o.ToByteArray().Matches(peerInit)), It.IsAny<CancellationToken?>()), Times.Once);
+                direct.Verify(m => m.WriteAsync(It.Is<byte[]>(o => o.Matches(peerInit)), It.IsAny<CancellationToken?>()), Times.Once);
             }
         }
 


### PR DESCRIPTION
Specifically, write the raw byte array to the connection and bypass the `MessageWritten` event.  The rationale is that we don't raise events when these messages are received, so suppressing the event is consistent.

Closes #463 