### PR TITLE
Add DownloadAsync() overload accepting a filename, remove Upload/DownloadAsync overloads working with byte arrays

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -127,7 +127,10 @@
             {
                 try
                 {
-                    var (transfer, bytes) = await client.DownloadAsync(username, file, startOffset: 0, token: index++, options: new TransferOptions(stateChanged: (e) =>
+                    var path = $"{OutputDirectory}{Path.DirectorySeparatorChar}{Path.GetDirectoryName(file).Replace(Path.GetDirectoryName(Path.GetDirectoryName(file)), "")}";
+                    var filename = Path.Combine(path, Path.GetFileName(file));
+
+                    var transfer = await client.DownloadAsync(username, file, filename, startOffset: 0, token: index++, options: new TransferOptions(stateChanged: (e) =>
                     {
                         var key = (e.Transfer.Username, e.Transfer.Filename, e.Transfer.Token);
                         var progress = Downloads.GetOrAdd(key, (e.Transfer.State, null, new ProgressBar(10)));
@@ -170,16 +173,11 @@
                     // normalize for both Windows and Linux by replacing / and \ with Path.DirectorySeparatorChar.
                     file = file.ToLocalOSPath();
 
-                    var path = $"{OutputDirectory}{Path.DirectorySeparatorChar}{Path.GetDirectoryName(file).Replace(Path.GetDirectoryName(Path.GetDirectoryName(file)), "")}";
 
                     if (!System.IO.Directory.Exists(path))
                     {
                         System.IO.Directory.CreateDirectory(path);
                     }
-
-                    var filename = Path.Combine(path, Path.GetFileName(file));
-
-                    System.IO.File.WriteAllBytes(filename, bytes);
                 }
                 catch (Exception ex)
                 {

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -472,12 +472,13 @@ namespace Soulseek
 
         /// <summary>
         ///     <para>
-        ///         Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///         using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/> to the
-        ///         specified <paramref name="localFilename"/>.
+        ///         Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified
+        ///         <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
+        ///         <paramref name="cancellationToken"/> to the specified <paramref name="localFilename"/>.
         ///     </para>
         ///     <para>
-        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise, it is overwritten.
+        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is
+        ///         appended. Otherwise, it is overwritten.
         ///     </para>
         /// </summary>
         /// <remarks>
@@ -497,7 +498,8 @@ namespace Soulseek
         ///     file contents.
         /// </returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or
+        ///     <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -505,8 +507,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -516,9 +518,9 @@ namespace Soulseek
         Task<Transfer> DownloadAsync(string username, string remoteFilename, string localFilename, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>
-        ///     to the specified <paramref name="outputStream"/>.
+        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
+        ///     <paramref name="cancellationToken"/> to the specified <paramref name="outputStream"/>.
         /// </summary>
         /// <remarks>
         ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
@@ -534,7 +536,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only
+        ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -546,8 +549,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -588,12 +591,13 @@ namespace Soulseek
 
         /// <summary>
         ///     <para>
-        ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///         using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>. to the
-        ///         specified <paramref name="localFilename"/>.
+        ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified
+        ///         <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
+        ///         <paramref name="cancellationToken"/>. to the specified <paramref name="localFilename"/>.
         ///     </para>
         ///     <para>
-        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise, it is overwritten.
+        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is
+        ///         appended. Otherwise, it is overwritten.
         ///     </para>
         ///     <para>
         ///         Functionally the same as
@@ -618,7 +622,8 @@ namespace Soulseek
         ///     file contents.
         /// </returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or
+        ///     <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -626,8 +631,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -662,7 +667,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous download operation.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only
+        ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -674,8 +680,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -1154,8 +1160,9 @@ namespace Soulseek
         Task StopPublicChatAsync(CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified <paramref name="localFilename"/> to the the
-        ///     specified <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
+        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="localFilename"/> to the the specified <paramref name="username"/> using the specified unique
+        ///     <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
@@ -1165,7 +1172,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or
+        ///     <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="FileNotFoundException">
         ///     Thrown when the specified <paramref name="localFilename"/> can not be found.
@@ -1173,8 +1181,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified <paramref name="username"/> is
-        ///     already in progress.
+        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -1184,9 +1192,9 @@ namespace Soulseek
         Task<Transfer> UploadAsync(string username, string remoteFilename, string localFilename, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified <paramref name="inputStream"/>
-        ///     to the the specified <paramref name="username"/> using the specified unique <paramref name="token"/> and
-        ///     optionally specified <paramref name="cancellationToken"/>.
+        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="inputStream"/> to the the specified <paramref name="username"/> using the specified unique
+        ///     <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
@@ -1197,7 +1205,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only
+        ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="size"/> is less than 1.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the specified <paramref name="inputStream"/> is null.</exception>
@@ -1207,8 +1216,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified <paramref name="username"/> is
-        ///     already in progress.
+        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -510,6 +510,47 @@ namespace Soulseek
 
         /// <summary>
         ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
+        ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>. If
+        ///     the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise,
+        ///     it is overwritten.
+        /// </summary>
+        /// <remarks>
+        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
+        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        /// </remarks>
+        /// <param name="username">The user from which to download the file.</param>
+        /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
+        /// <param name="localFilename">The fully qualified filename of the destination file.</param>
+        /// <param name="size">The size of the file, in bytes.</param>
+        /// <param name="startOffset">The offset at which to start the download, in bytes.</param>
+        /// <param name="token">The unique download token.</param>
+        /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        ///     The Task representing the asynchronous operation, including the transfer context and a byte array containing the
+        ///     file contents.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
+        /// <exception cref="DuplicateTransferException">
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
+        ///     is already in progress.
+        /// </exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
+        /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        Task<Transfer> DownloadAsync(string username, string remoteFilename, string localFilename, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
         ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>
         ///     to the specified <paramref name="outputStream"/>.
         /// </summary>
@@ -1174,19 +1215,16 @@ namespace Soulseek
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
-        /// <param name="localFilename">The file contents.</param>
+        /// <param name="localFilename">The fully qualified filename of the file to upload.</param>
         /// <param name="token">The unique upload token.</param>
         /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="FileNotFoundException">
         ///     Thrown when the specified <paramref name="localFilename"/> can not be found.
-        /// </exception>
-        /// <exception cref="IOException">
-        ///     Thrown when the specified <paramref name="localFilename"/> can not be opened for reading.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -471,48 +471,14 @@ namespace Soulseek
         void Disconnect(string message = null, Exception exception = null);
 
         /// <summary>
-        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
-        /// </summary>
-        /// <remarks>
-        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
-        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
-        /// </remarks>
-        /// <param name="username">The user from which to download the file.</param>
-        /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
-        /// <param name="size">The size of the file, in bytes.</param>
-        /// <param name="startOffset">The offset at which to start the download, in bytes.</param>
-        /// <param name="token">The unique download token.</param>
-        /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>
-        ///     The Task representing the asynchronous operation, including the transfer context and a byte array containing the
-        ///     file contents.
-        /// </returns>
-        /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
-        /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
-        /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
-        /// </exception>
-        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
-        /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
-        /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
-        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<(Transfer Transfer, byte[] Data)> DownloadAsync(string username, string remoteFilename, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
-
-        /// <summary>
-        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>. If
-        ///     the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise,
-        ///     it is overwritten.
+        ///     <para>
+        ///         Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
+        ///         using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/> to the
+        ///         specified <paramref name="localFilename"/>.
+        ///     </para>
+        ///     <para>
+        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise, it is overwritten.
+        ///     </para>
         /// </summary>
         /// <remarks>
         ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
@@ -622,13 +588,17 @@ namespace Soulseek
 
         /// <summary>
         ///     <para>
-        ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified
-        ///         <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
+        ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
+        ///         using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>. to the
+        ///         specified <paramref name="localFilename"/>.
+        ///     </para>
+        ///     <para>
+        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise, it is overwritten.
         ///     </para>
         ///     <para>
         ///         Functionally the same as
-        ///         <see cref="DownloadAsync(string, string, long?, long, int?, TransferOptions, CancellationToken?)"/>, but
-        ///         returns the download Task as soon as the download has been remotely enqueued.
+        ///         <see cref="DownloadAsync(string, string, Stream, long?, long, int?, TransferOptions, CancellationToken?)"/>,
+        ///         but returns the download Task as soon as the download has been remotely enqueued.
         ///     </para>
         /// </summary>
         /// <remarks>
@@ -637,14 +607,18 @@ namespace Soulseek
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
+        /// <param name="localFilename">The fully qualified filename of the destination file.</param>
         /// <param name="size">The size of the file, in bytes.</param>
         /// <param name="startOffset">The offset at which to start the download, in bytes.</param>
         /// <param name="token">The unique download token.</param>
         /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>The Task representing the asynchronous download operation.</returns>
+        /// <returns>
+        ///     The Task representing the asynchronous operation, including the transfer context and a byte array containing the
+        ///     file contents.
+        /// </returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -660,7 +634,7 @@ namespace Soulseek
         /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<Task<(Transfer Transfer, byte[] Data)>> EnqueueDownloadAsync(string username, string remoteFilename, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
+        Task<Task<Transfer>> EnqueueDownloadAsync(string username, string remoteFilename, string localFilename, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     <para>
@@ -1178,36 +1152,6 @@ namespace Soulseek
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
         Task StopPublicChatAsync(CancellationToken? cancellationToken = null);
-
-        /// <summary>
-        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> containing <paramref name="data"/> to the the
-        ///     specified <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
-        /// </summary>
-        /// <param name="username">The user to which to upload the file.</param>
-        /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
-        /// <param name="data">The file contents.</param>
-        /// <param name="token">The unique upload token.</param>
-        /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
-        /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     Thrown when the specified <paramref name="data"/> is null or of zero length.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
-        /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
-        /// <exception cref="DuplicateTransferException">
-        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified <paramref name="username"/> is
-        ///     already in progress.
-        /// </exception>
-        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
-        /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
-        /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
-        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<Transfer> UploadAsync(string username, string remoteFilename, byte[] data, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified <paramref name="localFilename"/> to the the

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -447,11 +447,11 @@ namespace Soulseek
         private IConnectionFactory ConnectionFactory { get; }
         private IDiagnosticFactory Diagnostic { get; }
         private bool Disposed { get; set; } = false;
+        private SemaphoreSlim GlobalUploadSemaphore { get; }
         private IIOAdapter IOAdapter { get; set; } = new IOAdapter();
         private SemaphoreSlim StateSyncRoot { get; } = new SemaphoreSlim(1, 1);
         private ITokenFactory TokenFactory { get; }
         private ConcurrentDictionary<string, SemaphoreSlim> UploadSemaphores { get; } = new ConcurrentDictionary<string, SemaphoreSlim>();
-        private SemaphoreSlim GlobalUploadSemaphore { get; }
         private ConcurrentDictionary<string, SemaphoreSlim> UserEndPointSemaphores { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
         /// <summary>
@@ -872,12 +872,13 @@ namespace Soulseek
 
         /// <summary>
         ///     <para>
-        ///         Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///         using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/> to the
-        ///         specified <paramref name="localFilename"/>.
+        ///         Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified
+        ///         <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
+        ///         <paramref name="cancellationToken"/> to the specified <paramref name="localFilename"/>.
         ///     </para>
         ///     <para>
-        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise, it is overwritten.
+        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is
+        ///         appended. Otherwise, it is overwritten.
         ///     </para>
         /// </summary>
         /// <remarks>
@@ -897,7 +898,8 @@ namespace Soulseek
         ///     file contents.
         /// </returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or
+        ///     <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -905,8 +907,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -963,9 +965,9 @@ namespace Soulseek
         }
 
         /// <summary>
-        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>
-        ///     to the specified <paramref name="outputStream"/>.
+        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
+        ///     <paramref name="cancellationToken"/> to the specified <paramref name="outputStream"/>.
         /// </summary>
         /// <remarks>
         ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
@@ -981,7 +983,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only
+        ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -993,8 +996,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -1113,12 +1116,13 @@ namespace Soulseek
 
         /// <summary>
         ///     <para>
-        ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///         using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>. to the
-        ///         specified <paramref name="localFilename"/>.
+        ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified
+        ///         <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
+        ///         <paramref name="cancellationToken"/>. to the specified <paramref name="localFilename"/>.
         ///     </para>
         ///     <para>
-        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise, it is overwritten.
+        ///         If the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is
+        ///         appended. Otherwise, it is overwritten.
         ///     </para>
         ///     <para>
         ///         Functionally the same as
@@ -1143,7 +1147,8 @@ namespace Soulseek
         ///     file contents.
         /// </returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or
+        ///     <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -1151,8 +1156,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -1217,7 +1222,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous download operation.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only
+        ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
@@ -1229,8 +1235,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
-        ///     is already in progress.
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -2263,8 +2269,9 @@ namespace Soulseek
         }
 
         /// <summary>
-        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified <paramref name="localFilename"/> to the the
-        ///     specified <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
+        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="localFilename"/> to the the specified <paramref name="username"/> using the specified unique
+        ///     <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
@@ -2274,7 +2281,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or
+        ///     <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="FileNotFoundException">
         ///     Thrown when the specified <paramref name="localFilename"/> can not be found.
@@ -2282,8 +2290,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified <paramref name="username"/> is
-        ///     already in progress.
+        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -2344,9 +2352,9 @@ namespace Soulseek
         }
 
         /// <summary>
-        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified <paramref name="inputStream"/>
-        ///     to the the specified <paramref name="username"/> using the specified unique <paramref name="token"/> and
-        ///     optionally specified <paramref name="cancellationToken"/>.
+        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified
+        ///     <paramref name="inputStream"/> to the the specified <paramref name="username"/> using the specified unique
+        ///     <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
@@ -2357,7 +2365,8 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only
+        ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="size"/> is less than 1.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the specified <paramref name="inputStream"/> is null.</exception>
@@ -2367,8 +2376,8 @@ namespace Soulseek
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
         /// <exception cref="DuplicateTransferException">
-        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified <paramref name="username"/> is
-        ///     already in progress.
+        ///     Thrown when an upload of the specified <paramref name="remoteFilename"/> to the specified
+        ///     <paramref name="username"/> is already in progress.
         /// </exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
@@ -3660,8 +3669,8 @@ namespace Soulseek
                 TransferProgressUpdated?.Invoke(this, eventArgs);
             }
 
-            // fetch (or create) an upload semaphore for this user. Soulseek NS can't handle concurrent downloads from the same source,
-            // so we need to enforce this regardless of what downstream implementations do.
+            // fetch (or create) an upload semaphore for this user. Soulseek NS can't handle concurrent downloads from the same
+            // source, so we need to enforce this regardless of what downstream implementations do.
             var semaphore = UploadSemaphores.GetOrAdd(username, new SemaphoreSlim(initialCount: Options.MaximumConcurrentUploadsPerUser, maxCount: Options.MaximumConcurrentUploadsPerUser));
 
             IPEndPoint endpoint = null;
@@ -3675,20 +3684,18 @@ namespace Soulseek
             {
                 UpdateState(TransferStates.Queued);
 
-                // permissive stage 1:
-                // acquire the per-user semaphore to ensure we aren't trying to process more than the allotted
-                // concurrent uploads to this user, and ensure that we aren't trying to acquire a slot for an upload
-                // until the requesting user is ready to receive it
+                // permissive stage 1: acquire the per-user semaphore to ensure we aren't trying to process more than the allotted
+                // concurrent uploads to this user, and ensure that we aren't trying to acquire a slot for an upload until the
+                // requesting user is ready to receive it
                 await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 Diagnostic.Debug($"Upload semaphore for file {Path.GetFileName(upload.Filename)} to {username} acquired");
                 semaphoreAcquired = true;
 
-                // in case the upload record was removed via cleanup while we were waiting, add it back.  this will happen
-                // more often than not if a user enqueues more than 1 file at a time, so this is important.
+                // in case the upload record was removed via cleanup while we were waiting, add it back. this will happen more
+                // often than not if a user enqueues more than 1 file at a time, so this is important.
                 semaphore = UploadSemaphores.AddOrUpdate(username, semaphore, (k, v) => semaphore);
 
-                // permissive stage 2:
-                // acquire an upload slot from the calling code
+                // permissive stage 2: acquire an upload slot from the calling code
                 try
                 {
                     await options.SlotAwaiter(new Transfer(upload), cancellationToken).ConfigureAwait(false);
@@ -3700,18 +3707,15 @@ namespace Soulseek
                     throw new TransferException($"Failed to acquire an upload slot for file {Path.GetFileName(upload.Filename)} to {username}: {ex.Message}", ex);
                 }
 
-                // permissive stage 3:
-                // acquire the global upload semaphore to ensure we aren't trying to process
-                // more than the total allotted concurrent uploads globally.  if we hit this limit,
-                // uploads will stack up behind it and will be processed in a round-robin-like fashion
-                // due to the limit on per-user concurrency.  calling code can avoid this by providing
-                // an implementation of AcquireSlot() that won't exceed the maximum concurrent upload limit
+                // permissive stage 3: acquire the global upload semaphore to ensure we aren't trying to process more than the
+                // total allotted concurrent uploads globally. if we hit this limit, uploads will stack up behind it and will be
+                // processed in a round-robin-like fashion due to the limit on per-user concurrency. calling code can avoid this
+                // by providing an implementation of AcquireSlot() that won't exceed the maximum concurrent upload limit
                 await GlobalUploadSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 Diagnostic.Debug($"Global upload semaphore for file {Path.GetFileName(upload.Filename)} to {username} acquired");
                 globalSemaphoreAcquired = true;
 
-                // all permissives have been given
-                // fetch the user endpoint and request that the transfer begins
+                // all permissives have been given fetch the user endpoint and request that the transfer begins
                 endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
                 var messageConnection = await PeerConnectionManager
                     .GetOrAddMessageConnectionAsync(username, endpoint, cancellationToken)
@@ -3848,9 +3852,8 @@ namespace Soulseek
 
                 Diagnostic.Debug(ex.ToString());
 
-                // cancelled async operations can throw TaskCanceledException, which is a
-                // subclass of OperationCanceledException, but we want to be deterministic,
-                // so wrap and re-throw them.
+                // cancelled async operations can throw TaskCanceledException, which is a subclass of OperationCanceledException,
+                // but we want to be deterministic, so wrap and re-throw them.
                 throw new OperationCanceledException("Operation cancelled", ex, cancellationToken);
             }
             catch (TimeoutException ex)
@@ -3884,8 +3887,8 @@ namespace Soulseek
                 // threads waiting on it, and it is added back after it is awaited above.
                 UploadSemaphores.TryRemove(username, out var _);
 
-                // make sure we successfully obtained all permissives before releasing them.  some of them may not have been attempted
-                // if the code throws.
+                // make sure we successfully obtained all permissives before releasing them. some of them may not have been
+                // attempted if the code throws.
                 if (semaphoreAcquired)
                 {
                     Diagnostic.Debug($"Upload semaphore for file {Path.GetFileName(upload.Filename)} to {username} released");
@@ -3894,10 +3897,9 @@ namespace Soulseek
 
                 if (uploadSlotAcquired)
                 {
-                    // give the next thread time to acquire the semaphore.  this is extremely sub-optimal,
-                    // but if there's a waiting upload we want the code within AcquireSlot() to be aware of it
-                    // before we release the slot.  10ms should be plenty of time, as this release and the subsequent
-                    // thread acquiring it should happen within nanoseconds.
+                    // give the next thread time to acquire the semaphore. this is extremely sub-optimal, but if there's a waiting
+                    // upload we want the code within AcquireSlot() to be aware of it before we release the slot. 10ms should be
+                    // plenty of time, as this release and the subsequent thread acquiring it should happen within nanoseconds.
                     await Task.Delay(10, CancellationToken.None).ConfigureAwait(false);
 
                     Diagnostic.Debug($"Upload slot for file {Path.GetFileName(upload.Filename)} to {username} released");

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -952,6 +952,94 @@ namespace Soulseek
 
         /// <summary>
         ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
+        ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>. If
+        ///     the destination file exists and <paramref name="startOffset"/> is greater than zero, the existing file is appended. Otherwise,
+        ///     it is overwritten.
+        /// </summary>
+        /// <remarks>
+        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
+        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        /// </remarks>
+        /// <param name="username">The user from which to download the file.</param>
+        /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
+        /// <param name="localFilename">The fully qualified filename of the destination file.</param>
+        /// <param name="size">The size of the file, in bytes.</param>
+        /// <param name="startOffset">The offset at which to start the download, in bytes.</param>
+        /// <param name="token">The unique download token.</param>
+        /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        ///     The Task representing the asynchronous operation, including the transfer context and a byte array containing the
+        ///     file contents.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
+        /// <exception cref="DuplicateTransferException">
+        ///     Thrown when a download of the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
+        ///     is already in progress.
+        /// </exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
+        /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public Task<Transfer> DownloadAsync(string username, string remoteFilename, string localFilename, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                throw new ArgumentException("The username must not be a null or empty string, or one consisting only of whitespace", nameof(username));
+            }
+
+            if (string.IsNullOrWhiteSpace(remoteFilename))
+            {
+                throw new ArgumentException("The remote filename must not be a null or empty string, or one consisting only of whitespace", nameof(remoteFilename));
+            }
+
+            if (string.IsNullOrWhiteSpace(localFilename))
+            {
+                throw new ArgumentException("The local filename must not be a null or empty string, or one consisting only of whitespace", nameof(localFilename));
+            }
+
+            if (size.HasValue && size.Value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), "The size, if supplied, must be greater than or equal to zero");
+            }
+
+            if (startOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startOffset), "The start offset must be greater than or equal to zero");
+            }
+
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to download files (currently: {State})");
+            }
+
+            token ??= GetNextToken();
+
+            if (UploadDictionary.ContainsKey(token.Value) || DownloadDictionary.ContainsKey(token.Value))
+            {
+                throw new DuplicateTokenException($"The specified or generated token {token} is already in progress");
+            }
+
+            if (DownloadDictionary.Values.Any(d => d.Username == username && d.Filename == remoteFilename))
+            {
+                throw new DuplicateTransferException($"An active or queued download of {remoteFilename} from {username} is already in progress");
+            }
+
+            options ??= new TransferOptions();
+
+            return DownloadToFileAsync(username, remoteFilename, localFilename, size, startOffset, token.Value, options, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified <paramref name="username"/>
         ///     using the specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>
         ///     to the specified <paramref name="outputStream"/>.
         /// </summary>
@@ -2315,19 +2403,16 @@ namespace Soulseek
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
-        /// <param name="localFilename">The file contents.</param>
+        /// <param name="localFilename">The fully qualified filename of the file to upload.</param>
         /// <param name="token">The unique upload token.</param>
         /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation, including the transfer context.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="remoteFilename"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/>, <paramref name="remoteFilename"/>, or <paramref name="localFilename"/> is null, empty, or consists only of whitespace.
         /// </exception>
         /// <exception cref="FileNotFoundException">
         ///     Thrown when the specified <paramref name="localFilename"/> can not be found.
-        /// </exception>
-        /// <exception cref="IOException">
-        ///     Thrown when the specified <paramref name="localFilename"/> can not be opened for reading.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
@@ -2849,6 +2934,20 @@ namespace Soulseek
                 var transfer = await DownloadToStreamAsync(username, remoteFilename, () => memoryStream, size, startOffset, token, options, cancellationToken).ConfigureAwait(false);
                 return (transfer, memoryStream.ToArray());
             }
+        }
+
+        private async Task<Transfer> DownloadToFileAsync(string username, string remoteFilename, string localFilename, long? size, long startOffset, int token, TransferOptions options, CancellationToken cancellationToken)
+        {
+            options = options.WithDisposalOptions(disposeOutputStreamOnCompletion: true);
+
+            var fileMode = FileMode.Create;
+
+            if (startOffset > 0)
+            {
+                fileMode = FileMode.Append;
+            }
+
+            return await DownloadToStreamAsync(username, remoteFilename, () => IOAdapter.GetFileStream(localFilename, fileMode, FileAccess.Write, FileShare.None), size, startOffset, token, options, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<Transfer> DownloadToStreamAsync(string username, string remoteFilename, Func<Stream> outputStreamFactory, long? size, long startOffset, int token, TransferOptions options, CancellationToken cancellationToken)

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -76,7 +76,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, "filename", "local"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -101,15 +101,31 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "DownloadAsync")]
-        [Theory(DisplayName = "DownloadAsync throws ArgumentException given bad filename")]
+        [Theory(DisplayName = "DownloadAsync throws ArgumentException given bad remote filename")]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public async Task DownloadAsync_Throws_ArgumentException_Given_Bad_Filename(string filename)
+        public async Task DownloadAsync_Throws_ArgumentException_Given_Bad_Remote_Filename(string filename)
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", filename));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", filename, "local"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+        }
+
+        [Trait("Category", "DownloadAsync")]
+        [Theory(DisplayName = "DownloadAsync throws ArgumentException given bad local filename")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task DownloadAsync_Throws_ArgumentException_Given_Bad_Local_Filename(string filename)
+        {
+            using (var s = new SoulseekClient())
+            {
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "remote", filename));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -169,7 +185,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "foo", size: -1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "remote", "local", size: -1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
@@ -183,7 +199,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "foo", startOffset: -1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "remote", "local", startOffset: -1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
@@ -197,7 +213,7 @@ namespace Soulseek.Tests.Unit.Client
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", "local"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -228,7 +244,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", "local"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -266,7 +282,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", "local", token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -287,7 +303,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("UploadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", "local", token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -352,7 +368,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, "local", token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -373,7 +389,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, "local", token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsNotType<DuplicateTransferException>(ex);
@@ -393,7 +409,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, "local", token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsNotType<DuplicateTransferException>(ex);
@@ -509,7 +525,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename));
+                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, "local"));
             }
 
             conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), CancellationToken.None), Times.Once);
