### PR TITLE
Allow several additional options to be patched in ReconfigureOptionsAsync()

### DIFF
--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -324,7 +324,15 @@ namespace Soulseek
                 patch.PeerConnectionOptions,
                 patch.TransferConnectionOptions,
                 patch.IncomingConnectionOptions,
-                patch.DistributedConnectionOptions);
+                patch.DistributedConnectionOptions,
+                patch.UserEndPointCache,
+                patch.SearchResponseResolver,
+                patch.SearchResponseCache,
+                patch.BrowseResponseResolver,
+                patch.DirectoryContentsResponseResolver,
+                patch.UserInfoResponseResolver,
+                patch.EnqueueDownloadAction,
+                patch.PlaceInQueueResponseResolver);
         }
 
         /// <summary>
@@ -350,6 +358,24 @@ namespace Soulseek
         /// <param name="transferConnectionOptions">The options for peer transfer connections.</param>
         /// <param name="incomingConnectionOptions">The options for incoming connections.</param>
         /// <param name="distributedConnectionOptions">The options for distributed message connections.</param>
+        /// <param name="userEndPointCache">The user endpoint cache to use when resolving user endpoints.</param>
+        /// <param name="searchResponseResolver">
+        ///     The delegate used to resolve the <see cref="SearchResponse"/> for an incoming <see cref="SearchRequest"/>.
+        /// </param>
+        /// <param name="searchResponseCache">The search response cache to use when a response is not able to be delivered immediately.</param>
+        /// <param name="browseResponseResolver">
+        ///     The delegate used to resolve the <see cref="BrowseResponse"/> for an incoming <see cref="BrowseRequest"/>.
+        /// </param>
+        /// <param name="directoryContentsResponseResolver">
+        ///     The delegate used to resolve the <see cref="FolderContentsResponse"/> for an incoming <see cref="FolderContentsRequest"/>.
+        /// </param>
+        /// <param name="userInfoResponseResolver">
+        ///     The delegate used to resolve the <see cref="UserInfo"/> for an incoming <see cref="UserInfoRequest"/>.
+        /// </param>
+        /// <param name="enqueueDownloadAction">The delegate invoked upon an receipt of an incoming <see cref="QueueDownloadRequest"/>.</param>
+        /// <param name="placeInQueueResponseResolver">
+        ///     The delegate used to resolve the <see cref="PlaceInQueueResponse"/> for an incoming request.
+        /// </param>
         /// <returns>The cloned instance.</returns>
         internal SoulseekClientOptions With(
             bool? enableListener = null,
@@ -365,7 +391,15 @@ namespace Soulseek
             ConnectionOptions peerConnectionOptions = null,
             ConnectionOptions transferConnectionOptions = null,
             ConnectionOptions incomingConnectionOptions = null,
-            ConnectionOptions distributedConnectionOptions = null)
+            ConnectionOptions distributedConnectionOptions = null,
+            IUserEndPointCache userEndPointCache = null,
+            Func<string, int, SearchQuery, Task<SearchResponse>> searchResponseResolver = null,
+            ISearchResponseCache searchResponseCache = null,
+            Func<string, IPEndPoint, Task<BrowseResponse>> browseResponseResolver = null,
+            Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResponseResolver = null,
+            Func<string, IPEndPoint, Task<UserInfo>> userInfoResponseResolver = null,
+            Func<string, IPEndPoint, string, Task> enqueueDownloadAction = null,
+            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null)
         {
             return new SoulseekClientOptions(
                 enableListener ?? EnableListener,
@@ -385,14 +419,14 @@ namespace Soulseek
                 (transferConnectionOptions ?? TransferConnectionOptions).WithoutInactivityTimeout(),
                 incomingConnectionOptions ?? IncomingConnectionOptions,
                 distributedConnectionOptions ?? DistributedConnectionOptions,
-                UserEndPointCache,
-                SearchResponseResolver,
-                SearchResponseCache,
-                BrowseResponseResolver,
-                DirectoryContentsResponseResolver,
-                UserInfoResponseResolver,
-                EnqueueDownloadAction,
-                PlaceInQueueResponseResolver);
+                userEndPointCache ?? UserEndPointCache,
+                searchResponseResolver ?? SearchResponseResolver,
+                searchResponseCache ?? SearchResponseCache,
+                browseResponseResolver ?? BrowseResponseResolver,
+                directoryContentsResponseResolver ?? DirectoryContentsResponseResolver,
+                userInfoResponseResolver ?? UserInfoResponseResolver,
+                enqueueDownloadAction ?? EnqueueDownloadAction,
+                placeInQueueResponseResolver ?? PlaceInQueueResponseResolver);
         }
     }
 }

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-pre-905211220</Version>
+    <Version>3.0.0-pre-913211833</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3097,7 +3097,15 @@ namespace Soulseek
                     peerConnectionOptions: patch.PeerConnectionOptions,
                     transferConnectionOptions: patch.TransferConnectionOptions,
                     incomingConnectionOptions: patch.IncomingConnectionOptions,
