### PR TITLE
Improve handling of superseded child connections

### DIFF
--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -138,7 +138,7 @@ namespace Soulseek.Network
         ///         This collection should be used any time a child connection needs to be referenced, such as when broadcasting messages.
         ///     </para>
         /// </remarks>
-        private ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>> ChildConnectionDictionary { get; set; } = new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
+        private ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>> ChildConnectionDictionary { get; set;  } = new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
 
         /// <remarks>
         ///     <para>Provides a collection of chilren for which a connection was successfully negotiated.</para>
@@ -165,7 +165,7 @@ namespace Soulseek.Network
         private ConcurrentDictionary<int, string> PendingSolicitationDictionary { get; } = new ConcurrentDictionary<int, string>();
         private SoulseekClient SoulseekClient { get; }
         private SystemTimer StatusDebounceTimer { get; set; }
-        private SemaphoreSlim StatusSyncRoot { get; set; } = new SemaphoreSlim(1, 1);
+        private SemaphoreSlim StatusSyncRoot { get; } = new SemaphoreSlim(1, 1);
         private SystemTimer WatchdogTimer { get; }
 
         /// <summary>
@@ -526,6 +526,7 @@ namespace Soulseek.Network
         public async void RemoveAndDisposeAll()
         {
             PendingSolicitationDictionary.Clear();
+            PendingInboundIndirectConnectionDictionary.Clear();
             ParentConnection?.Dispose();
 
             while (!ChildConnectionDictionary.IsEmpty)

--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -173,18 +173,9 @@ namespace Soulseek.Network
         ///     pierces the remote peer's firewall.
         /// </summary>
         /// <remarks>
-        ///     <para>
-        ///         Because this uses <see cref="ConcurrentDictionary{TKey, TValue}.GetOrAdd(TKey, Func{TKey, TValue})"/>, the
-        ///         code that creates and establishes the indirect connection is only invoked if the dictionary is lacking an
-        ///         entry. If a direct connection has been established, the <see cref="ConnectToPeerResponse"/> which led to the
-        ///         invocation of this method is effectively discarded.
-        ///     </para>
-        ///     <para>
-        ///         This creates a slight chance for a missed opportunity to establish a functioning connection, if a direct
-        ///         connection was connected first but ultimately fails to be established due to a problem with handshaking. This
-        ///         is not a big deal because of the nature of the distributed network, and the fact that if a direct connection
-        ///         ultimately failed, an indirect connection would likely fail also.
-        ///     </para>
+        ///     This method will be invoked from <see cref="Messaging.Handlers.ServerMessageHandler"/> upon receipt of an
+        ///     unsolicited <see cref="ConnectToPeerResponse"/> of type 'D' only. This connection should only be initiated if
+        ///     there is no existing connection; superseding should be avoided if possible.
         /// </remarks>
         /// <param name="connectToPeerResponse">The response that solicited the connection.</param>
         /// <returns>The operation context.</returns>
@@ -239,6 +230,7 @@ namespace Soulseek.Network
 
                 using (var cts = new CancellationTokenSource())
                 {
+                    // add a record to the pending dictionary so we can tell whether the following code is waiting
                     PendingInboundIndirectConnectionDictionary.AddOrUpdate(r.Username, cts, (username, existingCts) => cts);
 
                     try
@@ -257,6 +249,8 @@ namespace Soulseek.Network
                     }
                     finally
                     {
+                        // let everyone know this code is done executing and that .Value of the containing cache is safe to await
+                        // with no delay.
                         PendingInboundIndirectConnectionDictionary.TryRemove(r.Username, out _);
                     }
                 }
@@ -279,9 +273,9 @@ namespace Soulseek.Network
         ///     Adds a new child connection from an incoming connection.
         /// </summary>
         /// <remarks>
-        ///     Because the connection has already been established by the listener when this method is invoked, the code to hand
-        ///     off and establish the connection is executed regardless of whether we have an existing connection to this user. If
-        ///     a previous connection does exist, it is disposed.
+        ///     This method will be invoked from <see cref="ListenerHandler"/> upon receipt of an incoming unsolicited connection
+        ///     only. Because this connection is fully established by the time it is passed to this method, it must supersede any
+        ///     cached connection, as it will be the most recently established connection as tracked by the remote user.
         /// </remarks>
         /// <param name="username">The username from which the connection originated.</param>
         /// <param name="incomingConnection">The accepted connection.</param>