@@ -526,7 +542,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, cancellationToken: cancellationToken));
+                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, "local", cancellationToken: cancellationToken));
             }
 
             conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
@@ -552,7 +568,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", "local"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserOfflineException>(ex);
@@ -581,7 +597,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename"));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", "local"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -618,9 +634,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferException when WriteAsync throws"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferException_When_WriteAsync_Throws(string username, IPEndPoint endpoint, string filename, int token)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferException when WriteAsync throws"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferException_When_WriteAsync_Throws(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 1);
 
@@ -646,7 +662,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -654,9 +670,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferException on TransferResponse timeout"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferException_On_TransferResponse_Timeout(string username, IPEndPoint endpoint, string filename, int token)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferException on TransferResponse timeout"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferException_On_TransferResponse_Timeout(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 1);
 
@@ -678,16 +694,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferException on TransferResponse cancellation"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferException_On_TransferResponse_Cancellation(string username, IPEndPoint endpoint, string filename, int token)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferException on TransferResponse cancellation"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferException_On_TransferResponse_Cancellation(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -711,16 +727,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferException on TransferRequest cancellation"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferException_On_TransferRequest_Cancellation(string username, IPEndPoint endpoint, string filename, int token)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferException on TransferRequest cancellation"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferException_On_TransferRequest_Cancellation(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -745,16 +761,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferException on download cancellation"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferException_On_Download_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferException on download cancellation"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferException_On_Download_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -793,16 +809,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TimeoutException on transfer response timeout"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TimeoutException_On_Transfer_Response_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TimeoutException on transfer response timeout"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TimeoutException_On_Transfer_Response_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -834,16 +850,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TimeoutException on read timeout"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TimeoutException_On_Read_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TimeoutException on read timeout"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TimeoutException_On_Read_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -884,17 +900,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                byte[] downloadedData = null;
-                var ex = await Record.ExceptionAsync(async () => (_, downloadedData) = await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferRejectedException when acknowledgement is disallowed and message contains 'File not shared'"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferRejectedException_When_Acknowledgement_Is_Disallowed_And_File_Not_Shared(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferRejectedException when acknowledgement is disallowed and message contains 'File not shared'"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferRejectedException_When_Acknowledgement_Is_Disallowed_And_File_Not_Shared(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -937,17 +952,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                byte[] downloadedData = null;
-                var ex = await Record.ExceptionAsync(async () => (_, downloadedData) = await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferRejectedException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync raises expected events on success when skipping queue"), AutoData]
-        public async Task DownloadToByteArrayAsync_Raises_Expected_Events_On_Success_When_Skipping_Queue(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync raises expected events on success when skipping queue"), AutoData]
+        public async Task DownloadToFileAsync_Raises_Expected_Events_On_Success_When_Skipping_Queue(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -997,7 +1011,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null);
 
                 Assert.Equal(5, events.Count);
 
@@ -1018,9 +1032,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync uses size from TransferResponse given null size when skipping queue"), AutoData]
-        public async Task DownloadToByteArrayAsync_Uses_Size_From_TransferResponse_Given_Null_Size_When_Skipping_Queue(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync uses size from TransferResponse given null size when skipping queue"), AutoData]
+        public async Task DownloadToFileAsync_Uses_Size_From_TransferResponse_Given_Null_Size_When_Skipping_Queue(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1070,7 +1084,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, null, 0, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", null, 0, token, new TransferOptions(), null);
             }
 
             transferConn.Verify(
@@ -1082,9 +1096,9 @@ namespace Soulseek.Tests.Unit.Client
                 Times.Once);
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync uses given size when skipping queue"), AutoData]
-        public async Task DownloadToByteArrayAsync_Uses_Size_Given_Size_When_Skipping_Queue(string username, IPEndPoint endpoint, string filename, int token, int size, long givenSize)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync uses given size when skipping queue"), AutoData]
+        public async Task DownloadToFileAsync_Uses_Size_Given_Size_When_Skipping_Queue(string username, IPEndPoint endpoint, string filename, int token, int size, long givenSize)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1134,7 +1148,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, givenSize, 0, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", givenSize, 0, token, new TransferOptions(), null);
             }
 
             transferConn.Verify(
@@ -1146,9 +1160,9 @@ namespace Soulseek.Tests.Unit.Client
                 Times.Once);
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync writes offset to connection"), AutoData]
-        public async Task DownloadToByteArrayAsync_Writes_Offset_To_Connection(string username, IPEndPoint endpoint, string filename, long offset, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync writes offset to connection"), AutoData]
+        public async Task DownloadToFileAsync_Writes_Offset_To_Connection(string username, IPEndPoint endpoint, string filename, long offset, int token, int size)
         {
             var response = new TransferResponse(token, size); // allowed, will start download immediately
             var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
@@ -1189,13 +1203,13 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, offset, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, offset, token, new TransferOptions(), null);
             }
 
             transferConn.Verify(m => m.WriteAsync(It.Is<byte[]>(b => BitConverter.ToInt64(b, 0) == offset), It.IsAny<CancellationToken>()));
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
+        [Trait("Category", "DownloadToFileAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync disposes output stream given option flag"), AutoData]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1481:Unused local variables should be removed", Justification = "Discard")]
         public async Task DownloadToStreamAsync_Disposes_Output_Stream_Given_Option_Flag(string username, IPEndPoint endpoint, string filename, int token, int size)
@@ -1255,7 +1269,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
+        [Trait("Category", "DownloadToFileAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync completes following normal transfer connection disconnect"), AutoData]
         public async Task DownloadToStreamAsync_Completes_Following_Normal_Transfer_Connection_Disconnect(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
@@ -1321,7 +1335,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
+        [Trait("Category", "DownloadToFileAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync throws TimeoutException on unexpected transfer connection timeout"), AutoData]
         public async Task DownloadToStreamAsync_Throws_TimeoutException_On_Unexpected_Transfer_Connection_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
@@ -1385,7 +1399,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
+        [Trait("Category", "DownloadToFileAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync throws OperationCanceledException on unexpected transfer connection cancellation"), AutoData]
         public async Task DownloadToStreamAsync_Throws_OperationCanceledException_On_Unexpected_Transfer_Connection_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
@@ -1449,7 +1463,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
+        [Trait("Category", "DownloadToFileAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync throws wrapped Exception on unexpected transfer connection Exception"), AutoData]
         public async Task DownloadToStreamAsync_Throws_Wrapped_Exception_On_Unexpected_Transfer_Connection_Exception(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
@@ -1518,7 +1532,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
+        [Trait("Category", "DownloadToFileAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync does not dispose output stream given no option flag"), AutoData]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1481:Unused local variables should be removed", Justification = "Discard")]
         public async Task DownloadToStreamAsync_Does_Not_Dispose_Output_Stream_Given_No_Option_Flag(string username, IPEndPoint endpoint, string filename, int token, int size)
@@ -1577,9 +1591,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync uses size from TransferResponse given null size when queued"), AutoData]
-        public async Task DownloadToByteArrayAsync_Uses_Size_From_TransferResponse_When_Queued(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync uses size from TransferResponse given null size when queued"), AutoData]
+        public async Task DownloadToFileAsync_Uses_Size_From_TransferResponse_When_Queued(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1629,7 +1643,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, null, 0, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", null, 0, token, new TransferOptions(), null);
             }
 
             transferConn.Verify(
@@ -1641,9 +1655,9 @@ namespace Soulseek.Tests.Unit.Client
                 Times.Once);
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync uses given size when queued"), AutoData]
-        public async Task DownloadToByteArrayAsync_Uses_Given_Size_When_Queued(string username, IPEndPoint endpoint, string filename, int token, int size, long givenSize)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync uses given size when queued"), AutoData]
+        public async Task DownloadToFileAsync_Uses_Given_Size_When_Queued(string username, IPEndPoint endpoint, string filename, int token, int size, long givenSize)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1693,7 +1707,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, givenSize, 0, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", givenSize, 0, token, new TransferOptions(), null);
             }
 
             transferConn.Verify(
@@ -1705,9 +1719,9 @@ namespace Soulseek.Tests.Unit.Client
                 Times.Once);
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync initiates a transfer if remote client does not initiate after a disallowed response"), AutoData]
-        public async Task DownloadToByteArrayAsync_Initiates_A_Transfer_If_Remote_Client_Does_Not_Initiate(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync initiates a transfer if remote client does not initiate after a disallowed response"), AutoData]
+        public async Task DownloadToFileAsync_Initiates_A_Transfer_If_Remote_Client_Does_Not_Initiate(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1754,7 +1768,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 var fired = false;
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(stateChanged: (e) => fired = true), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(stateChanged: (e) => fired = true), null);
 
                 Assert.True(fired);
             }
@@ -1762,9 +1776,9 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Verify(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync invokes StateChanged delegate on state change"), AutoData]
-        public async Task DownloadToByteArrayAsync_Invokes_StateChanged_Delegate_On_State_Change(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync invokes StateChanged delegate on state change"), AutoData]
+        public async Task DownloadToFileAsync_Invokes_StateChanged_Delegate_On_State_Change(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1809,15 +1823,15 @@ namespace Soulseek.Tests.Unit.Client
 
                 var fired = false;
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(stateChanged: (e) => fired = true), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(stateChanged: (e) => fired = true), null);
 
                 Assert.True(fired);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync raises DownloadProgressUpdated event on data read"), AutoData]
-        public async Task DownloadToByteArrayAsync_Raises_DownloadProgressUpdated_Event_On_Data_Read(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync raises DownloadProgressUpdated event on data read"), AutoData]
+        public async Task DownloadToFileAsync_Raises_DownloadProgressUpdated_Event_On_Data_Read(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1869,7 +1883,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.TransferProgressUpdated += (d, e) => events.Add(e);
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null);
 
                 Assert.Equal(3, events.Count);
                 Assert.Equal(TransferStates.InProgress, events[0].Transfer.State);
@@ -1878,9 +1892,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync invokes ProgressUpdated delegate on data read"), AutoData]
-        public async Task DownloadToByteArrayAsync_Invokes_ProgressUpdated_Delegate_On_Data_Read(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync invokes ProgressUpdated delegate on data read"), AutoData]
+        public async Task DownloadToFileAsync_Invokes_ProgressUpdated_Delegate_On_Data_Read(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1930,15 +1944,15 @@ namespace Soulseek.Tests.Unit.Client
 
                 var fired = false;
 
-                await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(progressUpdated: (e) => fired = true), null);
+                await s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(progressUpdated: (e) => fired = true), null);
 
                 Assert.True(fired);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync raises Download events on failure"), AutoData]
-        public async Task DownloadToByteArrayAsync_Raises_Download_Events_On_Failure(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync raises Download events on failure"), AutoData]
+        public async Task DownloadToFileAsync_Raises_Download_Events_On_Failure(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1988,7 +2002,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -1999,9 +2013,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync raises Download events on timeout"), AutoData]
-        public async Task DownloadToByteArrayAsync_Raises_Expected_Final_Event_On_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync raises Download events on timeout"), AutoData]
+        public async Task DownloadToFileAsync_Raises_Expected_Final_Event_On_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2051,7 +2065,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -2061,9 +2075,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync raises Download events on cancellation"), AutoData]
-        public async Task DownloadToByteArrayAsync_Raises_Expected_Final_Event_On_Cancellation(string username, string filename, int token)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync raises Download events on cancellation"), AutoData]
+        public async Task DownloadToFileAsync_Raises_Expected_Final_Event_On_Cancellation(string username, string filename, int token)
         {
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
@@ -2084,7 +2098,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -2093,9 +2107,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferException and ConnectionException on transfer exception"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferException_And_ConnectionException_On_Transfer_Exception(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferException and ConnectionException on transfer exception"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferException_And_ConnectionException_On_Transfer_Exception(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2140,7 +2154,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -2149,9 +2163,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TimeoutException on transfer timeout"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TimeoutException_On_Transfer_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TimeoutException on transfer timeout"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TimeoutException_On_Transfer_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2196,16 +2210,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws OperationCanceledException on cancellation"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_OperationCanceledException_On_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws OperationCanceledException on cancellation"), AutoData]
+        public async Task DownloadToFileAsync_Throws_OperationCanceledException_On_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2250,16 +2264,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws TransferRejectedException on transfer rejection"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_TransferRejectedException_On_Transfer_Rejection(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws TransferRejectedException on transfer rejection"), AutoData]
+        public async Task DownloadToFileAsync_Throws_TransferRejectedException_On_Transfer_Rejection(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2302,17 +2316,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                byte[] downloadedData = null;
-                var ex = await Record.ExceptionAsync(async () => (_, downloadedData) = await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferRejectedException>(ex);
             }
         }
 
-        [Trait("Category", "DownloadToByteArrayAsync")]
-        [Theory(DisplayName = "DownloadToByteArrayAsync throws ConnectionException when transfer connection fails"), AutoData]
-        public async Task DownloadToByteArrayAsync_Throws_ConnectionException_When_Transfer_Connection_Fails(string username, IPEndPoint endpoint, string filename, int token, int size)
+        [Trait("Category", "DownloadToFileAsync")]
+        [Theory(DisplayName = "DownloadToFileAsync throws ConnectionException when transfer connection fails"), AutoData]
+        public async Task DownloadToFileAsync_Throws_ConnectionException_When_Transfer_Connection_Fails(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2355,8 +2368,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                byte[] downloadedData = null;
-                var ex = await Record.ExceptionAsync(async () => (_, downloadedData) = await s.InvokeMethod<Task<(Transfer Transfer, byte[] Data)>>("DownloadToByteArrayAsync", username, filename, 0L, 0, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/EnqueueDownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/EnqueueDownloadAsyncTests.cs
@@ -45,7 +45,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, "filename"));
+                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, "filename", "local"));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -121,7 +121,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var downloadTask = await s.EnqueueDownloadAsync(username, filename, 0L, 0, token);
+                var downloadTask = await s.EnqueueDownloadAsync(username, filename, "local", 0L, 0, token);
 
                 Assert.NotNull(downloadTask);
 
@@ -129,10 +129,10 @@ namespace Soulseek.Tests.Unit.Client
 
                 var transfer = await downloadTask;
 
-                Assert.Equal(TransferStates.Completed | TransferStates.Succeeded, transfer.Transfer.State);
-                Assert.Equal(username, transfer.Transfer.Username);
-                Assert.Equal(token, transfer.Transfer.Token);
-                Assert.Equal(filename, transfer.Transfer.Filename);
+                Assert.Equal(TransferStates.Completed | TransferStates.Succeeded, transfer.State);
+                Assert.Equal(username, transfer.Username);
+                Assert.Equal(token, transfer.Token);
+                Assert.Equal(filename, transfer.Filename);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var downloadTask = await s.EnqueueDownloadAsync(username, filename, 0L, 0, token);
+                var downloadTask = await s.EnqueueDownloadAsync(username, filename, "local", 0L, 0, token);
 
                 Assert.NotNull(downloadTask);
 
@@ -463,7 +463,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, filename, 0L, 0, token));
+                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, filename, "local", 0L, 0, token));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -36,23 +36,6 @@ namespace Soulseek.Tests.Unit.Client
     public class UploadAsyncTests
     {
         [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync throws ArgumentException given bad username")]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("   ")]
-        public async Task UploadAsync_Throws_ArgumentException_Given_Bad_Username(string username)
-        {
-            using (var s = new SoulseekClient())
-            {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, "filename", new byte[] { 0x0 }));
-
-                Assert.NotNull(ex);
-                Assert.IsType<ArgumentException>(ex);
-                Assert.Contains("username", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
         [Theory(DisplayName = "UploadAsync stream throws ArgumentException given bad username")]
         [InlineData(null)]
         [InlineData("")]
@@ -84,23 +67,6 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
                 Assert.Contains("username", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync throws ArgumentException given bad filename")]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("   ")]
-        public async Task UploadAsync_Throws_ArgumentException_Given_Bad_Filename(string filename)
-        {
-            using (var s = new SoulseekClient())
-            {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", filename, new byte[] { 0x0 }));
-
-                Assert.NotNull(ex);
-                Assert.IsType<ArgumentException>(ex);
-                Assert.Contains("remoteFilename", ex.Message, StringComparison.InvariantCultureIgnoreCase);
             }
         }
 
@@ -174,22 +140,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync throws ArgumentException null or empty byte array")]
-        [InlineData(null)]
-        [InlineData(new byte[] { })]
-        public async Task UploadAsync_Throws_ArgumentException_Given_Null_Or_Empty_Byte_Array(byte[] data)
-        {
-            using (var s = new SoulseekClient())
-            {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", data));
-
-                Assert.NotNull(ex);
-                Assert.IsType<ArgumentException>(ex);
-                Assert.Contains("data", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
         [Theory(DisplayName = "UploadAsync stream throws ArgumentException bad size")]
         [InlineData(0)]
         [InlineData(-1)]
@@ -204,20 +154,6 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
                 Assert.Contains("size", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
-        [Fact(DisplayName = "UploadAsync throws InvalidOperationException when not connected")]
-        public async Task UploadAsync_Throws_InvalidOperationException_When_Not_Connected()
-        {
-            using (var s = new SoulseekClient())
-            {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }));
-
-                Assert.NotNull(ex);
-                Assert.IsType<InvalidOperationException>(ex);
-                Assert.Contains("Connected", ex.Message, StringComparison.InvariantCultureIgnoreCase);
             }
         }
 
@@ -284,22 +220,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
-        [Fact(DisplayName = "UploadAsync throws InvalidOperationException when not logged in")]
-        public async Task UploadAsync_Throws_InvalidOperationException_When_Not_Logged_In()
-        {
-            using (var s = new SoulseekClient())
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }));
-
-                Assert.NotNull(ex);
-                Assert.IsType<InvalidOperationException>(ex);
-                Assert.Contains("logged in", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
         [Fact(DisplayName = "UploadAsync stream throws InvalidOperationException when not logged in")]
         public async Task UploadAsync_Stream_Throws_InvalidOperationException_When_Not_Logged_In()
         {
@@ -361,27 +281,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
-        [Fact(DisplayName = "UploadAsync throws DuplicateTokenException when token used")]
-        public async Task UploadAsync_Throws_DuplicateTokenException_When_Token_Used()
-        {
-            using (var s = new SoulseekClient())
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var queued = new ConcurrentDictionary<int, TransferInternal>();
-                queued.TryAdd(1, new TransferInternal(TransferDirection.Upload, "foo", "bar", 1));
-
-                s.SetProperty("UploadDictionary", queued);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }, 1));
-
-                Assert.NotNull(ex);
-                Assert.IsType<DuplicateTokenException>(ex);
-                Assert.Contains("token", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
         [Fact(DisplayName = "UploadAsync stream throws DuplicateTokenException when token used")]
         public async Task UploadAsync_Stream_Throws_DuplicateTokenException_When_Token_Used()
         {
@@ -430,67 +329,6 @@ namespace Soulseek.Tests.Unit.Client
                     Assert.IsType<DuplicateTokenException>(ex);
                     Assert.Contains("token", ex.Message, StringComparison.InvariantCultureIgnoreCase);
                 }
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync throws DuplicateTransferException when an existing Upload matches the username and filename"), AutoData]
-        public async Task UploadAsync_Throws_DuplicateTransferException_When_An_Existing_Upload_Matches_The_Username_And_Filename(string username, string filename)
-        {
-            using (var s = new SoulseekClient())
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var queued = new ConcurrentDictionary<int, TransferInternal>();
-                queued.TryAdd(0, new TransferInternal(TransferDirection.Upload, username, filename, 0));
-
-                s.SetProperty("UploadDictionary", queued);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, new byte[] { 0x0 }, 1));
-
-                Assert.NotNull(ex);
-                Assert.IsType<DuplicateTransferException>(ex);
-                Assert.Contains($"An active or queued upload of {filename} to {username} is already in progress", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync does not throw DuplicateTransferException when an existing Upload matches only the username"), AutoData]
-        public async Task UploadAsync_Does_Not_Throw_DuplicateTransferException_When_An_Existing_Upload_Matches_Only_The_Username(string username, string filename)
-        {
-            using (var s = new SoulseekClient())
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var queued = new ConcurrentDictionary<int, TransferInternal>();
-                queued.TryAdd(0, new TransferInternal(TransferDirection.Upload, username, filename, 0));
-
-                s.SetProperty("UploadDictionary", queued);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename + "!", new byte[] { 0x0 }, 1));
-
-                Assert.NotNull(ex);
-                Assert.IsNotType<DuplicateTransferException>(ex);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync does not throw DuplicateTransferException when an existing Upload matches only the filename"), AutoData]
-        public async Task UploadAsync_Does_Not_Throw_DuplicateTransferException_When_An_Existing_Upload_Matches_Only_The_Filename(string username, string filename)
-        {
-            using (var s = new SoulseekClient())
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var queued = new ConcurrentDictionary<int, TransferInternal>();
-                queued.TryAdd(0, new TransferInternal(TransferDirection.Upload, username, filename, 0));
-
-                s.SetProperty("UploadDictionary", queued);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username + "!", filename, new byte[] { 0x0 }, 1));
-
-                Assert.NotNull(ex);
-                Assert.IsNotType<DuplicateTransferException>(ex);
             }
         }
 
@@ -647,25 +485,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync uses given CancellationToken"), AutoData]
-        public async Task UploadAsync_Uses_Given_CancellationToken(string username, string filename)
-        {
-            var cancellationToken = new CancellationToken(true);
-
-            var conn = new Mock<IMessageConnection>();
-
-            using (var s = new SoulseekClient(serverConnection: conn.Object))
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, new byte[] { 0x0 }, cancellationToken: cancellationToken));
-
-                Assert.NotNull(ex);
-                Assert.IsType<OperationCanceledException>(ex);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
         [Theory(DisplayName = "UploadAsync stream uses given CancellationToken"), AutoData]
         public async Task UploadAsync_Stream_Uses_Given_CancellationToken(string username, string filename)
         {
@@ -719,35 +538,6 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
-        [Theory(DisplayName = "UploadAsync throws TimeoutException on peer message connection timeout"), AutoData]
-        public async Task UploadAsync_Throws_TimeoutException_On_Peer_Message_Connection_Timeout(IPEndPoint endpoint)
-        {
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var options = new SoulseekClientOptions(messageTimeout: 1);
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse("username", endpoint.Address, endpoint.Port)));
-
-            var manager = new Mock<IPeerConnectionManager>();
-            manager.Setup(m => m.GetOrAddMessageConnectionAsync(It.IsAny<string>(), endpoint, It.IsAny<CancellationToken>()))
-                .Throws(new TimeoutException());
-
-            using (var s = new SoulseekClient(waiter: waiter.Object, serverConnection: conn.Object, options: options, peerConnectionManager: manager.Object))
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", new byte[] { 0x0 }));
-
-                Assert.NotNull(ex);
-                Assert.IsType<TimeoutException>(ex);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
         [Theory(DisplayName = "UploadAsync stream throws TimeoutException on peer message connection timeout"), AutoData]
         public async Task UploadAsync_Stream_Throws_TimeoutException_On_Peer_Message_Connection_Timeout(IPEndPoint endpoint)
         {
@@ -777,9 +567,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws UserOfflineException when user offline"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_UserOfflineException_When_User_Offline(string username, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws UserOfflineException when user offline"), AutoData]
+        public async Task UploadFromFileAsync_Throws_UserOfflineException_When_User_Offline(string username, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -797,16 +587,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserOfflineException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws TimeoutException on TransferResponse timeout"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_TimeoutException_On_TransferResponse_Timeout(string username, IPEndPoint endpoint, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws TimeoutException on TransferResponse timeout"), AutoData]
+        public async Task UploadFromFileAsync_Throws_TimeoutException_On_TransferResponse_Timeout(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 1);
 
@@ -828,16 +618,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws OperationCanceledException on TransferResponse cancellation"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_OperationCanceledException_On_TransferResponse_Cancellation(string username, IPEndPoint endpoint, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws OperationCanceledException on TransferResponse cancellation"), AutoData]
+        public async Task UploadFromFileAsync_Throws_OperationCanceledException_On_TransferResponse_Cancellation(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -861,16 +651,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws OperationCanceledException on request write cancellation"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_OperationCanceledException_On_Request_Write_Cancellation(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws OperationCanceledException on request write cancellation"), AutoData]
+        public async Task UploadFromFileAsync_Throws_OperationCanceledException_On_Request_Write_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -903,16 +693,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws TimeoutException on transfer response timeout"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_TimeoutException_On_Transfer_Response_Timeout(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws TimeoutException on transfer response timeout"), AutoData]
+        public async Task UploadFromFileAsync_Throws_TimeoutException_On_Transfer_Response_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -944,67 +734,70 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync completes following normal transfer connection disconnect"), AutoData]
-        public async Task UploadFromByteArrayAsync_Completes_Following_Normal_Transfer_Connection_Disconnect(string username, IPEndPoint endpoint, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync completes following normal transfer connection disconnect"), AutoData]
+        public async Task UploadFromFileAsync_Completes_Following_Normal_Transfer_Connection_Disconnect(string username, IPEndPoint endpoint, byte[] data, string filename, int token)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-            var response = new TransferResponse(token, data.Length);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(tcs.Task);
-            waiter.Setup(m => m.Complete(It.IsAny<WaitKey>()))
-                .Callback<WaitKey>((key) => tcs.TrySetResult(true));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.ReadAsync(8, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
+                var response = new TransferResponse(token, "foo".Length);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                var task = s.InvokeMethod<Task<Transfer>>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(maximumLingerTime: 0), null);
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                transferConn.Raise(m => m.Disconnected += null, new ConnectionDisconnectedEventArgs("done"));
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(tcs.Task);
+                waiter.Setup(m => m.Complete(It.IsAny<WaitKey>()))
+                    .Callback<WaitKey>((key) => tcs.TrySetResult(true));
 
-                var transfer = await task;
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
 
-                Assert.Equal(username, transfer.Username);
-                Assert.Equal(filename, transfer.Filename);
-                Assert.Equal(token, transfer.Token);
-                Assert.Equal(data.Length, transfer.Size);
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.ReadAsync(8, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var task = s.InvokeMethod<Task<Transfer>>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(maximumLingerTime: 0), null);
+
+                    transferConn.Raise(m => m.Disconnected += null, new ConnectionDisconnectedEventArgs("done"));
+
+                    var transfer = await task;
+
+                    Assert.Equal(username, transfer.Username);
+                    Assert.Equal(filename, transfer.Filename);
+                    Assert.Equal(token, transfer.Token);
+                    Assert.Equal(data.Length, transfer.Size);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws TimeoutException on unexpected transfer connection timeout"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_TimeoutException_On_Unexpected_Transfer_Connection_Timeout(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws TimeoutException on unexpected transfer connection timeout"), AutoData]
+        public async Task UploadFromFileAsync_Throws_TimeoutException_On_Unexpected_Transfer_Connection_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
             var response = new TransferResponse(token, size);
