### PR TITLE
Add ConnectToUserAsync()

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -444,6 +444,25 @@ namespace Soulseek
         Task ConnectAsync(string address, int port, string username, string password, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        ///     Asynchronously establishes and caches a connection to the specified <paramref name="username"/>. If a connection
+        ///     is already cached, it is returned unless the <paramref name="invalidateCache"/> option is specified.
+        /// </summary>
+        /// <param name="username">The user to which to connect.</param>
+        /// <param name="invalidateCache">
+        ///     A value indicating whether to establish a new connection, regardless of whether one is cached.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        Task ConnectToUserAsync(string username, bool invalidateCache = false, CancellationToken? cancellationToken = null);
+
+        /// <summary>
         ///     Disconnects the client from the server.
         /// </summary>
         /// <param name="message">An optional message describing the reason the client is being disconnected.</param>

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -459,6 +459,7 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
         Task ConnectToUserAsync(string username, bool invalidateCache = false, CancellationToken? cancellationToken = null);
 

--- a/src/Network/IPeerConnectionManager.cs
+++ b/src/Network/IPeerConnectionManager.cs
@@ -92,10 +92,7 @@ namespace Soulseek.Network
         /// <summary>
         ///     Gets a new or existing message connection to the specified <paramref name="username"/>.
         /// </summary>
-        /// <remarks>
-        ///     If a connection doesn't exist, a new direct connection is attempted first, and, if unsuccessful, an indirect
-        ///     connection is attempted.
-        /// </remarks>
+        /// <remarks>If a connection doesn't exist, a new connection is attempted using direct and indirect methods concurrently.</remarks>
         /// <param name="username">The username of the user to which to connect.</param>
         /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -103,12 +100,9 @@ namespace Soulseek.Network
         Task<IMessageConnection> GetOrAddMessageConnectionAsync(string username, IPEndPoint ipEndPoint, CancellationToken cancellationToken);
 
         /// <summary>
-        ///     Gets a new or existing message connection to the specified <paramref name="username"/>.
+        ///     Gets a new or existing message connection to the specified <paramref name="username"/> using the specified <paramref name="solicitationToken"/>.
         /// </summary>
-        /// <remarks>
-        ///     If a connection doesn't exist, a new direct connection is attempted first, and, if unsuccessful, an indirect
-        ///     connection is attempted.
-        /// </remarks>
+        /// <remarks>If a connection doesn't exist, a new connection is attempted using direct and indirect methods concurrently.</remarks>
         /// <param name="username">The username of the user to which to connect.</param>
         /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
         /// <param name="solicitationToken">The optional token for the indirect connection solicitation.</param>
@@ -148,5 +142,12 @@ namespace Soulseek.Network
         ///     Removes and disposes all active and queued connections.
         /// </summary>
         void RemoveAndDisposeAll();
+
+        /// <summary>
+        ///     Invalidates the cached message connection to the specified <paramref name="username"/>, if one exists.
+        /// </summary>
+        /// <param name="username">The username of the user for which the connection should be removed.</param>
+        /// <returns>A value indicating whether a connection record was invalidated.</returns>
+        bool TryInvalidateMessageConnectionCache(string username);
     }
 }

--- a/src/Network/PeerConnectionManager.cs
+++ b/src/Network/PeerConnectionManager.cs
@@ -385,10 +385,7 @@ namespace Soulseek.Network
         /// <summary>
         ///     Gets a new or existing message connection to the specified <paramref name="username"/>.
         /// </summary>
-        /// <remarks>
-        ///     If a connection doesn't exist, new direct and indirect connections are attempted simultaneously, and the first to
-        ///     connect is returned.
-        /// </remarks>
+        /// <remarks>If a connection doesn't exist, a new connection is attempted using direct and indirect methods concurrently.</remarks>
         /// <param name="username">The username of the user to which to connect.</param>
         /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -397,11 +394,10 @@ namespace Soulseek.Network
             => GetOrAddMessageConnectionAsync(username, ipEndPoint, SoulseekClient.GetNextToken(), cancellationToken);
 
         /// <summary>