-                    distributedConnectionOptions: patch.DistributedConnectionOptions);
+                    distributedConnectionOptions: patch.DistributedConnectionOptions,
+                    userEndPointCache: patch.UserEndPointCache,
+                    searchResponseResolver: patch.SearchResponseResolver,
+                    searchResponseCache: patch.SearchResponseCache,
+                    browseResponseResolver: patch.BrowseResponseResolver,
+                    directoryContentsResponseResolver: patch.DirectoryContentsResponseResolver,
+                    userInfoResponseResolver: patch.UserInfoResponseResolver,
+                    enqueueDownloadAction: patch.EnqueueDownloadAction,
+                    placeInQueueResponseResolver: patch.PlaceInQueueResponseResolver);
 
                 Diagnostic.Info("Options reconfigured successfully");
 

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -18,11 +18,9 @@
 namespace Soulseek.Tests.Unit.Client
 {
     using System;
-    using System.Collections.Generic;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using AutoFixture.Xunit2;
     using Moq;
     using Soulseek.Messaging.Messages;
     using Soulseek.Network;
@@ -351,6 +349,16 @@ namespace Soulseek.Tests.Unit.Client
                 incomingConnectionOptions: new ConnectionOptions(),
                 distributedConnectionOptions: new ConnectionOptions()));
 
