### PR TITLE
Require a restart if AcceptDistributedChildren is changed to false

### DIFF
--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3410,9 +3410,13 @@ namespace Soulseek
                 bool reconnectRequired = false;
 
                 var enableDistributedNetworkChanged = patch.EnableDistributedNetwork.HasValue && patch.EnableDistributedNetwork.Value != Options.EnableDistributedNetwork;
+                var acceptDistributedChildrenChanged = patch.AcceptDistributedChildren.HasValue && patch.AcceptDistributedChildren.Value != Options.AcceptDistributedChildren;
                 var distributedConnectionOptionsChanged = patch.DistributedConnectionOptions != null && patch.DistributedConnectionOptions != Options.DistributedConnectionOptions;
 
-                if (connected && ((enableDistributedNetworkChanged && !patch.EnableDistributedNetwork.Value) || distributedConnectionOptionsChanged))
+                var distribledNetworkWasDisabled = enableDistributedNetworkChanged && !patch.EnableDistributedNetwork.Value;
+                var distributedChildrenWereDisabled = acceptDistributedChildrenChanged && !patch.AcceptDistributedChildren.Value;
+
+                if (connected && (distribledNetworkWasDisabled || distributedChildrenWereDisabled || distributedConnectionOptionsChanged))
                 {
                     // reconnect to avoid state issues that might be caused by disabling this on the fly. if we are disabling the
                     // big concerns are in half-open parent or child connections; we can stop the server from sending

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -19,7 +19,6 @@ namespace Soulseek.Tests.Unit.Client
 {
     using System;
     using System.Net;
-    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
@@ -113,12 +112,48 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Returns true if client connected and AcceptDistributedChildren changed to false")]
+        public async Task Returns_True_If_Client_Connected_And_AcceptDistributedChildren_Changed_To_False()
+        {
+            var (client, _) = GetFixture(new SoulseekClientOptions(acceptDistributedChildren: true));
+
+            var patch = new SoulseekClientOptionsPatch(acceptDistributedChildren: false);
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var reconnectRequired = await client.ReconfigureOptionsAsync(patch);
+
+                Assert.True(reconnectRequired);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
         [Fact(DisplayName = "Returns false if client connected and EnableDistributedNetwork changed to true")]
         public async Task Returns_False_If_Client_Connected_And_EnableDistributedNetwork_Changed_To_True()
         {
             var (client, _) = GetFixture(new SoulseekClientOptions(enableDistributedNetwork: false));
 
             var patch = new SoulseekClientOptionsPatch(enableDistributedNetwork: true);
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var reconnectRequired = await client.ReconfigureOptionsAsync(patch);
+
+                Assert.False(reconnectRequired);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Returns false if client connected and AcceptDistributedChildren changed to true")]
+        public async Task Returns_False_If_Client_Connected_And_AcceptDistributedChildren_Changed_To_True()
+        {
+            var (client, _) = GetFixture(new SoulseekClientOptions(acceptDistributedChildren: false));
+
+            var patch = new SoulseekClientOptionsPatch(acceptDistributedChildren: true);
 
             using (client)
             {


### PR DESCRIPTION
Here's some existing documentation:

```c#
  // reconnect to avoid state issues that might be caused by disabling this on the fly. if we are disabling the
  // big concerns are in half-open parent or child connections; we can stop the server from sending
  // NetInfo/demote us from branch root by sending HaveNoParents=false. if changing from disabled to enabled,
  // there's no restart required.
```

This was written with regards to disabling the distributed network, and it also holds true for no longer accepting distributed children.  This PR updates the logic to detect when the option has been disabled, and requires a restart if so.

Closes #631 