@@ -335,18 +329,26 @@ namespace Soulseek.Network
 
                 if (cachedConnectionRecord != null)
                 {
+                    // because the cache is Lazy<>, the cached entry may be either a connected or pending connection. if we try to
+                    // reference .Value before the cached function is dispositioned we'll get stuck waiting for it, which will
+                    // prevent this code from superseding the connection until the pending connection times out. to get around
+                    // this the pending connection dictionary was added, allowing us to tell if the connection is still pending.
+                    // if so, we can just cancel the token and move on.
                     if (PendingInboundIndirectConnectionDictionary.TryGetValue(username, out var pendingCts))
                     {
-                        Diagnostic.Debug($"Cancelling pending inbound indirect child connection to {username}");
+                        Diagnostic.Debug($"Cancelling pending indirect child connection to {username}");
                         pendingCts.Cancel();
                     }
                     else
                     {
                         try
                         {
+                            // if there's no entry in the pending connection dictionary, the Lazy<> function has completed
+                            // executing and we know that awaiting .Value will return immediately, allowing us to tear down the
+                            // existing connection.
                             var cachedConnection = await cachedConnectionRecord.Value.ConfigureAwait(false);
                             cachedConnection.Disconnected -= ChildConnection_Disconnected;
-                            Diagnostic.Debug($"Superseding cached child connection to {username} ({cachedConnection.IPEndPoint}) (old: {c.Id}, new: {connection.Id}");
+                            Diagnostic.Debug($"Superseding existing child connection to {username} ({cachedConnection.IPEndPoint}) (old: {c.Id}, new: {connection.Id}");
                             cachedConnection.Disconnect("Superseded.");
                             cachedConnection.Dispose();
                             superseded = true;

--- a/src/Network/PeerConnectionManager.cs
+++ b/src/Network/PeerConnectionManager.cs
@@ -85,9 +85,9 @@ namespace Soulseek.Network
         ///     Adds a new message connection from an incoming connection.
         /// </summary>
         /// <remarks>
-        ///     This method will be invoked from <see cref="ListenerHandler"/> upon receipt of an incoming unsolicited message
-        ///     only. Because this connection is fully established by the time it is passed to this method, it must supersede any
-        ///     cached connection, as it will be the most recently established connection as tracked by the remote user.
+        ///     This method will be invoked from <see cref="ListenerHandler"/> upon receipt of an incoming 'P' connection only.
+        ///     Because this connection is fully established by the time it is passed to this method, it must supersede any cached
+        ///     connection, as it will be the most recently established connection as tracked by the remote user.
         /// </remarks>
         /// <param name="username">The username of the user from which the connection originated.</param>
         /// <param name="incomingConnection">The the accepted connection.</param>

--- a/src/Network/PeerConnectionManager.cs
+++ b/src/Network/PeerConnectionManager.cs
@@ -77,8 +77,12 @@ namespace Soulseek.Network
         private ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>> MessageConnectionDictionary { get; set; } =
             new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
 
-        private ConcurrentDictionary<string, CancellationTokenSource> PendingInboundIndirectConnectionDictionary { get; set; } = new ConcurrentDictionary<string, CancellationTokenSource>();
-        private ConcurrentDictionary<int, string> PendingSolicitationDictionary { get; set; } = new ConcurrentDictionary<int, string>();
+        private ConcurrentDictionary<string, CancellationTokenSource> PendingInboundIndirectConnectionDictionary { get; set; } =
+            new ConcurrentDictionary<string, CancellationTokenSource>();
+
+        private ConcurrentDictionary<int, string> PendingSolicitationDictionary { get; set; } =
+            new ConcurrentDictionary<int, string>();
+
         private SoulseekClient SoulseekClient { get; }
 
         /// <summary>
@@ -576,6 +580,7 @@ namespace Soulseek.Network
         public async void RemoveAndDisposeAll()
         {
             PendingSolicitationDictionary.Clear();
+            PendingInboundIndirectConnectionDictionary.Clear();
 
             while (!MessageConnectionDictionary.IsEmpty)
             {

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -1138,7 +1138,7 @@ namespace Soulseek.Tests.Unit.Network
                 Assert.Equal(endpoint.Port, child.IPEndPoint.Port);
             }
 
-            mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Superseding cached child connection"))));
+            mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Superseding existing child connection"))));
         }
 
         [Trait("Category", "AddChildConnectionAsync")]


### PR DESCRIPTION
Track indirect connection requests and add logging when discarding a request due to receipt of an incoming connection.

I made this change because I noticed in logs that connections that were being updated via a direct connection would always fail.  Forgetting how Soulseek Qt works, I thought this might be because direct connections weren't supposed to actually supersede in-flight connections.

I double checked the logic and made some improvements to match the peer connection manager, but this will likely just help these doomed connections fail faster.

Because I forgot, here's a definitive log showing the behavior:

```
[Mon Mar 15 08:48:53 2021] Received PM_TRANSFER_REQUEST message from user <user>
[Mon Mar 15 08:48:53 2021] Send PM_TRANSFER_RESPONSE message to user <user>
[Mon Mar 15 08:48:53 2021]    Found 2 existing messaging connections to user, picking latest
```

The most recent connection is the one that should be used in all cases, so any time a direct connection is established either during or after an indirect connection, it should supersede.

Conversely, indirect connections (via receipt of `ConnectToPeerRequest`) should be ignored if a direct connection has been established.  Both the peer and distributed connection managers implement this logic (unless of course there's some bug I'm unaware of).