### PR TITLE
Add optional delegate to configure connection Socket instance

### DIFF
--- a/src/Network/ConnectionFactory.cs
+++ b/src/Network/ConnectionFactory.cs
@@ -69,7 +69,7 @@ namespace Soulseek.Network
             ConnectionOptions options = null,
             ITcpClient tcpClient = null)
         {
-            var connection = new MessageConnection(ipEndPoint, (options ?? new ConnectionOptions()).WithoutInactivityTimeout().WithKeepAlive(), tcpClient: tcpClient);
+            var connection = new MessageConnection(ipEndPoint, (options ?? new ConnectionOptions()).WithoutInactivityTimeout(), tcpClient: tcpClient);
             connection.Connected += connectedEventHandler;
             connection.Disconnected += disconnectedEventHandler;
             connection.MessageRead += messageReadEventHandler;

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -45,19 +45,10 @@ namespace Soulseek.Network.Tcp
 
             TcpClient = tcpClient ?? new TcpClientAdapter(new TcpClient());
 
-            // someone might be tempted to set the read and write buffer sizes on the
-            // TcpClient from options here; don't. for whatever reason this doesn't work
-            // as expected, especially not on Linux.  let the framework/OS handle this.
-            // the buffer size options refer to the buffer array used to chunk payloads.
-            TcpClient.Client.SendTimeout = Options.WriteTimeout;
-
-            if (Options.KeepAlive)
-            {
-                TcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-            }
-
             // invoke the configuration delegate to allow implementing code to configure
             // the socket.  .NET standard has a limited feature set with respect to SetSocketOptions()
+            // and there's a vast number of possible tweaks here, so delegating to implementing code
+            // is pretty much the only option.
             Options.ConfigureSocketAction(TcpClient.Client);
 
             WriteQueueSemaphore = new SemaphoreSlim(Options.WriteQueueSize);

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -153,11 +153,6 @@ namespace Soulseek.Network.Tcp
         public ConnectionOptions Options { get; protected set; }
 
         /// <summary>
-        ///     Gets the underlying Socket.
-        /// </summary>
-        public Socket Socket => TcpClient?.Client;
-
-        /// <summary>
         ///     Gets or sets the current connection state.
         /// </summary>
         public ConnectionState State { get; protected set; }

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -56,6 +56,10 @@ namespace Soulseek.Network.Tcp
                 TcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
             }
 
+            // invoke the configuration delegate to allow implementing code to configure
+            // the socket.  .NET standard has a limited feature set with respect to SetSocketOptions()
+            Options.ConfigureSocketAction(TcpClient.Client);
+
             WriteQueueSemaphore = new SemaphoreSlim(Options.WriteQueueSize);
 
             if (Options.InactivityTimeout > 0)

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -149,6 +149,11 @@ namespace Soulseek.Network.Tcp
         public ConnectionOptions Options { get; protected set; }
 
         /// <summary>
+        ///     Gets the underlying Socket.
+        /// </summary>
+        public Socket Socket => TcpClient?.Client;
+
+        /// <summary>
         ///     Gets or sets the current connection state.
         /// </summary>
         public ConnectionState State { get; protected set; }

--- a/src/Network/Tcp/IConnection.cs
+++ b/src/Network/Tcp/IConnection.cs
@@ -20,6 +20,7 @@ namespace Soulseek.Network.Tcp
     using System;
     using System.IO;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -77,6 +78,11 @@ namespace Soulseek.Network.Tcp
         ///     Gets the options for the connection.
         /// </summary>
         ConnectionOptions Options { get; }
+
+        /// <summary>
+        ///     Gets the underlying Socket.
+        /// </summary>
+        Socket Socket { get; }
 
         /// <summary>
         ///     Gets the current connection state.

--- a/src/Network/Tcp/IConnection.cs
+++ b/src/Network/Tcp/IConnection.cs
@@ -80,11 +80,6 @@ namespace Soulseek.Network.Tcp
         ConnectionOptions Options { get; }
 
         /// <summary>
