### PR TITLE
Add a basic upload queue with a configurable number of slots

### DIFF
--- a/src/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Messaging/Handlers/PeerMessageHandler.cs
@@ -332,8 +332,9 @@ namespace Soulseek.Messaging.Handlers
         /// <param name="args">The message event args.</param>
         public void HandleMessageWritten(object sender, MessageEventArgs args)
         {
+            var connection = (IMessageConnection)sender;
             var code = new MessageReader<MessageCode.Peer>(args.Message).ReadCode();
-            Diagnostic.Debug($"Peer message sent: {code}");
+            Diagnostic.Debug($"Peer message sent: {code} ({connection.IPEndPoint}) (id: {connection.Id})");
         }
 
         private async Task<(bool Rejected, string RejectionMessage)> TryEnqueueDownloadAsync(string username, IPEndPoint ipEndPoint, string filename)

--- a/src/Messaging/MessageCode.cs
+++ b/src/Messaging/MessageCode.cs
@@ -82,8 +82,17 @@ namespace Soulseek.Messaging
         /// <summary>
         ///     Peer message codes.
         /// </summary>
+        /// <remarks>
+        ///     Codes from 0-5500 were sent to Soulseek Qt 2020.3.12 and all but the ones
+        ///     documented here were reported as 'unknown'.
+        /// </remarks>
         public enum Peer
         {
+            /// <summary>
+            ///     1 (Deprecated)
+            /// </summary>
+            PrivateMessage = 1,
+
             /// <summary>
             ///     4
             /// </summary>
@@ -95,7 +104,7 @@ namespace Soulseek.Messaging
             BrowseResponse = 5,
 
             /// <summary>
-            ///     8
+            ///     8 (Deprecated)
             /// </summary>
             SearchRequest = 8,
 
@@ -103,6 +112,16 @@ namespace Soulseek.Messaging
             ///     9
             /// </summary>
             SearchResponse = 9,
+
+            /// <summary>
+            ///     10 (Deprecated)
+            /// </summary>
+            PrivateRoomInvitation = 10,
+
+            /// <summary>
+            ///     14 (Deprecated)
+            /// </summary>
+            CancelledQueuedTransfer = 14,
 
             /// <summary>
             ///     15
@@ -113,6 +132,16 @@ namespace Soulseek.Messaging
             ///     16
             /// </summary>
             InfoResponse = 16,
+
+            /// <summary>
+            ///     33 (Deprecated)
+            /// </summary>
+            SendConnectToken = 33,
+
+            /// <summary>
+            ///     34 (Deprecated)
+            /// </summary>
+            MoveDownloadToTop = 34,
 
             /// <summary>
             ///     36
@@ -155,6 +184,21 @@ namespace Soulseek.Messaging
             UploadFailed = 46,
 
             /// <summary>
+            ///     47 (Deprecated)
+            /// </summary>
+            ExactFileSearchRequest = 47,
+
+            /// <summary>
+            ///     48 (Deprecated)
+            /// </summary>
+            QueuedDownloads = 48,
+
+            /// <summary>
+            ///     49 (Deprecated)
+            /// </summary>
+            IndirectFileSearchRequest = 49,
+
+            /// <summary>
             ///     50
             /// </summary>
             UploadDenied = 50,
@@ -163,6 +207,11 @@ namespace Soulseek.Messaging
             ///     51
             /// </summary>
             PlaceInQueueRequest = 51,
+
+            /// <summary>
+            ///     52 (Deprecated)
+            /// </summary>
+            UploadQueueNotification = 52,
         }
 
         /// <summary>

--- a/src/Network/ListenerHandler.cs
+++ b/src/Network/ListenerHandler.cs
@@ -110,16 +110,13 @@ namespace Soulseek.Network
                         Diagnostic.Debug($"Distributed PierceFirewall with token {pierceFirewall.Token} received from {distributedUsername} ({connection.IPEndPoint.Address}:{SoulseekClient.Listener.Port}) (id: {connection.Id})");
                         SoulseekClient.Waiter.Complete(new WaitKey(Constants.WaitKey.SolicitedDistributedConnection, distributedUsername, pierceFirewall.Token), connection);
                     }
