### PR TITLE
Don't start Listener in ReconfigureOptionsAsync() if it isn't already listening

### DIFF
--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-pre-913211833</Version>
+    <Version>3.0.0-pre-913212123</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3069,6 +3069,8 @@ namespace Soulseek
 
                 if (enableListenerChanged || listenPortChanged || incomingConnectionOptionsChanged)
                 {
+                    var wasListening = Listener?.Listening ?? false;
+
                     Listener?.Stop();
                     Listener = null;
 
@@ -3077,7 +3079,7 @@ namespace Soulseek
                         listenPort: patch.ListenPort,
                         incomingConnectionOptions: patch.IncomingConnectionOptions);
 
-                    if (Options.EnableListener)
+                    if (wasListening && Options.EnableListener)
                     {
                         Listener = new Listener(Options.ListenPort, Options.IncomingConnectionOptions);
                         Listener.Accepted += ListenerHandler.HandleConnection;


### PR DESCRIPTION
This PR fixes a bug that causes the listener to start listening if `ReconfigureOptionsAsync()` is called while the client is disconnected.  The listener is intended to be started on connect and stopped on disconnect.