### PR TITLE
Increase zlib buffer size to 256k

### DIFF
--- a/src/Messaging/Compression/ZOutputStream.cs
+++ b/src/Messaging/Compression/ZOutputStream.cs
@@ -91,7 +91,12 @@ namespace Soulseek.Messaging.Compression
 		}
 		
 		protected internal ZStream z = new ZStream();
-		protected internal int bufsize = 4096;		
+
+		// CHUNK is simply the buffer size for feeding data to and pulling data from the zlib routines. 
+		// Larger buffer sizes would be more efficient, especially for inflate(). If the memory is available, 
+		// buffers sizes on the order of 128K or 256K bytes should be used.
+		// https://zlib.net/zlib_how.html
+		protected internal int bufsize = 262144;
 		protected internal int flush_Renamed_Field;		
 		protected internal byte[] buf, buf1 = new byte[1];
 		protected internal bool compress;


### PR DESCRIPTION
Closes #503

I have a feeling that this may be a coincidental solution, but it does work for the reported user and since there's only a handful of clients that would be sending these responses I'm confident enough to see how it goes.

Note that the zlib implementation here is included from: https://github.com/philippelatulippe/ZLIB.NET, which should be a direct copy of the original code from ComponentAce.  This was done to maintain zero dependencies, and was ok since the code uses a BSD-3 style license.

This repo has been forked to: https://github.com/Elskom/zlib.managed/tree/main/zlib.managed, which has been refactored and appears to include several fixes for bugs I haven't experienced.  I will probably transclude this code once this repo is out of preview.