-        ///     Gets the underlying Socket.
-        /// </summary>
-        Socket Socket { get; }
-
-        /// <summary>
         ///     Gets the current connection state.
         /// </summary>
         ConnectionState State { get; }

--- a/src/Options/ConnectionOptions.cs
+++ b/src/Options/ConnectionOptions.cs
@@ -17,11 +17,17 @@
 
 namespace Soulseek
 {
+    using System;
+    using System.Net.Sockets;
+
     /// <summary>
     ///     Options for connections.
     /// </summary>
     public class ConnectionOptions
     {
+        private readonly Action<Socket> defaultConfigureSocketAction =
+            (s) => { };
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ConnectionOptions"/> class.
         /// </summary>
@@ -33,6 +39,9 @@ namespace Soulseek
         /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
         /// <param name="keepAlive">A value indicating whether the connection should use TCP KeepAlives.</param>
         /// <param name="proxyOptions">Optional SOCKS 5 proxy configuration options.</param>
+        /// <param name="configureSocketAction">
+        ///     The delegate invoked during instantiation to configure the server Socket instance.
+        /// </param>
         public ConnectionOptions(
             int readBufferSize = 16384,
             int writeBufferSize = 16384,
@@ -41,7 +50,8 @@ namespace Soulseek
             int writeTimeout = 5000,
             int inactivityTimeout = 15000,
             bool keepAlive = false,
-            ProxyOptions proxyOptions = null)
+            ProxyOptions proxyOptions = null,
+            Action<Socket> configureSocketAction = null)
         {
             ReadBufferSize = readBufferSize;
             WriteBufferSize = writeBufferSize;
@@ -53,7 +63,14 @@ namespace Soulseek
             KeepAlive = keepAlive;
 
             ProxyOptions = proxyOptions;
+
+            ConfigureSocketAction = configureSocketAction ?? defaultConfigureSocketAction;
         }
+
+        /// <summary>
+        ///     Gets the delegate invoked during instantiation to configure the server Socket instance.
+        /// </summary>
+        public Action<Socket> ConfigureSocketAction { get; }
 
         /// <summary>
         ///     Gets the connection timeout, in milliseconds, for client and peer TCP connections. (Default = 10000).
@@ -105,7 +122,16 @@ namespace Soulseek
         /// <returns>A new instance with InactivityTimeout disabled.</returns>
         public ConnectionOptions WithoutInactivityTimeout()
         {
-            return new ConnectionOptions(ReadBufferSize, WriteBufferSize, WriteQueueSize, ConnectTimeout, WriteTimeout, inactivityTimeout: -1, KeepAlive, ProxyOptions);
+            return new ConnectionOptions(
+                readBufferSize: ReadBufferSize,
+                writeBufferSize: WriteBufferSize,
+                writeQueueSize: WriteQueueSize,
+                connectTimeout: ConnectTimeout,
+                writeTimeout: WriteTimeout,
+                inactivityTimeout: -1,
+                keepAlive: KeepAlive,
+                proxyOptions: ProxyOptions,
+                configureSocketAction: ConfigureSocketAction);
         }
 
         /// <summary>
@@ -114,7 +140,16 @@ namespace Soulseek
         /// <returns>A new instance with KeepAlive enabled.</returns>
         public ConnectionOptions WithKeepAlive()
         {
-            return new ConnectionOptions(ReadBufferSize, WriteBufferSize, WriteQueueSize, ConnectTimeout, WriteTimeout, InactivityTimeout, keepAlive: true, ProxyOptions);
+            return new ConnectionOptions(
+                readBufferSize: ReadBufferSize,
+                writeBufferSize: WriteBufferSize,
+                writeQueueSize: WriteQueueSize,
+                connectTimeout: ConnectTimeout,
+                writeTimeout: WriteTimeout,
+                inactivityTimeout: InactivityTimeout,
+                keepAlive: true,
+                proxyOptions: ProxyOptions,
+                configureSocketAction: ConfigureSocketAction);
         }
     }
 }