-        ///     Gets a new or existing message connection to the specified <paramref name="username"/>.
+        ///     Gets a new or existing message connection to the specified <paramref name="username"/> using the specified <paramref name="solicitationToken"/>.
         /// </summary>
         /// <remarks>
-        ///     If a connection doesn't exist, new direct and indirect connections are attempted simultaneously, and the first to
-        ///     connect is returned.
+        ///     If a connection doesn't exist, a new connection is attempted using direct and indirect methods concurrently.
         /// </remarks>
         /// <param name="username">The username of the user to which to connect.</param>
         /// <param name="ipEndPoint">The remote IP endpoint of the connection.</param>
@@ -660,6 +656,16 @@ namespace Soulseek.Network
                     (await connection.Value.ConfigureAwait(false))?.Dispose();
                 }
             }
+        }
+
+        /// <summary>
+        ///     Invalidates the cached message connection to the specified <paramref name="username"/>, if one exists.
+        /// </summary>
+        /// <param name="username">The username of the user for which the connection should be removed.</param>
+        /// <returns>A value indicating whether a connection record was invalidated.</returns>
+        public bool TryInvalidateMessageConnectionCache(string username)
+        {
+            return MessageConnectionDictionary.TryRemove(username, out _);
         }
 
         private void Dispose(bool disposing)

--- a/src/SearchResponder.cs
+++ b/src/SearchResponder.cs
@@ -183,6 +183,11 @@ namespace Soulseek
         /// <summary>
         ///     Sends the pending response matching the specified <paramref name="responseToken"/>, if one exists.
         /// </summary>
+        /// <remarks>
+        ///     This overload is called by the listener when an incoming connection is established with a pierce firewall token,
+        ///     and if that token doesn't match a pending solicitation, and if the token matches a cached search response.  In this case,
+        ///     the connection is retrieved from the cache and used to send the response.
+        /// </remarks>
         /// <param name="responseToken">The token matching the pending response to send.</param>
         /// <returns>The operation context, including a value indicating whether a response was successfully sent.</returns>
         public async Task<bool> TryRespondAsync(int responseToken)

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -784,6 +784,38 @@ namespace Soulseek
         }
 
         /// <summary>
