### PR TITLE
Don't send child depth when updating distributed status

### DIFF
--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -703,14 +703,13 @@ namespace Soulseek.Network
             {
                 var branchLevel = BranchLevel;
                 var branchRoot = BranchRoot;
-                var childDepth = ChildDictionary.Count;
                 var canAcceptChildren = CanAcceptChildren;
                 var haveNoParents = Enabled && !HasParent;
 
                 var status = new StringBuilder()
                     .Append($"Requesting parent: {haveNoParents}, ")
                     .Append($"Branch level: {branchLevel}, Branch root: {branchRoot}, ")
-                    .Append($"Number of children: {childDepth}/{ChildLimit}, Accepting children: {canAcceptChildren}");
+                    .Append($"Number of children: {ChildDictionary.Count}/{ChildLimit}, Accepting children: {canAcceptChildren}");
 
                 if (!status.ToString().Equals(LastStatus, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -722,7 +721,6 @@ namespace Soulseek.Network
 
                         payload.AddRange(new BranchLevelCommand(branchLevel).ToByteArray());
                         payload.AddRange(new BranchRootCommand(branchRoot).ToByteArray());
-                        payload.AddRange(new ChildDepthCommand(childDepth).ToByteArray());
                         payload.AddRange(new AcceptChildrenCommand(canAcceptChildren).ToByteArray());
                         payload.AddRange(new HaveNoParentsCommand(haveNoParents).ToByteArray());
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/OutgoingTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/OutgoingTests.cs
@@ -83,6 +83,32 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         }
 
         [Trait("Category", "Instantiation")]
+        [Trait("Request", "ChildDepthCommand")]
+        [Theory(DisplayName = "ChildDepthCommand instantiates properly"), AutoData]
+        public void ChildDepthCommand_Instantiates_Properly(int depth)
+        {
+            var msg = new ChildDepthCommand(depth);
+
+            Assert.Equal(depth, msg.Depth);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Trait("Request", "ChildDepthCommand")]
+        [Theory(DisplayName = "ChildDepthCommand constructs the correct message"), AutoData]
+        public void ChildDepthCommand_Constructs_The_Correct_Message(int depth)
+        {
+            var msg = new ChildDepthCommand(depth).ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Server>(msg);
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Server.ChildDepth, code);
+
+            Assert.Equal(4 + 4 + 4, msg.Length);
+            Assert.Equal(depth, reader.ReadInteger());
+        }
+
+        [Trait("Category", "Instantiation")]
         [Trait("Request", "AcknowledgePrivateMessage")]
         [Fact(DisplayName = "AcknowledgePrivateMessage instantiates properly")]
         public void AcknowledgePrivateMessage_Instantiates_Properly()

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -1763,7 +1763,7 @@ namespace Soulseek.Tests.Unit.Network
         [Fact(DisplayName = "UpdateStatusAsync writes expected payload to server")]
         internal async Task UpdateStatusAsync_Writes_Expected_Payload_To_Server()
         {
-            var expectedPayload = Convert.FromBase64String("CAAAAH4AAAABAAAACAAAAH8AAAAAAAAACAAAAIEAAAAAAAAABQAAAGQAAAABBQAAAEcAAAAA");
+            var expectedPayload = Convert.FromBase64String("CAAAAH4AAAABAAAACAAAAH8AAAAAAAAABQAAAGQAAAABBQAAAEcAAAAA");
 
             var (manager, mocks) = GetFixture();
 
@@ -1791,7 +1791,7 @@ namespace Soulseek.Tests.Unit.Network
         [Fact(DisplayName = "UpdateStatusAsync writes HaveNoParents = false if disabled")]
         internal async Task UpdateStatusAsync_Writes_HaveNoParents_False_If_Disabled()
         {
-            var expectedPayload = Convert.FromBase64String("CAAAAH4AAAAAAAAACAAAAH8AAAAAAAAACAAAAIEAAAAAAAAABQAAAGQAAAAABQAAAEcAAAAA");
+            var expectedPayload = Convert.FromBase64String("CAAAAH4AAAAAAAAACAAAAH8AAAAAAAAABQAAAGQAAAAABQAAAEcAAAAA");
 
             var (manager, mocks) = GetFixture();
 


### PR DESCRIPTION
Closes #641 