+            var userEndPointCache = new Mock<IUserEndPointCache>();
+            var searchResponseCache = new Mock<ISearchResponseCache>();
+
+            var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
+            var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
+            var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
+            var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
+
             var patch = new SoulseekClientOptionsPatch(
                 enableListener: true,
                 listenPort: Mocks.Port,
@@ -365,7 +373,15 @@ namespace Soulseek.Tests.Unit.Client
                 peerConnectionOptions: new ConnectionOptions(),
                 transferConnectionOptions: new ConnectionOptions(readBufferSize: 200),
                 incomingConnectionOptions: new ConnectionOptions(),
-                distributedConnectionOptions: new ConnectionOptions());
+                distributedConnectionOptions: new ConnectionOptions(),
+                userEndPointCache: userEndPointCache.Object,
+                searchResponseResolver: searchResponseResolver,
+                searchResponseCache: searchResponseCache.Object,
+                browseResponseResolver: browseResponseResolver,
+                directoryContentsResponseResolver: directoryContentsResponseResolver,
+                userInfoResponseResolver: userInfoResponseResolver,
+                enqueueDownloadAction: enqueueDownloadAction,
+                placeInQueueResponseResolver: placeInQueueResponseResolver);
 
             using (client)
             {
@@ -388,6 +404,15 @@ namespace Soulseek.Tests.Unit.Client
 
                 Assert.Equal(patch.ServerConnectionOptions.ReadBufferSize, client.Options.ServerConnectionOptions.ReadBufferSize);
                 Assert.Equal(patch.TransferConnectionOptions.ReadBufferSize, client.Options.TransferConnectionOptions.ReadBufferSize);
+
+                Assert.Equal(patch.UserEndPointCache, client.Options.UserEndPointCache);
+                Assert.Equal(patch.SearchResponseCache, client.Options.SearchResponseCache);
+                Assert.Equal(patch.SearchResponseResolver, client.Options.SearchResponseResolver);
+                Assert.Equal(patch.BrowseResponseResolver, client.Options.BrowseResponseResolver);
+                Assert.Equal(patch.DirectoryContentsResponseResolver, client.Options.DirectoryContentsResponseResolver);
+                Assert.Equal(patch.UserInfoResponseResolver, client.Options.UserInfoResponseResolver);
+                Assert.Equal(patch.EnqueueDownloadAction, client.Options.EnqueueDownloadAction);
+                Assert.Equal(patch.PlaceInQueueResponseResolver, client.Options.PlaceInQueueResponseResolver);
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
@@ -18,7 +18,10 @@
 namespace Soulseek.Tests.Unit
 {
     using System;
+    using System.Net;
+    using System.Threading.Tasks;
     using AutoFixture.Xunit2;
+    using Moq;
     using Xunit;
 
     public class SoulseekClientOptionsPatchTests
@@ -41,6 +44,16 @@ namespace Soulseek.Tests.Unit
             var incomingConnectionOptions = new ConnectionOptions();
             var distributedConnectionOptions = new ConnectionOptions();
 
+            var userEndPointCache = new Mock<IUserEndPointCache>();
+            var searchResponseCache = new Mock<ISearchResponseCache>();
+
+            var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
+            var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
+            var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
+            var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
+
             var rnd = new Random();
             var listenPort = rnd.Next(1024, 65535);
 
@@ -58,7 +71,15 @@ namespace Soulseek.Tests.Unit
                 peerConnectionOptions: peerConnectionOptions,
                 transferConnectionOptions: transferConnectionOptions,
                 incomingConnectionOptions: incomingConnectionOptions,
-                distributedConnectionOptions: distributedConnectionOptions);
+                distributedConnectionOptions: distributedConnectionOptions,
+                userEndPointCache: userEndPointCache.Object,
+                searchResponseResolver: searchResponseResolver,
+                searchResponseCache: searchResponseCache.Object,
+                browseResponseResolver: browseResponseResolver,
+                directoryContentsResponseResolver: directoryContentsResponseResolver,
+                userInfoResponseResolver: userInfoResponseResolver,
+                enqueueDownloadAction: enqueueDownloadAction,
+                placeInQueueResponseResolver: placeInQueueResponseResolver);
 
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenPort, o.ListenPort);
@@ -82,6 +103,15 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(transferConnectionOptions.WriteBufferSize, o.TransferConnectionOptions.WriteBufferSize);
             Assert.Equal(transferConnectionOptions.ConnectTimeout, o.TransferConnectionOptions.ConnectTimeout);
             Assert.Equal(-1, o.TransferConnectionOptions.InactivityTimeout);
+
+            Assert.Equal(userEndPointCache.Object, o.UserEndPointCache);
+            Assert.Equal(searchResponseResolver, o.SearchResponseResolver);
+            Assert.Equal(searchResponseCache.Object, o.SearchResponseCache);
+            Assert.Equal(browseResponseResolver, o.BrowseResponseResolver);
+            Assert.Equal(directoryContentsResponseResolver, o.DirectoryContentsResponseResolver);
+            Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
+            Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
+            Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
@@ -22,6 +22,7 @@ namespace Soulseek.Tests.Unit
     using System.Net;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
+    using Moq;
     using Soulseek.Diagnostics;
     using Xunit;
 