@@ -1040,7 +833,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var task = s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null);
+                var task = s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null);
 
                 transferConn.Raise(m => m.Disconnected += null, new ConnectionDisconnectedEventArgs("timed out", timeoutEx));
 
@@ -1052,9 +845,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws OperationCanceledException on unexpected transfer connection cancellation"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_OperationCanceledException_On_Unexpected_Transfer_Connection_Cancellation(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws OperationCanceledException on unexpected transfer connection cancellation"), AutoData]
+        public async Task UploadFromFileAsync_Throws_OperationCanceledException_On_Unexpected_Transfer_Connection_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
             var response = new TransferResponse(token, size);
@@ -1090,7 +883,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var task = s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null);
+                var task = s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null);
 
                 transferConn.Raise(m => m.Disconnected += null, new ConnectionDisconnectedEventArgs("canceled", cancelEx));
 
@@ -1103,9 +896,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws wrapped Exception on unexpected transfer connection Exception"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_Wrapped_Exception_On_Unexpected_Transfer_Connection_Exception(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws wrapped Exception on unexpected transfer connection Exception"), AutoData]
+        public async Task UploadFromFileAsync_Throws_Wrapped_Exception_On_Unexpected_Transfer_Connection_Exception(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
             var response = new TransferResponse(token, size);
@@ -1141,7 +934,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var task = s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null);
+                var task = s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null);
 
                 transferConn.Raise(m => m.Disconnected += null, new ConnectionDisconnectedEventArgs("some exception", thrownEx));
 