--- a/src/Options/ConnectionOptions.cs
+++ b/src/Options/ConnectionOptions.cs
@@ -35,9 +35,9 @@ namespace Soulseek
         /// <param name="writeBufferSize">The write buffer size for underlying TCP connections.</param>
         /// <param name="writeQueueSize">The size of the write queue for double buffered writes.</param>
         /// <param name="connectTimeout">The connection timeout, in milliseconds, for client and peer TCP connections.</param>
-        /// <param name="writeTimeout">The timeout, in milliseconds, for write operations.</param>
+        /// <param name="writeTimeout">(Obsolete) The timeout, in milliseconds, for write operations.</param>
         /// <param name="inactivityTimeout">The inactivity timeout, in milliseconds, for peer TCP connections.</param>
-        /// <param name="keepAlive">A value indicating whether the connection should use TCP KeepAlives.</param>
+        /// <param name="keepAlive">(Obsolete) A value indicating whether the connection should use TCP KeepAlives.</param>
         /// <param name="proxyOptions">Optional SOCKS 5 proxy configuration options.</param>
         /// <param name="configureSocketAction">
         ///     The delegate invoked during instantiation to configure the server Socket instance.
@@ -89,6 +89,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets a value indicating whether the connection should use TCP KeepAlives.  (Default = false).
         /// </summary>
+        [Obsolete("Use ConfigureSocketAction() to set KeepAlive and the various TcpKeepAlive parameters.  This will be removed in 4.x")]
         public bool KeepAlive { get; }
 
         /// <summary>
@@ -114,6 +115,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the timeout, in milliseconds, for write operations.  (Default = 5000).
         /// </summary>
+        [Obsolete("This will be removed in 4.x")]
         public int WriteTimeout { get; }
 
         /// <summary>

--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -33,9 +33,6 @@ namespace Soulseek
         private readonly Func<string, IPEndPoint, Task<BrowseResponse>> defaultBrowseResponse =
             (u, i) => Task.FromResult(new BrowseResponse(Enumerable.Empty<Directory>()));
 
-        private readonly Action<Socket> defaultConfigureServerSocketAction =
-            (s) => { };
-
         private readonly Func<string, IPEndPoint, string, Task> defaultEnqueueDownloadAction =
             (u, i, f) => Task.CompletedTask;
 
@@ -93,9 +90,6 @@ namespace Soulseek
         /// <param name="placeInQueueResponseResolver">
         ///     The delegate used to resolve the <see cref="PlaceInQueueResponse"/> for an incoming request.
         /// </param>
-        /// <param name="configureServerSocketAction">
-        ///     The delegate invoked during instantiation to configure the server Socket instance.
-        /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the value supplied for <paramref name="listenPort"/> is not between 1024 and 65535.
         /// </exception>
@@ -127,8 +121,7 @@ namespace Soulseek
             Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResponseResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResponseResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownloadAction = null,
-            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null,
-            Action<Socket> configureServerSocketAction = null)
+            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null)
         {
             EnableListener = enableListener;
             ListenPort = listenPort;
@@ -173,7 +166,6 @@ namespace Soulseek
             UserInfoResponseResolver = userInfoResponseResolver ?? defaultUserInfoResponse;
             EnqueueDownloadAction = enqueueDownloadAction ?? defaultEnqueueDownloadAction;
             PlaceInQueueResponseResolver = placeInQueueResponseResolver ?? defaultPlaceInQueueResponse;
-            ConfigureServerSocketAction = configureServerSocketAction ?? defaultConfigureServerSocketAction;
         }
 
         /// <summary>
@@ -202,11 +194,6 @@ namespace Soulseek
         ///     or directories).
         /// </summary>
         public Func<string, IPEndPoint, Task<BrowseResponse>> BrowseResponseResolver { get; }
-
-        /// <summary>
-        ///     Gets the delegate invoked during instantiation to configure the server Socket instance.
-        /// </summary>
-        public Action<Socket> ConfigureServerSocketAction { get; }
 
         /// <summary>
         ///     Gets a value indicating whether duplicated distributed search requests should be discarded. (Default = discard duplicates).
