### PR TITLE
Target .NET Standard 2.0 and 2.1

### DIFF
--- a/examples/Web/api/WebAPI.csproj
+++ b/examples/Web/api/WebAPI.csproj
@@ -19,6 +19,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Debug\netcoreapp2.2\WebAPI.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Web/api/WebAPI.csproj
+++ b/examples/Web/api/WebAPI.csproj
@@ -30,12 +30,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/WaitKey.cs
+++ b/src/Common/WaitKey.cs
@@ -86,7 +86,11 @@ namespace Soulseek
         /// <returns>The hash code of this instance.</returns>
         public override int GetHashCode()
         {
+#if NETSTANDARD2_0
+            return string.IsNullOrEmpty(Token) ? 0 : Token.GetHashCode();
+#else
             return string.IsNullOrEmpty(Token) ? 0 : Token.GetHashCode(StringComparison.InvariantCulture);
+#endif
         }
 
         /// <summary>

--- a/src/Network/Tcp/ConnectionKey.cs
+++ b/src/Network/Tcp/ConnectionKey.cs
@@ -89,7 +89,11 @@ namespace Soulseek.Network.Tcp
         public override int GetHashCode()
         {
             var str = $"{Username}:{IPEndPoint?.Address}:{IPEndPoint?.Port}";
+#if NETSTANDARD2_0
+            return str.GetHashCode();
+#else
             return str.GetHashCode(StringComparison.CurrentCulture);
+#endif
         }
     }
 }

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -55,7 +55,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2496,8 +2496,11 @@ namespace Soulseek
                 options.MaximumLingerTime,
                 disposeInputStreamOnCompletion: false,
                 disposeOutputStreamOnCompletion: false);
-
+#if NETSTANDARD2_0
+            using var memoryStream = new MemoryStream();
+#else
             await using var memoryStream = new MemoryStream();
+#endif
 
             await DownloadToStreamAsync(username, filename, memoryStream, size, startOffset, token, options, cancellationToken).ConfigureAwait(false);
             return memoryStream.ToArray();
@@ -2572,7 +2575,11 @@ namespace Soulseek
                         .GetTransferConnectionAsync(username, endpoint, transferRequestAcknowledgement.Token, cancellationToken)
                         .ConfigureAwait(false);
                 }
+#if NETSTANDARD2_0
+                else if (transferRequestAcknowledgement.Message.Contains("not shared"))
+#else
                 else if (transferRequestAcknowledgement.Message.Contains("not shared", StringComparison.InvariantCultureIgnoreCase))
+#endif
                 {
                     throw new TransferRejectedException(transferRequestAcknowledgement.Message);
                 }
@@ -2731,7 +2738,11 @@ namespace Soulseek
                     }
                     finally
                     {
+#if NETSTANDARD2_0
+                        outputStream.Dispose();
+#else
                         await outputStream.DisposeAsync().ConfigureAwait(false);
+#endif
                     }
                 }
             }
@@ -3278,7 +3289,12 @@ namespace Soulseek
                 disposeInputStreamOnCompletion: false,
                 disposeOutputStreamOnCompletion: false);
 
+#if NETSTANDARD2_0
+            using var memoryStream = new MemoryStream(data);
+#else
             await using var memoryStream = new MemoryStream(data);
+#endif
+
             await UploadFromStreamAsync(username, filename, data.Length, memoryStream, token, options, cancellationToken).ConfigureAwait(false);
         }
 
@@ -3532,7 +3548,11 @@ namespace Soulseek
 
                 if (options.DisposeInputStreamOnCompletion)
                 {
+#if NETSTANDARD2_0
+                    inputStream.Dispose();
+#else
                     await inputStream.DisposeAsync().ConfigureAwait(false);
+#endif
                 }
             }
         }

--- a/tests/Soulseek.Tests.Integration/Soulseek.Tests.Integration.csproj
+++ b/tests/Soulseek.Tests.Integration/Soulseek.Tests.Integration.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Soulseek.Tests.Unit/Client/SendUploadSpeedAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SendUploadSpeedAsyncTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SetStatusAsyncTests.cs" company="JP Dillingham">
+﻿// <copyright file="SendUploadSpeedAsyncTests.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/EmbeddedMessageTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/EmbeddedMessageTests.cs
@@ -17,11 +17,11 @@
 
 namespace Soulseek.Tests.Unit.Messaging.Messages
 {
+    using System;
+    using System.Linq;
     using AutoFixture.Xunit2;
     using Soulseek.Messaging;
     using Soulseek.Messaging.Messages;
-    using System;
-    using System.Linq;
     using Xunit;
 
     public class EmbeddedMessageTests

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/PeerSearchRequestTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/PeerSearchRequestTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="QueueFailedResponseTests.cs" company="JP Dillingham">
+﻿// <copyright file="PeerSearchRequestTests.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,6 @@
 
 namespace Soulseek.Tests.Unit.Messaging.Messages
 {
-    using System;
     using AutoFixture.Xunit2;
     using Soulseek.Messaging;
     using Soulseek.Messaging.Messages;

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -1921,7 +1921,7 @@ namespace Soulseek.Tests.Unit.Network
 
         [Trait("Category", "ResetStatus")]
         [Theory(DisplayName = "ResetStatus resets status and demotes from branch root"), AutoData]
-        internal async Task ResetStatus_Resets_Status_And_Demotes_From_Branch_Root(string lastStatus, DateTime lastStatusTimestamp)
+        internal void ResetStatus_Resets_Status_And_Demotes_From_Branch_Root(string lastStatus, DateTime lastStatusTimestamp)
         {
             var (manager, _) = GetFixture();
 

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -1933,8 +1933,8 @@ namespace Soulseek.Tests.Unit.Network
 
                 manager.ResetStatus();
 
-                Assert.Equal(default(string), manager.GetProperty<string>("LastStatusHash"));
-                Assert.Equal(default(DateTime), manager.GetProperty<DateTime>("LastStatusTimestamp"));
+                Assert.Equal(default, manager.GetProperty<string>("LastStatusHash"));
+                Assert.Equal(default, manager.GetProperty<DateTime>("LastStatusTimestamp"));
                 Assert.False(manager.IsBranchRoot);
             }
         }

--- a/tests/Soulseek.Tests.Unit/Soulseek.Tests.Unit.csproj
+++ b/tests/Soulseek.Tests.Unit/Soulseek.Tests.Unit.csproj
@@ -18,15 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.16.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.16.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #529 

Also updates dependencies and resolves a few warnings, including `CS1591` in the web example project.