@@ -1156,180 +949,192 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync completes without Exception when transfer is allowed"), AutoData]
-        public async Task UploadFromByteArrayAsync_Completes_Without_Exception_When_Transfer_Is_Allowed(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync completes without Exception when transfer is allowed"), AutoData]
+        public async Task UploadFromFileAsync_Completes_Without_Exception_When_Transfer_Is_Allowed(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var transferConn = new Mock<IConnection>();
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                Assert.Null(ex);
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var transferConn = new Mock<IConnection>();
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(), null));
+
+                    Assert.Null(ex);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync completes without Exception when trailing read throws ConnectionReadException"), AutoData]
-        public async Task UploadFromByteArrayAsync_Completes_Without_Exception_When_Trailing_Read_Throws_ConnectionReadException(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync completes without Exception when trailing read throws ConnectionReadException"), AutoData]
+        public async Task UploadFromFileAsync_Completes_Without_Exception_When_Trailing_Read_Throws_ConnectionReadException(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
-            transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromException<byte[]>(new ConnectionReadException()));
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                Assert.Null(ex);
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromException<byte[]>(new ConnectionReadException()));
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(), null));
+
+                    Assert.Null(ex);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync completes without Exception after MaximumLingerTime when trailing read does not throw ConnectionReadException"), AutoData]
-        public async Task UploadFromByteArrayAsync_Completes_Without_Exception_After_MaximumLingerTime_When_Trailing_Read_Does_Not_Throw_ConnectionReadException(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync completes without Exception after MaximumLingerTime when trailing read does not throw ConnectionReadException"), AutoData]
+        public async Task UploadFromFileAsync_Completes_Without_Exception_After_MaximumLingerTime_When_Trailing_Read_Does_Not_Throw_ConnectionReadException(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
-            transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(new byte[] { 0x0 }));
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            var txOptions = new TransferOptions(maximumLingerTime: 200);
-
-            using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile())
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, txOptions, null));
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                Assert.Null(ex);
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(new byte[] { 0x0 }));
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                var txOptions = new TransferOptions(maximumLingerTime: 200);
+
+                using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, txOptions, null));
+
+                    Assert.Null(ex);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync produces warning diagnostic when disconnected due to MaximumLingerTime"), AutoData]
-        public async Task UploadFromByteArrayAsync_Produces_Warning_Diagnostic_When_Disconnected_Due_To_MaximumLingerTime(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync produces warning diagnostic when disconnected due to MaximumLingerTime"), AutoData]
+        public async Task UploadFromFileAsync_Produces_Warning_Diagnostic_When_Disconnected_Due_To_MaximumLingerTime(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
-            transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(new byte[] { 0x0 }));
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            var diagnostic = new Mock<IDiagnosticFactory>();
-
-            var txOptions = new TransferOptions(maximumLingerTime: 200);
-
-            using (var s = new SoulseekClient(options: options, diagnosticFactory: diagnostic.Object, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, txOptions, null));
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                Assert.Null(ex);
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(new byte[] { 0x0 }));
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                var diagnostic = new Mock<IDiagnosticFactory>();
+
+                var txOptions = new TransferOptions(maximumLingerTime: 200);
+
+                using (var s = new SoulseekClient(options: options, diagnosticFactory: diagnostic.Object, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, txOptions, null));
+
+                    Assert.Null(ex);
+                }
+
+                diagnostic.Verify(m => m.Warning(It.Is<string>(s => s.ContainsInsensitive("maximum linger time")), null), Times.Once);
             }