@@ -348,8 +335,7 @@ namespace Soulseek
                 directoryContentsResponseResolver: patch.DirectoryContentsResponseResolver,
                 userInfoResponseResolver: patch.UserInfoResponseResolver,
                 enqueueDownloadAction: patch.EnqueueDownloadAction,
-                placeInQueueResponseResolver: patch.PlaceInQueueResponseResolver,
-                configureServerSocketAction: patch.ConfigureServerSocketAction);
+                placeInQueueResponseResolver: patch.PlaceInQueueResponseResolver);
         }
 
         /// <summary>
@@ -395,9 +381,6 @@ namespace Soulseek
         /// <param name="placeInQueueResponseResolver">
         ///     The delegate used to resolve the <see cref="PlaceInQueueResponse"/> for an incoming request.
         /// </param>
-        /// <param name="configureServerSocketAction">
-        ///     The delegate invoked during instantiation to configure the server Socket instance.
-        /// </param>
         /// <returns>The cloned instance.</returns>
         internal SoulseekClientOptions With(
             bool? enableListener = null,
@@ -421,8 +404,7 @@ namespace Soulseek
             Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResponseResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResponseResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownloadAction = null,
-            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null,
-            Action<Socket> configureServerSocketAction = null)
+            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null)
         {
             return new SoulseekClientOptions(
                 enableListener: enableListener ?? EnableListener,
@@ -449,8 +431,7 @@ namespace Soulseek
                 directoryContentsResponseResolver: directoryContentsResponseResolver ?? DirectoryContentsResponseResolver,
                 userInfoResponseResolver: userInfoResponseResolver ?? UserInfoResponseResolver,
                 enqueueDownloadAction: enqueueDownloadAction ?? EnqueueDownloadAction,
-                placeInQueueResponseResolver: placeInQueueResponseResolver ?? PlaceInQueueResponseResolver,
-                configureServerSocketAction: configureServerSocketAction ?? ConfigureServerSocketAction);
+                placeInQueueResponseResolver: placeInQueueResponseResolver ?? PlaceInQueueResponseResolver);
         }
     }
 }

--- a/src/Options/SoulseekClientOptionsPatch.cs
+++ b/src/Options/SoulseekClientOptionsPatch.cs
@@ -19,6 +19,7 @@ namespace Soulseek
 {
     using System;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading.Tasks;
     using Soulseek.Messaging.Messages;
 
@@ -70,6 +71,9 @@ namespace Soulseek
         /// <param name="placeInQueueResponseResolver">
         ///     The delegate used to resolve the <see cref="PlaceInQueueResponse"/> for an incoming request.
         /// </param>
+        /// <param name="configureServerSocketAction">
+        ///     The delegate invoked during instantiation to configure the server Socket instance.
+        /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the value supplied for <paramref name="listenPort"/> is not between 1024 and 65535.
         /// </exception>
@@ -98,7 +102,8 @@ namespace Soulseek
             Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResponseResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResponseResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownloadAction = null,
-            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null)
+            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null,
+            Action<Socket> configureServerSocketAction = null)
         {
             EnableListener = enableListener;
             ListenPort = listenPort;
@@ -140,6 +145,7 @@ namespace Soulseek
             UserInfoResponseResolver = userInfoResponseResolver;
             EnqueueDownloadAction = enqueueDownloadAction;
             PlaceInQueueResponseResolver = placeInQueueResponseResolver;
+            ConfigureServerSocketAction = configureServerSocketAction;
         }
 
         /// <summary>
@@ -166,6 +172,11 @@ namespace Soulseek
         ///     Gets the delegate used to resolve the response for an incoming browse request.
         /// </summary>
         public Func<string, IPEndPoint, Task<BrowseResponse>> BrowseResponseResolver { get; }
