### PR TITLE
Handle distributed reset/code 130

### DIFF
--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -378,9 +378,9 @@
 
                     if (CurrentReconnectAttempts <= MaxReconnectAttempts)
                     {
-                        var wait = CurrentReconnectAttempts ^ 3;
+                        var wait = Math.Pow(CurrentReconnectAttempts, 3);
                         Console.WriteLine($"Waiting {wait} second(s) before reconnect...");
-                        await Task.Delay(wait);
+                        await Task.Delay((int)wait);
 
                         Console.WriteLine($"Attepting to reconnect...");
                         await Client.ConnectAsync(Username, Password);

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -62,6 +62,11 @@ namespace Soulseek
         event EventHandler<DistributedChildEventArgs> DistributedChildDisconnected;
 
         /// <summary>
+        ///     Occurs when the server requests a distributed network reset.
+        /// </summary>
+        event EventHandler DistributedNetworkReset;
+
+        /// <summary>
         ///     Occurs when a new parent is adopted.
         /// </summary>
         event EventHandler<DistributedParentEventArgs> DistributedParentAdopted;
@@ -455,7 +460,10 @@ namespace Soulseek
         /// <param name="token">The unique download token.</param>
         /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>The Task representing the asynchronous operation, including the transfer context and a byte array containing the file contents.</returns>
+        /// <returns>
+        ///     The Task representing the asynchronous operation, including the transfer context and a byte array containing the
+        ///     file contents.
+        /// </returns>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="username"/> or <paramref name="filename"/> is null, empty, or consists only of whitespace.
         /// </exception>

--- a/src/Messaging/Handlers/IServerMessageHandler.cs
+++ b/src/Messaging/Handlers/IServerMessageHandler.cs
@@ -26,6 +26,11 @@ namespace Soulseek.Messaging.Handlers
     internal interface IServerMessageHandler : IMessageHandler
     {
         /// <summary>
+        ///     Occurs when the server requests a distributed network reset.
+        /// </summary>
+        event EventHandler DistributedNetworkReset;
+
+        /// <summary>
         ///     Occurs when a global message is received.
         /// </summary>
         event EventHandler<string> GlobalMessageReceived;

--- a/src/Messaging/Handlers/ServerMessageHandler.cs
+++ b/src/Messaging/Handlers/ServerMessageHandler.cs
@@ -51,6 +51,11 @@ namespace Soulseek.Messaging.Handlers
         public event EventHandler<DiagnosticEventArgs> DiagnosticGenerated;
 
         /// <summary>
+        ///     Occurs when the server requests a distributed network reset.
+        /// </summary>
+        public event EventHandler DistributedNetworkReset;
+
+        /// <summary>
         ///     Occurs when a global message is received.
         /// </summary>
         public event EventHandler<string> GlobalMessageReceived;
@@ -296,6 +301,8 @@ namespace Soulseek.Messaging.Handlers
 
                     case MessageCode.Server.DistributedReset:
                         Diagnostic.Info($"Distributed network reset received from the server");
+                        DistributedNetworkReset?.Invoke(this, EventArgs.Empty);
+
                         SoulseekClient.DistributedConnectionManager.RemoveAndDisposeAll();
                         SoulseekClient.DistributedConnectionManager.ResetStatus();
 

--- a/src/Messaging/Handlers/ServerMessageHandler.cs
+++ b/src/Messaging/Handlers/ServerMessageHandler.cs
@@ -294,6 +294,13 @@ namespace Soulseek.Messaging.Handlers
 
                         break;
 
+                    case MessageCode.Server.DistributedReset:
+                        Diagnostic.Info($"Distributed network reset received from the server");
+                        SoulseekClient.DistributedConnectionManager.RemoveAndDisposeAll();
+                        SoulseekClient.DistributedConnectionManager.ResetStatus();
+
+                        break;
+
                     case MessageCode.Server.CannotConnect:
                         var cannotConnect = CannotConnect.FromByteArray(message);
                         Diagnostic.Debug($"Received CannotConnect message for token {cannotConnect.Token}{(!string.IsNullOrEmpty(cannotConnect.Username) ? $" from user {cannotConnect.Username}" : string.Empty)}");

--- a/src/Messaging/MessageCode.cs
+++ b/src/Messaging/MessageCode.cs
@@ -498,6 +498,11 @@ namespace Soulseek.Messaging
             ChildDepth = 129,
 
             /// <summary>
+            ///     130
+            /// </summary>
+            DistributedReset = 130,
+
+            /// <summary>
             ///     133
             /// </summary>
             PrivateRoomUsers = 133,

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -154,6 +154,7 @@ namespace Soulseek
             ServerMessageHandler.RoomListReceived += (sender, e) => RoomListReceived?.Invoke(this, e);
             ServerMessageHandler.DiagnosticGenerated += (sender, e) => DiagnosticGenerated?.Invoke(sender, e);
             ServerMessageHandler.GlobalMessageReceived += (sender, e) => GlobalMessageReceived?.Invoke(this, e);
+            ServerMessageHandler.DistributedNetworkReset += (sender, e) => DistributedNetworkReset?.Invoke(this, e);
 
             ServerMessageHandler.KickedFromServer += (sender, e) =>
             {
@@ -197,6 +198,11 @@ namespace Soulseek
         ///     Occurs when a child connection is disconnected.
         /// </summary>
         public event EventHandler<DistributedChildEventArgs> DistributedChildDisconnected;
+
+        /// <summary>
+        ///     Occurs when the server requests a distributed network reset.
+        /// </summary>
+        public event EventHandler DistributedNetworkReset;
 
         /// <summary>
         ///     Occurs when a new parent is adopted.

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -1264,6 +1264,41 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         }
 
         [Trait("Category", "Message")]
+        [Fact(DisplayName = "Raises DistributedNetworkReset on DistributedReset")]
+        public void Raises_DistributedNetworkReset_On_DistributedReset()
+        {
+            var (handler, mocks) = GetFixture();
+
+            var message = new MessageBuilder()
+                .WriteCode(MessageCode.Server.DistributedReset)
+                .Build();
+
+            bool fired = false;
+
+            handler.DistributedNetworkReset += (sender, args) => fired = true;
+
+            handler.HandleMessageRead(null, message);
+
+            Assert.True(fired);
+        }
+
+        [Trait("Category", "Message")]
+        [Fact(DisplayName = "Raises DistributedNetworkReset on DistributedReset")]
+        public void Raises_Resets_Distributed_Network_On_DistributedReset()
+        {
+            var (handler, mocks) = GetFixture();
+
+            var message = new MessageBuilder()
+                .WriteCode(MessageCode.Server.DistributedReset)
+                .Build();
+
+            handler.HandleMessageRead(null, message);
+
+            mocks.DistributedConnectionManager.Verify(m => m.ResetStatus(), Times.Once);
+            mocks.DistributedConnectionManager.Verify(m => m.RemoveAndDisposeAll(), Times.Once);
+        }
+
+        [Trait("Category", "Message")]
         [Theory(DisplayName = "Acknowledges NotifyPrivileges when AutoAcknowledgePrivilegeNotifications is true"), AutoData]
         public void Acknowledges_NotifyPrivileges_When_AutoAcknowledgePrivilegeNotifications_Is_True(string username, int id)
         {

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -875,6 +875,37 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "ServerMessageHandler Event")]
+        [Fact(DisplayName = "DistributedNetworkReset fires when handler raises")]
+        public void DistributedNetworkReset_Fires_When_Handler_Raises()
+        {
+            var mock = new Mock<IServerMessageHandler>();
+
+            using (var s = new SoulseekClient(serverMessageHandler: mock.Object))
+            {
+                bool fired = false;
+
+                s.DistributedNetworkReset += (sender, args) => fired = true;
+                mock.Raise(m => m.DistributedNetworkReset += null, mock.Object, EventArgs.Empty);
+
+                Assert.True(fired);
+            }
+        }
+
+        [Trait("Category", "ServerMessageHandler Event")]
+        [Fact(DisplayName = "DistributedNetworkReset does not throw if event not bound")]
+        public void DistributedNetworkReset_Does_Not_Throw_If_Event_Not_Bound()
+        {
+            var mock = new Mock<IServerMessageHandler>();
+
+            using (var s = new SoulseekClient(serverMessageHandler: mock.Object))
+            {
+                var ex = Record.Exception(() => mock.Raise(m => m.DistributedNetworkReset += null, mock.Object, EventArgs.Empty));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "ServerMessageHandler Event")]
         [Theory(DisplayName = "PrivateMessageReceived fires when handler raises"), AutoData]
         public void PrivateMessageReceived_Fires_When_Handler_Raises(int id, DateTime timestamp, string username, string message, bool isAdmin)
         {


### PR DESCRIPTION
When receiving a code 130 'distributed reset' message from the server, the library will now disconnect all distributed parent and children connections, and reset the status of the distributed connection manager.

Closes #576 