-
-            diagnostic.Verify(m => m.Warning(It.Is<string>(s => s.ContainsInsensitive("maximum linger time")), null), Times.Once);
         }
 
         [Trait("Category", "UploadFromStreamAsync")]
@@ -1579,9 +1384,9 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Verify(m => m.WriteAsync(size - offset, It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken?>()));
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws TransferRejectedException when acknowledgement is disallowed and message contains 'File not shared'"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_TransferRejectedException_When_Acknowledgement_Is_Disallowed_And_File_Not_Shared(string username, IPEndPoint endpoint, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws TransferRejectedException when acknowledgement is disallowed and message contains 'File not shared'"), AutoData]
+        public async Task UploadFromFileAsync_Throws_TransferRejectedException_When_Acknowledgement_Is_Disallowed_And_File_Not_Shared(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1612,65 +1417,68 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferRejectedException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync invokes StateChanged delegate on state change"), AutoData]
-        public async Task UploadFromByteArrayAsync_Invokes_StateChanged_Delegate_On_State_Change(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync invokes StateChanged delegate on state change"), AutoData]
+        public async Task UploadFromFileAsync_Invokes_StateChanged_Delegate_On_State_Change(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
-
-            var transferConn = new Mock<IConnection>();
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(request));
-            waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.WaitIndefinitely<byte[]>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<byte[]>(data));
-            waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var fired = false;
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(stateChanged: (e) => fired = true), null);
+                var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
 