+
+        /// <summary>
+        ///     Gets the delegate invoked during instantiation to configure the server Socket instance.
+        /// </summary>
+        public Action<Socket> ConfigureServerSocketAction { get; }
 
         /// <summary>
         ///     Gets a value indicating whether duplicated distributed search requests should be discarded.

--- a/src/Options/SoulseekClientOptionsPatch.cs
+++ b/src/Options/SoulseekClientOptionsPatch.cs
@@ -71,9 +71,6 @@ namespace Soulseek
         /// <param name="placeInQueueResponseResolver">
         ///     The delegate used to resolve the <see cref="PlaceInQueueResponse"/> for an incoming request.
         /// </param>
-        /// <param name="configureServerSocketAction">
-        ///     The delegate invoked during instantiation to configure the server Socket instance.
-        /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the value supplied for <paramref name="listenPort"/> is not between 1024 and 65535.
         /// </exception>
@@ -102,8 +99,7 @@ namespace Soulseek
             Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResponseResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResponseResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownloadAction = null,
-            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null,
-            Action<Socket> configureServerSocketAction = null)
+            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResponseResolver = null)
         {
             EnableListener = enableListener;
             ListenPort = listenPort;
@@ -145,7 +141,6 @@ namespace Soulseek
             UserInfoResponseResolver = userInfoResponseResolver;
             EnqueueDownloadAction = enqueueDownloadAction;
             PlaceInQueueResponseResolver = placeInQueueResponseResolver;
-            ConfigureServerSocketAction = configureServerSocketAction;
         }
 
         /// <summary>
@@ -172,11 +167,6 @@ namespace Soulseek
         ///     Gets the delegate used to resolve the response for an incoming browse request.
         /// </summary>
         public Func<string, IPEndPoint, Task<BrowseResponse>> BrowseResponseResolver { get; }
-
-        /// <summary>
-        ///     Gets the delegate invoked during instantiation to configure the server Socket instance.
-        /// </summary>
-        public Action<Socket> ConfigureServerSocketAction { get; }
 
         /// <summary>
         ///     Gets a value indicating whether duplicated distributed search requests should be discarded.

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.1.2</Version>
+    <Version>3.2.1</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -95,6 +95,7 @@ namespace Soulseek
         {
 #pragma warning restore S3427 // Method overloads with default parameter values should not overlap
             Options = options ?? new SoulseekClientOptions();
+
             ServerConnection = serverConnection;
 
             Waiter = waiter ?? new Waiter(Options.MessageTimeout);
@@ -2620,6 +2621,8 @@ namespace Soulseek
                         ServerConnection_MessageWritten,
                         Options.ServerConnectionOptions);
 
+                    Options.ConfigureServerSocketAction(ServerConnection.Socket);
+
                     await ServerConnection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
                     Address = address;
@@ -3279,8 +3282,9 @@ namespace Soulseek
                 }
 
                 var serverConnectionOptionsChanged = patch.ServerConnectionOptions != null && patch.ServerConnectionOptions != Options.ServerConnectionOptions;
+                var configureServerSocketActionChanged = patch.ConfigureServerSocketAction != null && patch.ConfigureServerSocketAction != Options.ConfigureServerSocketAction;
 
-                if (connected && serverConnectionOptionsChanged)
+                if (connected && (serverConnectionOptionsChanged || configureServerSocketActionChanged))
                 {
                     // required because we need to re-instantiate ServerConnection in order to pass it the new options
                     reconnectRequired = true;

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2621,8 +2621,6 @@ namespace Soulseek
                         ServerConnection_MessageWritten,
                         Options.ServerConnectionOptions);
 
-                    Options.ConfigureServerSocketAction(ServerConnection.Socket);
-
                     await ServerConnection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
                     Address = address;
@@ -3282,9 +3280,8 @@ namespace Soulseek
                 }
 
                 var serverConnectionOptionsChanged = patch.ServerConnectionOptions != null && patch.ServerConnectionOptions != Options.ServerConnectionOptions;
-                var configureServerSocketActionChanged = patch.ConfigureServerSocketAction != null && patch.ConfigureServerSocketAction != Options.ConfigureServerSocketAction;
 
