### PR TITLE
Fix Cannot access a disposed object. Object name: 'Timer' handling search responses

### DIFF
--- a/src/Common/Extensions.cs
+++ b/src/Common/Extensions.cs
@@ -95,8 +95,15 @@ namespace Soulseek
         /// <param name="timer">The timer to reset.</param>
         public static void Reset(this Timer timer)
         {
-            timer.Stop();
-            timer.Start();
+            try
+            {
+                timer.Stop();
+                timer.Start();
+            }
+            catch (ObjectDisposedException)
+            {
+                // noop
+            }
         }
 
         /// <summary>

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.3.1</Version>
+    <Version>3.3.2</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/tests/Soulseek.Tests.Unit/Common/ExtensionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Common/ExtensionsTests.cs
@@ -49,5 +49,17 @@ namespace Soulseek.Tests.Unit
                 Assert.IsType<ObjectDisposedException>(ex2);
             }
         }
+
+        [Trait("Category", "Extension")]
+        [Fact(DisplayName = "Timer reset does not throw given a disposed timer")]
+        public void Timer_Reset_Does_Not_Throw_On_Disposed_Timer()
+        {
+            var timer = new Timer();
+            timer.Dispose();
+
+            var ex = Record.Exception(() => timer.Reset());
+
+            Assert.Null(ex);
+        }
     }
 }


### PR DESCRIPTION
This was a concurrency bug, where a thread would make it into the response handler prior to the response object being disposed, and where the object would be disposed mid-flight.  The fix is to ignore `ObjectDisposedException` when resetting the timer.

Closes #638 