### PR TITLE
Raise RoomLeft upon receipt of LeaveRoom

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -753,6 +753,7 @@ namespace Soulseek
         /// <summary>
         ///     Asynchronously leaves the chat room with the specified <paramref name="roomName"/>.
         /// </summary>
+        /// <remarks>When successful, a corresponding <see cref="RoomLeft"/> event will be raised.</remarks>
         /// <param name="roomName">The name of the chat room to leave.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the server response.</returns>

--- a/src/Messaging/Handlers/ServerMessageHandler.cs
+++ b/src/Messaging/Handlers/ServerMessageHandler.cs
@@ -418,6 +418,12 @@ namespace Soulseek.Messaging.Handlers
                     case MessageCode.Server.LeaveRoom:
                         var leaveRoomResponse = LeaveRoomResponse.FromByteArray(message);
                         SoulseekClient.Waiter.Complete(new WaitKey(code, leaveRoomResponse.RoomName));
+
+                        // the server doesn't send a UserLeftRoom message when the current user is the one who left,
+                        // whereas we do get a UserJoinedRoom message when the current user joins a room.  to keep the API
+                        // consistent, raise RoomLeft to mimic this behavior client side.  this may result in duplicate events
+                        // if the server behavior changes.
+                        RoomLeft?.Invoke(this, new RoomLeftEventArgs(leaveRoomResponse.RoomName, SoulseekClient.Username));
                         break;
 
                     case MessageCode.Server.SayInChatRoom:

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -1415,6 +1415,7 @@ namespace Soulseek
         /// <summary>
         ///     Asynchronously leaves the chat room with the specified <paramref name="roomName"/>.
         /// </summary>
+        /// <remarks>When successful, a corresponding <see cref="RoomLeft"/> event will be raised.</remarks>
         /// <param name="roomName">The name of the chat room to leave.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the server response.</returns>

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -985,6 +985,29 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         }
 
         [Trait("Category", "Message")]
+        [Theory(DisplayName = "Raises RoomLeft on LeaveRoom"), AutoData]
+        public void Raises_RoomLeft_On_LeaveRoom(string roomName, string username)
+        {
+            var (handler, mocks) = GetFixture();
+
+            mocks.Client.Setup(m => m.Username).Returns(username);
+
+            var builder = new MessageBuilder()
+                .WriteCode(MessageCode.Server.LeaveRoom)
+                .WriteString(roomName);
+
+            var message = builder.Build();
+            RoomLeftEventArgs args = null;
+
+            handler.RoomLeft += (sender, a) => args = a;
+            handler.HandleMessageRead(null, message);
+
+            Assert.NotNull(args);
+            Assert.Equal(roomName, args.RoomName);
+            Assert.Equal(username, args.Username);
+        }
+
+        [Trait("Category", "Message")]
         [Theory(DisplayName = "Handles SayInChatRoom"), AutoData]
         public void Handles_SayInChatRoom(string roomName, string username, string msg)
         {


### PR DESCRIPTION
The `RoomLeft` event will now be raised any time we leave a room, whether we've done it ourselves, someone revokes a private room membership, or any other reason the server would send a `LeaveRoom` message.

This is a breaking change because `RoomLeft` was previously only raised when someone other than ourselves left a room.

Closes #591 