-                if (connected && (serverConnectionOptionsChanged || configureServerSocketActionChanged))
+                if (connected && serverConnectionOptionsChanged)
                 {
                     // required because we need to re-instantiate ServerConnection in order to pass it the new options
                     reconnectRequired = true;

--- a/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
@@ -338,6 +338,23 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "Connect")]
+        [Fact(DisplayName = "Invokes ConfigureServerSocketAction")]
+        public async Task Invokes_ConfigureServerSocketAction()
+        {
+            var called = false;
+            var (client, mocks) = GetFixture(new SoulseekClientOptions(configureServerSocketAction: (_) => { called = true; }));
+
+            using (client)
+            {
+                var ex = await Record.ExceptionAsync(() => client.ConnectAsync("u", "p"));
+
+                Assert.Null(ex);
+
+                Assert.True(called);
+            }
+        }
+
+        [Trait("Category", "Connect")]
         [Fact(DisplayName = "Raises correct StateChanged sequence on success")]
         public async Task Raises_Correct_StateChanged_Sequence_On_Success()
         {

--- a/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
@@ -338,23 +338,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "Connect")]
-        [Fact(DisplayName = "Invokes ConfigureServerSocketAction")]
-        public async Task Invokes_ConfigureServerSocketAction()
-        {
-            var called = false;
-            var (client, mocks) = GetFixture(new SoulseekClientOptions(configureServerSocketAction: (_) => { called = true; }));
-
-            using (client)
-            {
-                var ex = await Record.ExceptionAsync(() => client.ConnectAsync("u", "p"));
-
-                Assert.Null(ex);
-
-                Assert.True(called);
-            }
-        }
-
-        [Trait("Category", "Connect")]
         [Fact(DisplayName = "Raises correct StateChanged sequence on success")]
         public async Task Raises_Correct_StateChanged_Sequence_On_Success()
         {

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -185,27 +185,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "ReconfigureOptions")]
-        [Fact(DisplayName = "Returns true if client connected and ServerConnectionOptions changed")]
-        public async Task Returns_True_If_Client_Connected_And_ConfigureServerSocketAction_Changed()
-        {
-            Action<Socket> one = (s) => { };
-            Action<Socket> two = (s) => { };
-
-            var (client, _) = GetFixture(new SoulseekClientOptions(configureServerSocketAction: one));
-
-            var patch = new SoulseekClientOptionsPatch(configureServerSocketAction: two);
-
-            using (client)
-            {
-                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var reconnectRequired = await client.ReconfigureOptionsAsync(patch);
-
-                Assert.True(reconnectRequired);
-            }
-        }
-
-        [Trait("Category", "ReconfigureOptions")]
         [Fact(DisplayName = "Nulls listener if EnableListener changed from true to false")]
         public async Task Nulls_Listener_If_EnableListener_Changed()
         {

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -19,6 +19,7 @@ namespace Soulseek.Tests.Unit.Client
 {
     using System;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
@@ -172,6 +173,27 @@ namespace Soulseek.Tests.Unit.Client
             var (client, _) = GetFixture(new SoulseekClientOptions(serverConnectionOptions: new ConnectionOptions()));
 
             var patch = new SoulseekClientOptionsPatch(serverConnectionOptions: new ConnectionOptions());
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var reconnectRequired = await client.ReconfigureOptionsAsync(patch);
+
+                Assert.True(reconnectRequired);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Returns true if client connected and ServerConnectionOptions changed")]
+        public async Task Returns_True_If_Client_Connected_And_ConfigureServerSocketAction_Changed()
+        {
+            Action<Socket> one = (s) => { };
+            Action<Socket> two = (s) => { };
+
+            var (client, _) = GetFixture(new SoulseekClientOptions(configureServerSocketAction: one));
+
+            var patch = new SoulseekClientOptionsPatch(configureServerSocketAction: two);
 
             using (client)
             {

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -143,6 +143,19 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             }
         }
 
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Invokes ConfigureSocketAction and passes TcpClient Socket"), AutoData]
+        public void Invokes_ConfigureSocketAction(IPEndPoint endpoint)
+        {
+            Socket socket = null;
+
+            using (var c = new Connection(endpoint, options: new ConnectionOptions(configureSocketAction: (s) => socket = s)))
+            {
+                var tcpClient = c.GetProperty<TcpClientAdapter>("TcpClient");
+                Assert.Equal(tcpClient.Client, socket);
+            }
+        }
+
         [Trait("Category", "Dispose")]
         [Theory(DisplayName = "Disposes without throwing"), AutoData]
         public void Disposes_Without_Throwing(IPEndPoint endpoint)

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -57,7 +57,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             Assert.NotEqual(Guid.Empty, c.Id);
             Assert.Equal(ConnectionTypes.None, c.Type);
             Assert.NotEqual(new TimeSpan(), c.InactiveTime);
-            Assert.NotNull(c.Socket);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -57,6 +57,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             Assert.NotEqual(Guid.Empty, c.Id);
             Assert.Equal(ConnectionTypes.None, c.Type);
             Assert.NotEqual(new TimeSpan(), c.InactiveTime);
+            Assert.NotNull(c.Socket);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
@@ -81,8 +81,7 @@ namespace Soulseek.Tests.Unit.Options
                 directoryContentsResponseResolver: directoryContentsResponseResolver,
                 userInfoResponseResolver: userInfoResponseResolver,
                 enqueueDownloadAction: enqueueDownloadAction,
-                placeInQueueResponseResolver: placeInQueueResponseResolver,
-                configureServerSocketAction: configureServerSocketAction);
+                placeInQueueResponseResolver: placeInQueueResponseResolver);
 
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenPort, o.ListenPort);
@@ -115,7 +114,6 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
             Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
             Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