-                Assert.True(fired);
+                var transferConn = new Mock<IConnection>();
+
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(request));
+                waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var fired = false;
+
+                    await s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(stateChanged: (e) => fired = true), null);
+
+                    Assert.True(fired);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync raises UploadProgressUpdated event on data write"), AutoData]
-        public async Task UploadFromByteArrayAsync_Raises_UploadProgressUpdated_Event_On_Data_Read(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync raises UploadProgressUpdated event on data write"), AutoData]
+        public async Task UploadFromFileAsync_Raises_UploadProgressUpdated_Event_On_Data_Read(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1714,6 +1522,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
+            using (var testData = new TestFile(data))
             using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -1722,7 +1531,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.TransferProgressUpdated += (d, e) => events.Add(e);
 
-                await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(maximumLingerTime: 0), null);
+                await s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testData.Path, token, new TransferOptions(maximumLingerTime: 0), null);
 
                 Assert.Equal(3, events.Count);
                 Assert.Equal(TransferStates.InProgress, events[0].Transfer.State);
@@ -1730,63 +1539,66 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync invokes ProgressUpdated delegate on data read"), AutoData]
-        public async Task UploadFromByteArrayAsync_Invokes_ProgressUpdated_Delegate_On_Data_Read(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync invokes ProgressUpdated delegate on data read"), AutoData]
+        public async Task UploadFromFileAsync_Invokes_ProgressUpdated_Delegate_On_Data_Read(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(BitConverter.GetBytes(token)))
-                .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(request));
-            waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.WaitIndefinitely<byte[]>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<byte[]>(data));
-            waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var fired = false;
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                await s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(progressUpdated: (e) => fired = true), null);
+                var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
 
