### PR TITLE
Fix bug with transfer speed computation when starting offset is not zero

### DIFF
--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2859,7 +2859,7 @@ namespace Soulseek
                     await download.Connection.WriteAsync(startOffsetBytes, cancellationToken).ConfigureAwait(false);
 
                     UpdateState(TransferStates.InProgress);
-                    UpdateProgress(startOffset);
+                    UpdateProgress(download.StartOffset);
 
                     await download.Connection.ReadAsync(download.Size.Value - startOffset, outputStream, (cancelToken) => options.Governor(new Transfer(download), cancelToken), cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Also fixes an issue computing the final speed of the transfer once it completes.

Closes #602 