### PR TITLE
Suppress shared count updates if nothing has updated

### DIFF
--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -264,11 +264,13 @@
                 searchResponseResolver: SearchResponseResolver);
 
             Client = new SoulseekClient(options: clientOptions);
+            SharedCounts = (Directories: 0, Files: 0);
 
             SharedFileCache.Refreshed += (e, args) =>
             {
-                if (args.Files != SharedCounts.Files || args.Directories != SharedCounts.Directories)
+                if (SharedCounts != args)
                 {
+                    SharedCounts = args;
                     _ = Client.SetSharedCountsAsync(args.Directories, args.Files);
                 }
             };

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -56,6 +56,7 @@
         private ISharedFileCache SharedFileCache { get; set; }
         private readonly int MaxReconnectAttempts = 3;
         private int CurrentReconnectAttempts = 0;
+        private (int Directories, int Files) SharedCounts { get; set; }
 
         public Startup(IConfiguration configuration)
         {
@@ -266,7 +267,10 @@
 
             SharedFileCache.Refreshed += (e, args) =>
             {
-                _ = Client.SetSharedCountsAsync(args.Directories, args.Files);
+                if (args.Files != SharedCounts.Files || args.Directories != SharedCounts.Directories)
+                {
+                    _ = Client.SetSharedCountsAsync(args.Directories, args.Files);
+                }
             };
 
             // bind the DiagnosticGenerated event so we can trap and display diagnostic messages.  this is optional, and if the event 


### PR DESCRIPTION
Per discussion in #505, redundant updates create noise for the server and other users.