### PR TITLE
Throw NoResponseException from JoinRoomAsync() if the server does not respond

### DIFF
--- a/src/Exceptions/NoResponseException.cs
+++ b/src/Exceptions/NoResponseException.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="NoResponseException.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    ///     Represents an error performing an operation in or on a private chat room.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class NoResponseException : SoulseekClientException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoResponseException"/> class.
+        /// </summary>
+        public NoResponseException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoResponseException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public NoResponseException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoResponseException"/> class with a specified error message and a
+        ///     reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        ///     The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no
+        ///     inner exception is specified.
+        /// </param>
+        public NoResponseException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NoResponseException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected NoResponseException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -746,6 +746,7 @@ namespace Soulseek
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
         /// <exception cref="RoomJoinForbiddenException">Thrown when the server rejects the request.</exception>
+        /// <exception cref="NoResponseException">Thrown when the server does not respond to the request.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
         Task<RoomData> JoinRoomAsync(string roomName, bool isPrivate = false, CancellationToken? cancellationToken = null);
 

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-pre-913212123</Version>
+    <Version>3.0.0-pre-916212204</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3016,7 +3016,7 @@ namespace Soulseek
                     throw new NoResponseException($"The server didn't respond to the request to join chat room {roomName}. This probably indicates that the room is already joined.");
                 }
             }
-            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException) && !(ex is RoomJoinForbiddenException))
+            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException) && !(ex is RoomJoinForbiddenException) && !(ex is NoResponseException))
             {
                 throw new SoulseekClientException($"Failed to join chat room {roomName}: {ex.Message}", ex);
             }


### PR DESCRIPTION
This indicates that the room has already been joined (generally).

This is a small breaking change.

Closes #588 