-                    else if (SoulseekClient.Options.SearchResponseCache != default)
+                    else if (SoulseekClient.Options.SearchResponseCache?.TryGet(pierceFirewall.Token, out var cachedSearchResponse) ?? false)
                     {
-                        if (SoulseekClient.Options.SearchResponseCache.TryGet(pierceFirewall.Token, out var cachedSearchResponse))
-                        {
-                            // users may connect to retrieve search results long after we've given up waiting for them.  if this is the case, accept the connection,
-                            // cache it with the manager for potential reuse, then try to send the pending response.
-                            Diagnostic.Debug($"PierceFirewall matching pending search response received from {cachedSearchResponse.Username} ({connection.IPEndPoint.Address}:{SoulseekClient.Listener.Port}) (id: {connection.Id})");
-                            await SoulseekClient.PeerConnectionManager.AddOrUpdateMessageConnectionAsync(cachedSearchResponse.Username, connection).ConfigureAwait(false);
-                            await SoulseekClient.SearchResponder.TryRespondAsync(pierceFirewall.Token).ConfigureAwait(false);
-                        }
+                        // users may connect to retrieve search results long after we've given up waiting for them.  if this is the case, accept the connection,
+                        // cache it with the manager for potential reuse, then try to send the pending response.
+                        Diagnostic.Debug($"PierceFirewall matching pending search response received from {cachedSearchResponse.Username} ({connection.IPEndPoint.Address}:{SoulseekClient.Listener.Port}) (id: {connection.Id})");
+                        await SoulseekClient.PeerConnectionManager.AddOrUpdateMessageConnectionAsync(cachedSearchResponse.Username, connection).ConfigureAwait(false);
+                        await SoulseekClient.SearchResponder.TryRespondAsync(pierceFirewall.Token).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/Network/ListenerHandler.cs
+++ b/src/Network/ListenerHandler.cs
@@ -110,12 +110,14 @@ namespace Soulseek.Network
                         Diagnostic.Debug($"Distributed PierceFirewall with token {pierceFirewall.Token} received from {distributedUsername} ({connection.IPEndPoint.Address}:{SoulseekClient.Listener.Port}) (id: {connection.Id})");
                         SoulseekClient.Waiter.Complete(new WaitKey(Constants.WaitKey.SolicitedDistributedConnection, distributedUsername, pierceFirewall.Token), connection);
                     }
-                    else if (SoulseekClient.Options.SearchResponseCache?.TryGet(pierceFirewall.Token, out var cachedSearchResponse) ?? false)
+                    else if (SoulseekClient.Options.SearchResponseCache != null && SoulseekClient.Options.SearchResponseCache.TryGet(pierceFirewall.Token, out var cachedSearchResponse))
                     {
                         // users may connect to retrieve search results long after we've given up waiting for them.  if this is the case, accept the connection,
                         // cache it with the manager for potential reuse, then try to send the pending response.
-                        Diagnostic.Debug($"PierceFirewall matching pending search response received from {cachedSearchResponse.Username} ({connection.IPEndPoint.Address}:{SoulseekClient.Listener.Port}) (id: {connection.Id})");
-                        await SoulseekClient.PeerConnectionManager.AddOrUpdateMessageConnectionAsync(cachedSearchResponse.Username, connection).ConfigureAwait(false);
+                        var (username, _, _, _) = cachedSearchResponse;
+
+                        Diagnostic.Debug($"PierceFirewall matching pending search response received from {username} ({connection.IPEndPoint.Address}:{SoulseekClient.Listener.Port}) (id: {connection.Id})");
+                        await SoulseekClient.PeerConnectionManager.AddOrUpdateMessageConnectionAsync(username, connection).ConfigureAwait(false);
                         await SoulseekClient.SearchResponder.TryRespondAsync(pierceFirewall.Token).ConfigureAwait(false);
                     }
                     else

--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -20,7 +20,6 @@ namespace Soulseek
     using System;
     using System.Linq;
     using System.Net;
-    using System.Net.Sockets;
     using System.Threading.Tasks;
     using Soulseek.Diagnostics;
     using Soulseek.Messaging.Messages;
@@ -50,6 +49,8 @@ namespace Soulseek
         /// <param name="enableDistributedNetwork">A value indicating whether to establish distributed network connections.</param>
         /// <param name="acceptDistributedChildren">A value indicating whether to accept distributed child connections.</param>
         /// <param name="distributedChildLimit">The number of allowed distributed children.</param>
+        /// <param name="enableUploadQueue">A value indicating whether to use the internal queue for upload transfers.</param>
+        /// <param name="uploadSlots">The number of allowed concurrent uploads.</param>
         /// <param name="deduplicateSearchRequests">
         ///     A value indicating whether duplicated distributed search requests should be discarded.
         /// </param>