-                Assert.True(fired);
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+                transferConn.Setup(m => m.ReadAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(token)))
+                    .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
+
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(request));
+                waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.WaitIndefinitely<byte[]>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult<byte[]>(data));
+                waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var fired = false;
+
+                    await s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(progressUpdated: (e) => fired = true), null);
+
+                    Assert.True(fired);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync raises Upload events on failure"), AutoData]
-        public async Task UploadFromByteArrayAsync_Raises_Upload_Events_On_Failure(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync raises Upload events on failure"), AutoData]
+        public async Task UploadFromFileAsync_Raises_Upload_Events_On_Failure(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -1825,6 +1637,7 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(transferConn.Object));
 
+            using (var testFile = new TestFile(data))
             using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -1836,7 +1649,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(maximumLingerTime: 0), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(maximumLingerTime: 0), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -1847,134 +1660,140 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync raises Upload events on bad offset data"), AutoData]
-        public async Task UploadFromByteArrayAsync_Raises_Upload_Events_On_Bad_Offset_Data(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync raises Upload events on bad offset data"), AutoData]
+        public async Task UploadFromFileAsync_Raises_Upload_Events_On_Bad_Offset_Data(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(Array.Empty<byte>()));
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(request));
-            waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromException<Task>(new MessageReadException()));
-            waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var events = new List<TransferStateChangedEventArgs>();
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                s.TransferStateChanged += (sender, e) =>
+                var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
+
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+                transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(Array.Empty<byte>()));
+
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(request));
+                waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromException<Task>(new MessageReadException()));
+                waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
                 {
-                    events.Add(e);
-                };
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                    var events = new List<TransferStateChangedEventArgs>();
 
-                Assert.NotNull(ex);
-                Assert.IsType<SoulseekClientException>(ex);
-                Assert.IsType<MessageReadException>(ex.InnerException);
+                    s.TransferStateChanged += (sender, e) =>
+                    {
+                        events.Add(e);
+                    };
 