@@ -48,13 +49,22 @@ namespace Soulseek.Tests.Unit
             var incomingConnectionOptions = new ConnectionOptions();
             var distributedConnectionOptions = new ConnectionOptions();
 
+            var userEndPointCache = new Mock<IUserEndPointCache>();
+            var searchResponseCache = new Mock<ISearchResponseCache>();
+
+            var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
+            var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
+            var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
+            var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
+
             var rnd = new Random();
             var listenPort = rnd.Next(1024, 65535);
 
             var o = new SoulseekClientOptions(
                 enableListener,
                 listenPort,
-                userEndPointCache: null,
                 enableDistributedNetwork: enableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit,
@@ -69,11 +79,18 @@ namespace Soulseek.Tests.Unit
                 peerConnectionOptions: peerConnectionOptions,
                 transferConnectionOptions: transferConnectionOptions,
                 incomingConnectionOptions: incomingConnectionOptions,
-                distributedConnectionOptions: distributedConnectionOptions);
+                distributedConnectionOptions: distributedConnectionOptions,
+                userEndPointCache: userEndPointCache.Object,
+                searchResponseResolver: searchResponseResolver,
+                searchResponseCache: searchResponseCache.Object,
+                browseResponseResolver: browseResponseResolver,
+                directoryContentsResponseResolver: directoryContentsResponseResolver,
+                userInfoResponseResolver: userInfoResponseResolver,
+                enqueueDownloadAction: enqueueDownloadAction,
+                placeInQueueResponseResolver: placeInQueueResponseResolver);
 
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenPort, o.ListenPort);
-            Assert.Null(o.UserEndPointCache);
             Assert.Equal(enableDistributedNetwork, o.EnableDistributedNetwork);
             Assert.Equal(acceptDistributedChildren, o.AcceptDistributedChildren);
             Assert.Equal(distributedChildLimit, o.DistributedChildLimit);
@@ -98,8 +115,14 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(transferConnectionOptions.ConnectTimeout, o.TransferConnectionOptions.ConnectTimeout);
             Assert.Equal(-1, o.TransferConnectionOptions.InactivityTimeout);
 
-            Assert.Null(o.UserEndPointCache);
-            Assert.Null(o.SearchResponseCache);
+            Assert.Equal(userEndPointCache.Object, o.UserEndPointCache);
+            Assert.Equal(searchResponseResolver, o.SearchResponseResolver);
+            Assert.Equal(searchResponseCache.Object, o.SearchResponseCache);
+            Assert.Equal(browseResponseResolver, o.BrowseResponseResolver);
+            Assert.Equal(directoryContentsResponseResolver, o.DirectoryContentsResponseResolver);
+            Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
+            Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
+            Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
         }
 
         [Trait("Category", "Instantiation")]
@@ -227,6 +250,16 @@ namespace Soulseek.Tests.Unit
             var incomingConnectionOptions = new ConnectionOptions();
             var distributedConnectionOptions = new ConnectionOptions();
 
+            var userEndPointCache = new Mock<IUserEndPointCache>();
+            var searchResponseCache = new Mock<ISearchResponseCache>();
+
+            var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
+            var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
+            var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
+            var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
+
             var rnd = new Random();
             var listenPort = rnd.Next(1024, 65535);
 
@@ -244,7 +277,15 @@ namespace Soulseek.Tests.Unit
                 peerConnectionOptions: peerConnectionOptions,
                 transferConnectionOptions: transferConnectionOptions,
                 incomingConnectionOptions: incomingConnectionOptions,
-                distributedConnectionOptions: distributedConnectionOptions);
+                distributedConnectionOptions: distributedConnectionOptions,
+                userEndPointCache: userEndPointCache.Object,
+                searchResponseResolver: searchResponseResolver,
+                searchResponseCache: searchResponseCache.Object,
+                browseResponseResolver: browseResponseResolver,
+                directoryContentsResponseResolver: directoryContentsResponseResolver,
+                userInfoResponseResolver: userInfoResponseResolver,
+                enqueueDownloadAction: enqueueDownloadAction,
+                placeInQueueResponseResolver: placeInQueueResponseResolver);
 
             var o = new SoulseekClientOptions().With(patch);
 
