### PR TITLE
Use RunContinuationsAsynchronously when fire-and-forgetting Tasks

### DIFF
--- a/src/Common/Extensions.cs
+++ b/src/Common/Extensions.cs
@@ -55,7 +55,7 @@ namespace Soulseek
         /// <param name="task">The task to continue.</param>
         public static void Forget(this Task task)
         {
-            task.ContinueWith(t => { });
+            task.ContinueWith(t => { }, TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Soulseek
         public static void ForgetButThrowWhenFaulted<T>(this Task task)
             where T : Exception
         {
-            task.ContinueWith(t => { throw (T)Activator.CreateInstance(typeof(T), t.Exception.Message, t.Exception); }, TaskContinuationOptions.OnlyOnFaulted);
+            task.ContinueWith(t => { throw (T)Activator.CreateInstance(typeof(T), t.Exception.Message, t.Exception); }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
         /// <summary>

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-pre-991113210652</Version>
+    <Version>3.0.0-pre-991113210753</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>


### PR DESCRIPTION
I suspect this may be causing a deadlock on task continuations.  Even if it isn't, it's a good idea to include it.