-            Assert.Equal(configureServerSocketAction, o.ConfigureServerSocketAction);
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
@@ -19,6 +19,7 @@ namespace Soulseek.Tests.Unit.Options
 {
     using System;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
     using Moq;
@@ -53,6 +54,7 @@ namespace Soulseek.Tests.Unit.Options
             var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
             var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
             var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
+            var configureServerSocketAction = new Action<Socket>(s => { });
 
             var rnd = new Random();
             var listenPort = rnd.Next(1024, 65535);
@@ -79,7 +81,8 @@ namespace Soulseek.Tests.Unit.Options
                 directoryContentsResponseResolver: directoryContentsResponseResolver,
                 userInfoResponseResolver: userInfoResponseResolver,
                 enqueueDownloadAction: enqueueDownloadAction,
-                placeInQueueResponseResolver: placeInQueueResponseResolver);
+                placeInQueueResponseResolver: placeInQueueResponseResolver,
+                configureServerSocketAction: configureServerSocketAction);
 
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenPort, o.ListenPort);
@@ -112,6 +115,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
             Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
             Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
+            Assert.Equal(configureServerSocketAction, o.ConfigureServerSocketAction);
         }
 
         [Trait("Category", "Instantiation")]


### PR DESCRIPTION
.NET Standard has a limited set of options available when setting socket options.  .NET Core 3.1 improved upon these, notably adding TCP Keepalive settings, which are desirable for connections to the server.

Since the library itself targets .NET Standard, there's no way to set these options internally (without reinventing the wheel), and implementing code might want to set a variety of socket options for a given use case.

To solve this, this PR adds a delegate to `ConnectionOptions` that passes the underlying `Socket` instance for each connection.  Within the body of this delegate, implementing code can set whatever options are desired.  For example:

```c#
new ConnectionOptions(configureSocketAction: (socket) =>
{
    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
    socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 5);
    socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 5);
    socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, 5);
});
```

Upon instantiation of each type of connection that is given this set of options, the socket will be configured to enable KeepAlive packets, at a 5 second interval, beginning after 5 seconds of inactivity, and continuing until 5 KeepAlive packets go un-ACKed, at which point the connection will disconnect.

Related to #628 