@@ -270,6 +311,15 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(transferConnectionOptions.WriteBufferSize, o.TransferConnectionOptions.WriteBufferSize);
             Assert.Equal(transferConnectionOptions.ConnectTimeout, o.TransferConnectionOptions.ConnectTimeout);
             Assert.Equal(-1, o.TransferConnectionOptions.InactivityTimeout);
+
+            Assert.Equal(userEndPointCache.Object, o.UserEndPointCache);
+            Assert.Equal(searchResponseResolver, o.SearchResponseResolver);
+            Assert.Equal(searchResponseCache.Object, o.SearchResponseCache);
+            Assert.Equal(browseResponseResolver, o.BrowseResponseResolver);
+            Assert.Equal(directoryContentsResponseResolver, o.DirectoryContentsResponseResolver);
+            Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
+            Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
+            Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
         }
 
         [Trait("Category", "With")]
@@ -290,6 +340,16 @@ namespace Soulseek.Tests.Unit
             var incomingConnectionOptions = new ConnectionOptions();
             var distributedConnectionOptions = new ConnectionOptions();
 
+            var userEndPointCache = new Mock<IUserEndPointCache>();
+            var searchResponseCache = new Mock<ISearchResponseCache>();
+
+            var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
+            var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
+            var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
+            var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
+
             var rnd = new Random();
             var listenPort = rnd.Next(1024, 65535);
 
@@ -307,7 +367,15 @@ namespace Soulseek.Tests.Unit
                 peerConnectionOptions: peerConnectionOptions,
                 transferConnectionOptions: transferConnectionOptions,
                 incomingConnectionOptions: incomingConnectionOptions,
-                distributedConnectionOptions: distributedConnectionOptions);
+                distributedConnectionOptions: distributedConnectionOptions,
+                userEndPointCache: userEndPointCache.Object,
+                searchResponseResolver: searchResponseResolver,
+                searchResponseCache: searchResponseCache.Object,
+                browseResponseResolver: browseResponseResolver,
+                directoryContentsResponseResolver: directoryContentsResponseResolver,
+                userInfoResponseResolver: userInfoResponseResolver,
+                enqueueDownloadAction: enqueueDownloadAction,
+                placeInQueueResponseResolver: placeInQueueResponseResolver);
 
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenPort, o.ListenPort);
@@ -331,6 +399,15 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(transferConnectionOptions.WriteBufferSize, o.TransferConnectionOptions.WriteBufferSize);
             Assert.Equal(transferConnectionOptions.ConnectTimeout, o.TransferConnectionOptions.ConnectTimeout);
             Assert.Equal(-1, o.TransferConnectionOptions.InactivityTimeout);
+
+            Assert.Equal(userEndPointCache.Object, o.UserEndPointCache);
+            Assert.Equal(searchResponseResolver, o.SearchResponseResolver);
+            Assert.Equal(searchResponseCache.Object, o.SearchResponseCache);
+            Assert.Equal(browseResponseResolver, o.BrowseResponseResolver);
+            Assert.Equal(directoryContentsResponseResolver, o.DirectoryContentsResponseResolver);
+            Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
+            Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
+            Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
         }
 
         [Trait("Category", "With")]


### PR DESCRIPTION
Allow several additional options to be patched in `ReconfigureOptionsAsync()`:

* DistributedConnectionOptions
* UserEndPointCache
* SearchResponseResolver
* SearchResponseCache
* BrowseResponseResolver
* DirectoryContentsResponseResolver
* UserInfoResponseResolver
* EnqueueDownloadAction
* PlaceInQueueResponseResolver