-                Assert.Equal(TransferStates.Initializing, events[events.Count - 1].PreviousState);
-                Assert.Equal(TransferStates.Completed | TransferStates.Errored, events[events.Count - 1].Transfer.State);
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(), null));
+
+                    Assert.NotNull(ex);
+                    Assert.IsType<SoulseekClientException>(ex);
+                    Assert.IsType<MessageReadException>(ex.InnerException);
+
+                    Assert.Equal(TransferStates.Initializing, events[events.Count - 1].PreviousState);
+                    Assert.Equal(TransferStates.Completed | TransferStates.Errored, events[events.Count - 1].Transfer.State);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync raises Upload events on timeout"), AutoData]
-        public async Task UploadFromByteArrayAsync_Raises_Expected_Final_Event_On_Timeout(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync raises Upload events on timeout"), AutoData]
+        public async Task UploadFromFileAsync_Raises_Expected_Final_Event_On_Timeout(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
         {
-            var options = new SoulseekClientOptions(messageTimeout: 5);
-
-            var response = new TransferResponse(token, size);
-            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
-
-            var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
-
-            var transferConn = new Mock<IConnection>();
-            transferConn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken?>()))
-                .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
-
-            var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response));
-            waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(request));
-            waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromException<Task>(new TimeoutException()));
-            waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
-
-            var conn = new Mock<IMessageConnection>();
-            conn.Setup(m => m.State)
-                .Returns(ConnectionState.Connected);
-
-            var connManager = new Mock<IPeerConnectionManager>();
-            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(conn.Object));
-            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(transferConn.Object));
-
-            using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+            using (var testFile = new TestFile(data))
             {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var options = new SoulseekClientOptions(messageTimeout: 5);
 
-                var events = new List<TransferStateChangedEventArgs>();
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-                s.TransferStateChanged += (sender, e) =>
+                var request = new TransferRequest(TransferDirection.Upload, token, filename, size);
+
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+                transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.WaitIndefinitely<TransferRequest>(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(request));
+                waiter.Setup(m => m.Wait(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromException<Task>(new TimeoutException()));
+                waiter.Setup(m => m.Wait<IConnection>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                using (var s = new SoulseekClient(options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
                 {
-                    events.Add(e);
-                };
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(maximumLingerTime: 0), null));
+                    var events = new List<TransferStateChangedEventArgs>();
 
-                Assert.NotNull(ex);
-                Assert.IsType<TimeoutException>(ex);
+                    s.TransferStateChanged += (sender, e) =>
+                    {
+                        events.Add(e);
+                    };
 
-                Assert.Equal(TransferStates.InProgress, events[events.Count - 1].PreviousState);
-                Assert.Equal(TransferStates.Completed | TransferStates.TimedOut, events[events.Count - 1].Transfer.State);
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(maximumLingerTime: 0), null));
+
+                    Assert.NotNull(ex);
+                    Assert.IsType<TimeoutException>(ex);
+
+                    Assert.Equal(TransferStates.InProgress, events[events.Count - 1].PreviousState);
+                    Assert.Equal(TransferStates.Completed | TransferStates.TimedOut, events[events.Count - 1].Transfer.State);
+                }
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync raises Upload events on cancellation"), AutoData]
-        public async Task UploadFromByteArrayAsync_Raises_Expected_Final_Event_On_Cancellation(string username, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync raises Upload events on cancellation"), AutoData]
+        public async Task UploadFromFileAsync_Raises_Expected_Final_Event_On_Cancellation(string username, string filename, byte[] data, int token)
         {
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
@@ -1984,6 +1803,7 @@ namespace Soulseek.Tests.Unit.Client
             conn.Setup(m => m.State)
                 .Returns(ConnectionState.Connected);
 
+            using (var testFile = new TestFile(data))
             using (var s = new SoulseekClient(null, waiter: waiter.Object, serverConnection: conn.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
@@ -1995,7 +1815,7 @@ namespace Soulseek.Tests.Unit.Client
                     events.Add(e);
                 };
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -2004,9 +1824,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync writes UploadDenied on cancellation"), AutoData]
-        public async Task UploadFromByteArrayAsync_Writes_UploadDenied_On_Cancellation(string username, string filename, byte[] data, int token, IPEndPoint endpoint)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync writes UploadDenied on cancellation"), AutoData]
+        public async Task UploadFromFileAsync_Writes_UploadDenied_On_Cancellation(string username, string filename, int token, IPEndPoint endpoint)
         {
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -2026,11 +1846,12 @@ namespace Soulseek.Tests.Unit.Client
             connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(peerConn.Object));
 
+            using (var testFile = new TestFile())
             using (var s = new SoulseekClient(null, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -2040,9 +1861,9 @@ namespace Soulseek.Tests.Unit.Client
             peerConn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws SoulseekClientException and ConnectionException on transfer exception"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_SoulseekClientException_And_ConnectionException_On_Transfer_Exception(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws SoulseekClientException and ConnectionException on transfer exception"), AutoData]
+        public async Task UploadFromFileAsync_Throws_SoulseekClientException_And_ConnectionException_On_Transfer_Exception(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2085,7 +1906,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -2094,9 +1915,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws SoulseekClientException on failure to read offset data"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_SoulseekClientException_On_Failure_To_Read_Offset_Data(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws SoulseekClientException on failure to read offset data"), AutoData]
+        public async Task UploadFromFileAsync_Throws_SoulseekClientException_On_Failure_To_Read_Offset_Data(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2134,7 +1955,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -2143,9 +1964,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws SoulseekClientException on bad offset data"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_SoulseekClientException_On_Bad_Offset_Data(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws SoulseekClientException on bad offset data"), AutoData]
+        public async Task UploadFromFileAsync_Throws_SoulseekClientException_On_Bad_Offset_Data(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2178,7 +1999,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -2186,9 +2007,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws TimeoutException on transfer timeout"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_TimeoutException_On_Transfer_Timeout(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws TimeoutException on transfer timeout"), AutoData]
+        public async Task UploadFromFileAsync_Throws_TimeoutException_On_Transfer_Timeout(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2231,16 +2052,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws OperationCanceledException on cancellation"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_OperationCanceledException_On_Cancellation(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws OperationCanceledException on cancellation"), AutoData]
+        public async Task UploadFromFileAsync_Throws_OperationCanceledException_On_Cancellation(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2283,7 +2104,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -2292,9 +2113,9 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Verify(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()));
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws TransferRejectedException on transfer rejection"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_TransferRejectedException_On_Transfer_Rejection(string username, IPEndPoint endpoint, string filename, byte[] data, int token)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws TransferRejectedException on transfer rejection"), AutoData]
+        public async Task UploadFromFileAsync_Throws_TransferRejectedException_On_Transfer_Rejection(string username, IPEndPoint endpoint, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2325,16 +2146,16 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferRejectedException>(ex);
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync throws ConnectionException when transfer connection fails"), AutoData]
-        public async Task UploadFromByteArrayAsync_Throws_ConnectionException_When_Transfer_Connection_Fails(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync throws ConnectionException when transfer connection fails"), AutoData]
+        public async Task UploadFromFileAsync_Throws_ConnectionException_When_Transfer_Connection_Fails(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2363,7 +2184,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -2371,9 +2192,9 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync updates remote user on failure"), AutoData]
-        public async Task UploadFromByteArrayAsync_Updates_Remote_User_On_Failure(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync updates remote user on failure"), AutoData]
+        public async Task UploadFromFileAsync_Updates_Remote_User_On_Failure(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2416,7 +2237,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(), null));
 
                 Assert.NotNull(ex);
             }
@@ -2425,9 +2246,9 @@ namespace Soulseek.Tests.Unit.Client
             conn.Verify(m => m.WriteAsync(It.Is<IOutgoingMessage>(msg => msg.ToByteArray().Matches(expectedBytes)), It.IsAny<CancellationToken?>()));
         }
 
-        [Trait("Category", "UploadFromByteArrayAsync")]
-        [Theory(DisplayName = "UploadFromByteArrayAsync swallows final read exception"), AutoData]
-        public async Task UploadFromByteArrayAsync_Swallows_Final_Read_Exception(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync swallows final read exception"), AutoData]
+        public async Task UploadFromFileAsync_Swallows_Final_Read_Exception(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
 
@@ -2462,7 +2283,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromByteArrayAsync", username, filename, data, token, new TransferOptions(maximumLingerTime: int.MaxValue), null));
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(maximumLingerTime: int.MaxValue), null));
 
                 Assert.Null(ex);
             }

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -1039,7 +1039,7 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "UploadFromFileAsync")]
         [Theory(DisplayName = "UploadFromFileAsync completes without Exception after MaximumLingerTime when trailing read does not throw ConnectionReadException"), AutoData]
-        public async Task UploadFromFileAsync_Completes_Without_Exception_After_MaximumLingerTime_When_Trailing_Read_Does_Not_Throw_ConnectionReadException(string username, IPEndPoint endpoint, string filename, byte[] data, int token, int size)
+        public async Task UploadFromFileAsync_Completes_Without_Exception_After_MaximumLingerTime_When_Trailing_Read_Does_Not_Throw_ConnectionReadException(string username, IPEndPoint endpoint, string filename, int token, int size)
         {
             using (var testFile = new TestFile())
             {

--- a/tests/Soulseek.Tests.Unit/Support/TestFile.cs
+++ b/tests/Soulseek.Tests.Unit/Support/TestFile.cs
@@ -21,9 +21,14 @@ namespace Soulseek.Tests.Unit
 
     internal class TestFile : IDisposable
     {
-        public TestFile()
+        public TestFile(byte[] data = null)
         {
             Path = System.IO.Path.GetTempFileName();
+
+            if (data != null)
+            {
+                System.IO.File.WriteAllBytes(Path, data);
+            }
         }
 
         public string Path { get; private set; }


### PR DESCRIPTION
Using byte arrays for this is impractical, and I don't want to deal with this many overloaded methods.  Anyone that was relying on this can create their own `MemoryStream` and pass it to the overloads accepting a stream; this is all the library was doing under the hood anyway.

Closes #648 