@@ -102,6 +103,8 @@ namespace Soulseek
             bool enableDistributedNetwork = true,
             bool acceptDistributedChildren = true,
             int distributedChildLimit = 25,
+            bool enableUploadQueue = true,
+            int uploadSlots = 5,
             bool deduplicateSearchRequests = true,
             int messageTimeout = 5000,
             bool autoAcknowledgePrivateMessages = true,
@@ -138,6 +141,14 @@ namespace Soulseek
             if (DistributedChildLimit < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(distributedChildLimit), "Must be greater than or equal to zero");
+            }
+
+            EnableUploadQueue = enableUploadQueue;
+            UploadSlots = uploadSlots;
+
+            if (UploadSlots < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(uploadSlots), "Must be greater than or equal to one");
             }
 
             DeduplicateSearchRequests = deduplicateSearchRequests;
@@ -227,6 +238,11 @@ namespace Soulseek
         public bool EnableListener { get; }
 
         /// <summary>
+        ///     Gets a value indicating whether to use the internal queue for upload transfers. (Default = enable).
+        /// </summary>
+        public bool EnableUploadQueue { get; }
+
+        /// <summary>
         ///     Gets the delegate invoked upon an receipt of an incoming <see cref="QueueDownloadRequest"/>. (Default = do nothing).
         /// </summary>
         /// <remarks>
@@ -289,6 +305,11 @@ namespace Soulseek
         ///     Gets the options for peer transfer connections.
         /// </summary>
         public ConnectionOptions TransferConnectionOptions { get; }
+
+        /// <summary>
+        ///     Gets the number of allowed concurrent uploads. (Default = 5).
+        /// </summary>
+        public int UploadSlots { get; }
 
         /// <summary>
         ///     Gets the user endpoint cache to use when resolving user endpoints.

--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -103,7 +103,7 @@ namespace Soulseek
             bool enableDistributedNetwork = true,
             bool acceptDistributedChildren = true,
             int distributedChildLimit = 25,
-            bool enableUploadQueue = true,
+            bool enableUploadQueue = false,
             int uploadSlots = 5,
             bool deduplicateSearchRequests = true,
             int messageTimeout = 5000,
@@ -238,7 +238,7 @@ namespace Soulseek
         public bool EnableListener { get; }
 
         /// <summary>
-        ///     Gets a value indicating whether to use the internal queue for upload transfers. (Default = enable).
+        ///     Gets a value indicating whether to use the internal queue for upload transfers. (Default = disable).
         /// </summary>
         public bool EnableUploadQueue { get; }
 

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.3.2</Version>
+    <Version>3.4.0</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -96,6 +96,8 @@ namespace Soulseek
 #pragma warning restore S3427 // Method overloads with default parameter values should not overlap
             Options = options ?? new SoulseekClientOptions();
 
+            UploadSlotSemaphore = new SemaphoreSlim(initialCount: Options.UploadSlots, maxCount: Options.UploadSlots);
+
             ServerConnection = serverConnection;
 
             Waiter = waiter ?? new Waiter(Options.MessageTimeout);
@@ -445,6 +447,7 @@ namespace Soulseek
         private SemaphoreSlim StateSyncRoot { get; } = new SemaphoreSlim(1, 1);
         private ITokenFactory TokenFactory { get; }
         private ConcurrentDictionary<string, SemaphoreSlim> UploadSemaphores { get; } = new ConcurrentDictionary<string, SemaphoreSlim>();
+        private SemaphoreSlim UploadSlotSemaphore { get; }
         private ConcurrentDictionary<string, SemaphoreSlim> UserEndPointSemaphores { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
         /// <summary>
@@ -3631,12 +3634,13 @@ namespace Soulseek
                 TransferProgressUpdated?.Invoke(this, eventArgs);
             }
 
-            // fetch (or create) the semaphore for this user. the official client can't handle concurrent downloads, so we need to
-            // enforce this regardless of what downstream implementations do.
-            var semaphore = UploadSemaphores.GetOrAdd(username, new SemaphoreSlim(1, 1));
+            // fetch (or create) the semaphore for this user. Soulseek NS can't handle concurrent downloads from the same source,
+            // so we need to enforce this regardless of what downstream implementations do.
+            var semaphore = UploadSemaphores.GetOrAdd(username, new SemaphoreSlim(initialCount: 1, maxCount: 1));
 
             IPEndPoint endpoint = null;
             bool semaphoreAcquired = false;