+        ///     Asynchronously establishes and caches a connection to the specified <paramref name="username"/>. If a connection
+        ///     is already cached, it is returned unless the <paramref name="invalidateCache"/> option is specified.
+        /// </summary>
+        /// <param name="username">The user to which to connect.</param>
+        /// <param name="invalidateCache">
+        ///     A value indicating whether to establish a new connection, regardless of whether one is cached.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public Task ConnectToUserAsync(string username, bool invalidateCache = false, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrEmpty(username))
+            {
+                throw new ArgumentException("Username may not be null or an empty string", nameof(username));
+            }
+
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to connect to other users (currently: {State})");
+            }
+
+            return ConnectToUserInternalAsync(username, invalidateCache, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
         ///     Disconnects the client from the server.
         /// </summary>
         /// <param name="message">An optional message describing the reason the client is being disconnected.</param>
@@ -2685,6 +2717,25 @@ namespace Soulseek
             {
                 Disconnect(ex.Message, exception: ex);
                 throw;
+            }
+        }
+
+        private async Task ConnectToUserInternalAsync(string username, bool invalidateCache, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
+
+                if (invalidateCache && PeerConnectionManager.TryInvalidateMessageConnectionCache(username))
+                {
+                    Diagnostic.Debug($"Invalidated message connection cache for {username}");
+                }
+
+                await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
+            {
+                throw new SoulseekClientException($"Failed to connect to user {username}: {ex.Message}", ex);
             }
         }
 

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -799,10 +799,11 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
         public Task ConnectToUserAsync(string username, bool invalidateCache = false, CancellationToken? cancellationToken = null)
         {
-            if (string.IsNullOrEmpty(username))
+            if (string.IsNullOrWhiteSpace(username))
             {
                 throw new ArgumentException("Username may not be null or an empty string", nameof(username));
             }
@@ -2733,7 +2734,7 @@ namespace Soulseek
 
                 await PeerConnectionManager.GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
+            catch (Exception ex) when (!(ex is UserOfflineException) && !(ex is OperationCanceledException) && !(ex is TimeoutException))
             {
                 throw new SoulseekClientException($"Failed to connect to user {username}: {ex.Message}", ex);
             }

--- a/tests/Soulseek.Tests.Unit/Client/ConnectToUserAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ConnectToUserAsyncTests.cs
@@ -1,0 +1,169 @@
+﻿// <copyright file="ConnectToUserAsyncTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit.Client
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoFixture.Xunit2;
+    using Moq;
+    using Soulseek.Network;
+    using Xunit;
+
+    public class ConnectToUserAsyncTests
+    {
+        [Trait("Category", "ConnectToUserAsync")]
+        [Theory(DisplayName = "ConnectToUserAsync Throws ArgumentException on bad username")]
+        [InlineData(null)]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        [InlineData("")]
+        public async Task Throws_ArgumentException_On_Bad_Username(string username)
+        {
+            using (var s = new SoulseekClient())
+            {
+                var ex = await Record.ExceptionAsync(() => s.ConnectToUserAsync(username));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+        }
+
+        [Trait("Category", "ConnectToUserAsync")]
+        [Theory(DisplayName = "ConnectToUserAsync throws InvalidOperationException if not connected and logged in")]
+        [InlineData(SoulseekClientStates.None)]
+        [InlineData(SoulseekClientStates.Disconnected)]
+        [InlineData(SoulseekClientStates.Connected)]
+        [InlineData(SoulseekClientStates.LoggedIn)]
+        public async Task ConnectToUserAsync_Throws_InvalidOperationException_If_Logged_In(SoulseekClientStates state)
+        {
+            using (var s = new SoulseekClient())
+            {
+                s.SetProperty("State", state);
+
+                var ex = await Record.ExceptionAsync(() => s.ConnectToUserAsync("a"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Fact(DisplayName = "Throws UserOfflineException when user is offline")]
+        public async Task Throws_UserOfflineException_When_User_Is_Offline()
+        {
+            var (client, mocks) = GetFixture();
+
+            mocks.Client.Setup(m => m.GetUserEndPointAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new UserOfflineException());
+
+            using (client)
+            {
+                var ex = await Record.ExceptionAsync(() => client.ConnectToUserAsync("u"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<UserOfflineException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Fact(DisplayName = "Throws TimeoutException when connection times out")]
+        public async Task Throws_TimeoutException_When_Connection_Times_Out()
+        {
+            var (client, mocks) = GetFixture();
+
+            mocks.Client.Setup(m => m.GetUserEndPointAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new TimeoutException());
+
+            using (client)
+            {
+                var ex = await Record.ExceptionAsync(() => client.ConnectToUserAsync("u"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<TimeoutException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Fact(DisplayName = "Throws OperationCanceledException when canceled")]
+        public async Task Throws_OperationCanceledException_When_Canceled()
+        {
+            var (client, mocks) = GetFixture();
+
+            mocks.Client.Setup(m => m.GetUserEndPointAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+
+            using (client)
+            {
+                var ex = await Record.ExceptionAsync(() => client.ConnectToUserAsync("u"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+
+        [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Uses given CancellationToken"), AutoData]
+        public async Task Uses_Given_CancellationToken(string user)
+        {
+            var cancellationToken = new CancellationToken();
+
+            var (client, mocks) = GetFixture();
+
+            using (client)
+            {
+                await client.ConnectToUserAsync(user, cancellationToken: cancellationToken);
+            }
+
+            mocks.Client.Verify(m => m.GetUserEndPointAsync(user, cancellationToken), Times.AtLeastOnce);
+        }
+
+        private (SoulseekClient client, Mocks Mocks) GetFixture()
+        {
+            var mocks = new Mocks();
+            var client = mocks.Client.Object;
+
+            return (client, mocks);
+        }
+
+        private class Mocks
+        {
+            public Mocks()
+            {
+                Client = new Mock<SoulseekClient>()
+                {
+                    CallBase = true,
+                };
+
+                Client.Setup(m => m.State).Returns(SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                Client.Setup(m => m.GetUserEndPointAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 5555)));
+                Client.Setup(m => m.PeerConnectionManager).Returns(PeerConnectionManager.Object);
+
+                PeerConnectionManager.Setup(m => m.TryInvalidateMessageConnectionCache(It.IsAny<string>()))
+                    .Returns(false);
+                PeerConnectionManager.Setup(m => m.GetOrAddMessageConnectionAsync(It.IsAny<string>(), It.IsAny<IPEndPoint>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new Mock<IMessageConnection>().Object));
+            }
+
+            public Mock<SoulseekClient> Client { get; }
+            public Mock<IPeerConnectionManager> PeerConnectionManager { get; } = new Mock<IPeerConnectionManager>();
+        }
+    }
+}

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -2885,6 +2885,58 @@ namespace Soulseek.Tests.Unit.Network
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive("Failed to establish a direct or indirect transfer connection"))));
         }
 
+        [Trait("Category", "TryInvalidateMessageConnectionCache")]
+        [Theory(DisplayName = "TryInvalidateMessageConnectionCache removes corresponding entry from MessageConnectionDictionary"), AutoData]
+        internal void TryInvalidateMessageConnectionCache_Removes_Corresponding_Entry_From_MessageConnectionDictionary(string username)
+        {
+            var (manager, mocks) = GetFixture();
+
+            using (manager)
+            {
+                var dict = new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
+                dict.GetOrAdd(username, new Lazy<Task<IMessageConnection>>(() => Task.FromResult(new Mock<IMessageConnection>().Object)));
+
+                manager.SetProperty("MessageConnectionDictionary", dict);
+
+                manager.TryInvalidateMessageConnectionCache(username);
+
+                Assert.Empty(dict);
+            }
+        }
+
+        [Trait("Category", "TryInvalidateMessageConnectionCache")]
+        [Theory(DisplayName = "TryInvalidateMessageConnectionCache returns true if cache is invalidated"), AutoData]
+        internal void TryInvalidateMessageConnectionCache_Returns_True_If_Cache_Is_Invalidated(string username)
+        {
+            var (manager, mocks) = GetFixture();
+
+            using (manager)
+            {
+                var dict = new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
+                dict.GetOrAdd(username, new Lazy<Task<IMessageConnection>>(() => Task.FromResult(new Mock<IMessageConnection>().Object)));
+
+                manager.SetProperty("MessageConnectionDictionary", dict);
+
+                var result = manager.TryInvalidateMessageConnectionCache(username);
+
+                Assert.True(result);
+            }
+        }
+
+        [Trait("Category", "TryInvalidateMessageConnectionCache")]
+        [Theory(DisplayName = "TryInvalidateMessageConnectionCache returns false if cache is missed"), AutoData]
+        internal void TryInvalidateMessageConnectionCache_Returns_False_If_Cache_Is_Missed(string username)
+        {
+            var (manager, mocks) = GetFixture();
+
+            using (manager)
+            {
+                var result = manager.TryInvalidateMessageConnectionCache(username);
+
+                Assert.False(result);
+            }
+        }
+
         [Trait("Category", "Diagnostic")]
         [Fact(DisplayName = "Diagnostic raises DiagnosticGenerated")]
         internal void Diagnostic_Raises_DiagnosticGenerated()


### PR DESCRIPTION
Adds a way to explicitly establish a connection to a user, with an optional flag to invalidate the cache of any existing connection.  Calling this method prior to attempting an operation that connects to a user (enqueuing a download, browsing, fetching user info, etc) allows callers to more gracefully handle connection failures, and "primes" the cache in a more deterministic way.

In some cases, a connection may be cached but may not be viable, for instance, if connection was used to deliver search results, the sender may have disconnected it on their end.  It's a good idea to force a "fresh" connection if there's any question.

Closes #635 