### PR TITLE
Add UploadSlotsPerUser option

### DIFF
--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -312,6 +312,15 @@ namespace Soulseek
         public int UploadSlots { get; }
 
         /// <summary>
+        ///     Gets the number of upload slots per user.
+        /// </summary>
+        /// <remarks>
+        ///     This can be set with reflection for experimentation.  It needs to remain 1 in production
+        ///     to avoid causing problems with Soulseek NS.
+        /// </remarks>
+        public int UploadSlotsPerUser { get; private set; } = 1;
+
+        /// <summary>
         ///     Gets the user endpoint cache to use when resolving user endpoints.
         /// </summary>
         public IUserEndPointCache UserEndPointCache { get; }

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3636,7 +3636,7 @@ namespace Soulseek
 
             // fetch (or create) the semaphore for this user. Soulseek NS can't handle concurrent downloads from the same source,
             // so we need to enforce this regardless of what downstream implementations do.
-            var semaphore = UploadSemaphores.GetOrAdd(username, new SemaphoreSlim(initialCount: 1, maxCount: 1));
+            var semaphore = UploadSemaphores.GetOrAdd(username, new SemaphoreSlim(initialCount: Options.UploadSlotsPerUser, maxCount: Options.UploadSlotsPerUser));
 
             IPEndPoint endpoint = null;
             bool semaphoreAcquired = false;
@@ -3657,7 +3657,7 @@ namespace Soulseek
                 if (Options.EnableUploadQueue)
                 {
                     await UploadSlotSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    
+
                     Diagnostic.Debug($"Upload slot acquired");
                     slotAcquired = true;
                 }

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
@@ -129,6 +129,17 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(userInfoResponseResolver, o.UserInfoResponseResolver);
             Assert.Equal(enqueueDownloadAction, o.EnqueueDownloadAction);
             Assert.Equal(placeInQueueResponseResolver, o.PlaceInQueueResponseResolver);
+
+            Assert.Equal(1, o.UploadSlotsPerUser);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Instantiates with UploadSlotsPerUser set to 1")]
+        public void Instantiates_With_UploadSlotsPerUser_1()
+        {
+            var o = new SoulseekClientOptions();
+
+            Assert.Equal(1, o.UploadSlotsPerUser);
         }
 
         [Trait("Category", "Instantiation")]


### PR DESCRIPTION
This option is initially 1, and can only be set via reflection.  I'd like to experiment with concurrent downloads from slskd, and this is the easiest way to do that.

Anyone that stumbles upon this option should understand that changing this to anything other than 1 will either deadlock all uploads (if set to 0), or cause most uploads to users using Soulseek NS to fail (if set to > 1).