+            bool slotAcquired = false;
 
             try
             {
@@ -3656,6 +3660,21 @@ namespace Soulseek
 
                 // in case the upload record was removed via cleanup while we were waiting, add it back.
                 semaphore = UploadSemaphores.AddOrUpdate(username, semaphore, (k, v) => semaphore);
+
+                if (Options.EnableUploadQueue)
+                {
+                    try
+                    {
+                        await UploadSlotSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        throw new OperationCanceledException("Operation cancelled", ex, cancellationToken);
+                    }
+
+                    Diagnostic.Debug($"Upload slot acquired");
+                    slotAcquired = true;
+                }
 
                 endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
                 var messageConnection = await PeerConnectionManager
@@ -3828,7 +3847,13 @@ namespace Soulseek
                 if (semaphoreAcquired)
                 {
                     Diagnostic.Debug($"Upload semaphore for {username} released");
-                    semaphore.Release();
+                    semaphore.Release(releaseCount: 1);
+                }
+
+                if (slotAcquired)
+                {
+                    Diagnostic.Info($"Upload slot released");
+                    UploadSlotSemaphore.Release(releaseCount: 1);
                 }
 
                 upload.Connection?.Dispose();

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
@@ -35,6 +35,8 @@ namespace Soulseek.Tests.Unit.Options
             bool enableDistributedNetwork,
             bool acceptDistributedChildren,
             int distributedChildLimit,
+            bool enableUploadQueue,
+            int uploadSlots,
             bool deduplicateSearchRequests,
             int messageTimeout,
             bool autoAcknowledgePrivateMessages,
@@ -68,6 +70,8 @@ namespace Soulseek.Tests.Unit.Options
                 enableDistributedNetwork: enableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit,
+                enableUploadQueue: enableUploadQueue,
+                uploadSlots: uploadSlots,
                 deduplicateSearchRequests: deduplicateSearchRequests,
                 messageTimeout: messageTimeout,
                 autoAcknowledgePrivateMessages: autoAcknowledgePrivateMessages,
@@ -94,6 +98,8 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(enableDistributedNetwork, o.EnableDistributedNetwork);
             Assert.Equal(acceptDistributedChildren, o.AcceptDistributedChildren);
             Assert.Equal(distributedChildLimit, o.DistributedChildLimit);
+            Assert.Equal(enableUploadQueue, o.EnableDistributedNetwork);
+            Assert.Equal(uploadSlots, o.UploadSlots);
             Assert.Equal(deduplicateSearchRequests, o.DeduplicateSearchRequests);
             Assert.Equal(messageTimeout, o.MessageTimeout);
             Assert.Equal(autoAcknowledgePrivateMessages, o.AutoAcknowledgePrivateMessages);
@@ -195,6 +201,28 @@ namespace Soulseek.Tests.Unit.Options
         {
             SoulseekClientOptions x;
             var ex = Record.Exception(() => x = new SoulseekClientOptions(distributedChildLimit: -1));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentOutOfRangeException>(ex);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Throws if upload slots are zero")]
+        public void Throws_If_Upload_Slots_Are_Zero()
+        {
+            SoulseekClientOptions x;
+            var ex = Record.Exception(() => x = new SoulseekClientOptions(uploadSlots: 0));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentOutOfRangeException>(ex);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Throws if upload slots are negative")]
+        public void Throws_If_Upload_Slots_Are_Negative()
+        {
+            SoulseekClientOptions x;
+            var ex = Record.Exception(() => x = new SoulseekClientOptions(uploadSlots: -1));
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentOutOfRangeException>(ex);


### PR DESCRIPTION
This PR adds an extremely basic, first-come-first-served upload queue.   The "queue" is just a semaphore, and each upload must acquire it before it can proceed.

Uploads attempt to obtain the "queue" semaphore after they obtain the existing semaphore that limits concurrent uploads to each user to 1.  The ordering of the queue follows the order in which uploads are ready on a per user basis.  This leads to a more-or-less fair round robin style implementation.

It should be noted that this is a poor substitution for a properly designed queue; there's no control over or visibility into the order, the order is not preserved between application restarts (neither is any official client, but that's not the point), and more importantly, it results in every queued upload winding up as an async state machine with an open stream to the file to be uploaded, which is not easy on system resources and will lock files the entire time they are in the queue.  All that being said, it is better than nothing.

Adds two new options:

* `EnableUploadQueue` to enable or disable the queue (defaults to false)
* `UploadSlots` to control the total number of concurrent uploads (defaults to 5)

Related to #633