### PR TITLE
Detect backups in distributed search request delivery

### DIFF
--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-pre-991113210753</Version>
+    <Version>3.0.0-pre-991113212231</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>


### PR DESCRIPTION
This is more of an experiment or confirmation of an issue rather than a long term fix.  Assuming this proves broadcast contention is causing memory pressure, this code will be refactored.