### PR TITLE
Accept Func<Stream> instead of Stream in UploadAsync and DownloadAsync

### DIFF
--- a/examples/Web/api/Controllers/TransfersController.cs
+++ b/examples/Web/api/Controllers/TransfersController.cs
@@ -99,7 +99,7 @@
 
                 var cts = new CancellationTokenSource();
 
-                var downloadTask = Client.DownloadAsync(username, request.Filename, stream, request.Size, 0, request.Token, new TransferOptions(disposeOutputStreamOnCompletion: true, stateChanged: (e) =>
+                var downloadTask = Client.DownloadAsync(username, request.Filename, () => stream, request.Size, 0, request.Token, new TransferOptions(disposeOutputStreamOnCompletion: true, stateChanged: (e) =>
                 {
                     Tracker.AddOrUpdate(e, cts);
 

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -625,7 +625,7 @@
             Task.Run(async () =>
             {
                 using var stream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read);
-                await Client.UploadAsync(username, filename, fileInfo.Length, stream, options: topts, cancellationToken: cts.Token);
+                await Client.UploadAsync(username, filename, fileInfo.Length, () => stream, options: topts, cancellationToken: cts.Token);
 
                 cts.Dispose();
             }).ContinueWith(t =>

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -1,18 +1,13 @@
 ﻿// <copyright file="ISoulseekClient.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
-//     This program is free software: you can redistribute it and/or modify
-//     it under the terms of the GNU General Public License as published by
-//     the Free Software Foundation, either version 3 of the License, or
-//     (at your option) any later version.
+//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+//     as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 //
-//     This program is distributed in the hope that it will be useful,
-//     but WITHOUT ANY WARRANTY; without even the implied warranty of
-//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//     GNU General Public License for more details.
+//     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+//     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 //
-//     You should have received a copy of the GNU General Public License
-//     along with this program.  If not, see https://www.gnu.org/licenses/.
+//     You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
 namespace Soulseek
@@ -520,7 +515,7 @@ namespace Soulseek
         /// <summary>
         ///     Asynchronously downloads the specified <paramref name="remoteFilename"/> from the specified
         ///     <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
-        ///     <paramref name="cancellationToken"/> to the specified <paramref name="outputStream"/>.
+        ///     <paramref name="cancellationToken"/> to the <see cref="Stream"/> created by the specified <paramref name="outputStreamFactory"/>.
         /// </summary>
         /// <remarks>
         ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
@@ -528,7 +523,7 @@ namespace Soulseek
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
-        /// <param name="outputStream">The stream to which to write the file contents.</param>
+        /// <param name="outputStreamFactory">A delegate used to create the stream to which to write the file contents.</param>
         /// <param name="size">The size of the file, in bytes.</param>
         /// <param name="startOffset">The offset at which to start the download, in bytes.</param>
         /// <param name="token">The unique download token.</param>
@@ -542,9 +537,8 @@ namespace Soulseek
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
         /// </exception>
-        /// <exception cref="ArgumentNullException">Thrown when the specified <paramref name="outputStream"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown when the specified <paramref name="outputStream"/> is not writeable.
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the specified <paramref name="outputStreamFactory"/> is null.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
@@ -557,7 +551,7 @@ namespace Soulseek
         /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<Transfer> DownloadAsync(string username, string remoteFilename, Stream outputStream, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
+        Task<Transfer> DownloadAsync(string username, string remoteFilename, Func<Stream> outputStreamFactory, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Asynchronously removes the currently logged in user from the list of members in the specified private <paramref name="roomName"/>.
@@ -601,7 +595,7 @@ namespace Soulseek
         ///     </para>
         ///     <para>
         ///         Functionally the same as
-        ///         <see cref="DownloadAsync(string, string, Stream, long?, long, int?, TransferOptions, CancellationToken?)"/>,
+        ///         <see cref="DownloadAsync(string, string, Func{Stream}, long?, long, int?, TransferOptions, CancellationToken?)"/>,
         ///         but returns the download Task as soon as the download has been remotely enqueued.
         ///     </para>
         /// </summary>
@@ -645,11 +639,11 @@ namespace Soulseek
         ///     <para>
         ///         Asynchronously enqueues a download for the specified <paramref name="remoteFilename"/> from the specified
         ///         <paramref name="username"/> using the specified unique <paramref name="token"/> and optionally specified
-        ///         <paramref name="cancellationToken"/> to the specified <paramref name="outputStream"/>.
+        ///         <paramref name="cancellationToken"/> to the <see cref="Stream"/> created by the specified <paramref name="outputStreamFactory"/>.
         ///     </para>
         ///     <para>
         ///         Functionally the same as
-        ///         <see cref="DownloadAsync(string, string, Stream, long?, long, int?, TransferOptions, CancellationToken?)"/>,
+        ///         <see cref="DownloadAsync(string, string, Func{Stream}, long?, long, int?, TransferOptions, CancellationToken?)"/>,
         ///         but returns the download Task as soon as the download has been remotely enqueued.
         ///     </para>
         /// </summary>
@@ -659,7 +653,7 @@ namespace Soulseek
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
-        /// <param name="outputStream">The stream to which to write the file contents.</param>
+        /// <param name="outputStreamFactory">A delegate used to create the stream to which to write the file contents.</param>
         /// <param name="size">The size of the file, in bytes.</param>
         /// <param name="startOffset">The offset at which to start the download, in bytes.</param>
         /// <param name="token">The unique download token.</param>
@@ -673,9 +667,8 @@ namespace Soulseek
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the specified <paramref name="size"/> or <paramref name="startOffset"/> is less than zero.
         /// </exception>
-        /// <exception cref="ArgumentNullException">Thrown when the specified <paramref name="outputStream"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown when the specified <paramref name="outputStream"/> is not writeable.
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the specified <paramref name="outputStreamFactory"/> is null.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
@@ -688,7 +681,7 @@ namespace Soulseek
         /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<Task<Transfer>> EnqueueDownloadAsync(string username, string remoteFilename, Stream outputStream, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
+        Task<Task<Transfer>> EnqueueDownloadAsync(string username, string remoteFilename, Func<Stream> outputStreamFactory, long? size = null, long startOffset = 0, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Asynchronously fetches the contents of the specified <paramref name="directoryName"/> from the specified <paramref name="username"/>.
@@ -1192,14 +1185,14 @@ namespace Soulseek
         Task<Transfer> UploadAsync(string username, string remoteFilename, string localFilename, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the specified
-        ///     <paramref name="inputStream"/> to the the specified <paramref name="username"/> using the specified unique
-        ///     <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
+        ///     Asynchronously uploads the specified <paramref name="remoteFilename"/> from the <see cref="Stream"/> created by
+        ///     the specified <paramref name="inputStreamFactory"/> to the the specified <paramref name="username"/> using the
+        ///     specified unique <paramref name="token"/> and optionally specified <paramref name="cancellationToken"/>.
         /// </summary>
         /// <param name="username">The user to which to upload the file.</param>
         /// <param name="remoteFilename">The filename of the file to upload, as requested by the remote user.</param>
         /// <param name="size">The size of the file to upload, in bytes.</param>
-        /// <param name="inputStream">The stream from which to retrieve the file contents.</param>
+        /// <param name="inputStreamFactory">A delegate used to create the stream from which to retrieve the file contents.</param>
         /// <param name="token">The unique upload token.</param>
         /// <param name="options">The operation <see cref="TransferOptions"/>.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -1209,9 +1202,8 @@ namespace Soulseek
         ///     of whitespace.
         /// </exception>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="size"/> is less than 1.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when the specified <paramref name="inputStream"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown when the specified <paramref name="inputStream"/> is not readable.
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the specified <paramref name="inputStreamFactory"/> is null.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="DuplicateTokenException">Thrown when the specified or generated token is already in use.</exception>
@@ -1224,6 +1216,6 @@ namespace Soulseek
         /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="TransferRejectedException">Thrown when the transfer is rejected.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<Transfer> UploadAsync(string username, string remoteFilename, long size, Stream inputStream, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
+        Task<Transfer> UploadAsync(string username, string remoteFilename, long size, Func<Stream> inputStreamFactory, int? token = null, TransferOptions options = null, CancellationToken? cancellationToken = null);
     }
 }

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -1,13 +1,18 @@
 ﻿// <copyright file="ISoulseekClient.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
-//     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
-//     as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
 //
-//     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-//     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
 //
-//     You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/.
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
 // </copyright>
 
 namespace Soulseek

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -35,33 +35,17 @@ namespace Soulseek.Tests.Unit.Client
     public class DownloadAsyncTests
     {
         [Trait("Category", "DownloadAsync")]
-        [Fact(DisplayName = "DownloadAsync stream throws ArgumentNullException null stream")]
-        public async Task DownloadAsync_Stream_Throws_ArgumentNullException_Given_Null_Stream()
+        [Fact(DisplayName = "DownloadAsync stream throws ArgumentNullException null stream factory")]
+        public async Task DownloadAsync_Stream_Throws_ArgumentNullException_Given_Null_Stream_Factory()
         {
             using (var s = new SoulseekClient())
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", outputStream: null));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", outputStreamFactory: null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
-            }
-        }
-
-        [Trait("Category", "DownloadAsync")]
-        [Fact(DisplayName = "DownloadAsync stream throws InvalidOperationException given unwriteable stream")]
-        public async Task DownloadAsync_Stream_Throws_InvalidOperationException_Given_Unwriteable_Stream()
-        {
-            using (var stream = new UnReadableWriteableStream())
-            using (var s = new SoulseekClient())
-            {
-                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
-
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
-
-                Assert.NotNull(ex);
-                Assert.IsType<InvalidOperationException>(ex);
             }
         }
 
@@ -93,7 +77,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, "filename", () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -142,7 +126,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", filename, stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", filename, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -156,7 +140,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "foo", stream, size: -1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "foo", () => stream, size: -1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
@@ -171,7 +155,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "foo", stream, startOffset: -1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "foo", () => stream, startOffset: -1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
@@ -228,7 +212,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -261,7 +245,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -325,7 +309,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", () => stream, token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -347,7 +331,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("UploadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", () => stream, token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -430,7 +414,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, () => stream, token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -452,7 +436,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, () => stream, token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsNotType<DuplicateTransferException>(ex);
@@ -473,7 +457,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("DownloadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream, token: 1));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, () => stream, token: 1));
 
                 Assert.NotNull(ex);
                 Assert.IsNotType<DuplicateTransferException>(ex);
@@ -491,7 +475,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream));
+                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, () => stream));
             }
 
             conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), CancellationToken.None), Times.Once);
@@ -509,7 +493,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, stream, cancellationToken: cancellationToken));
+                await Record.ExceptionAsync(() => s.DownloadAsync(username, filename, () => stream, cancellationToken: cancellationToken));
             }
 
             conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
@@ -627,7 +611,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.DownloadAsync("username", "filename", () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/EnqueueDownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/EnqueueDownloadAsyncTests.cs
@@ -62,7 +62,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, "filename", stream));
+                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, "filename", () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -189,7 +189,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var downloadTask = await s.EnqueueDownloadAsync(username, filename, stream, 0L, 0, token);
+                var downloadTask = await s.EnqueueDownloadAsync(username, filename, () => stream, 0L, 0, token);
 
                 Assert.NotNull(downloadTask);
 
@@ -260,7 +260,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var downloadTask = await s.EnqueueDownloadAsync(username, filename, stream, 0L, 0, token);
+                var downloadTask = await s.EnqueueDownloadAsync(username, filename, () => stream, 0L, 0, token);
 
                 Assert.NotNull(downloadTask);
 
@@ -399,7 +399,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, filename, stream, 0L, 0, token));
+                var ex = await Record.ExceptionAsync(() => s.EnqueueDownloadAsync(username, filename, () => stream, 0L, 0, token));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -45,7 +45,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, "filename", 1, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -80,7 +80,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", filename, 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", filename, 1, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -149,7 +149,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", size, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", size, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);
@@ -164,7 +164,7 @@ namespace Soulseek.Tests.Unit.Client
             using (var stream = new MemoryStream())
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -191,31 +191,16 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
-        [Fact(DisplayName = "UploadAsync stream throws ArgumentNullException given null stream")]
-        public async Task UploadAsync_Stream_Throws_ArgumentNullException_Given_Null_Stream()
+        [Fact(DisplayName = "UploadAsync stream throws ArgumentNullException given null stream factory")]
+        public async Task UploadAsync_Stream_Throws_ArgumentNullException_Given_Null_Stream_Factory()
         {
             using (var s = new SoulseekClient())
             {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, null));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, inputStreamFactory: null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentNullException>(ex);
-                Assert.Contains("stream is null", ex.Message, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        [Trait("Category", "UploadAsync")]
-        [Fact(DisplayName = "UploadAsync stream throws InvalidOperationException given unreadable stream")]
-        public async Task UploadAsync_Stream_Throws_InvalidOperationException_Given_Unreadable_Stream()
-        {
-            using (var stream = new UnReadableWriteableStream())
-            using (var s = new SoulseekClient())
-            {
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
-
-                Assert.NotNull(ex);
-                Assert.IsType<InvalidOperationException>(ex);
-                Assert.Contains("not readable", ex.Message, StringComparison.InvariantCultureIgnoreCase);
+                Assert.Contains("stream factory is null", ex.Message, StringComparison.InvariantCultureIgnoreCase);
             }
         }
 
@@ -228,7 +213,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<InvalidOperationException>(ex);
@@ -294,7 +279,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("UploadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, () => stream, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTokenException>(ex);
@@ -346,7 +331,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("UploadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, 1, stream, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, 1, () => stream, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<DuplicateTransferException>(ex);
@@ -368,7 +353,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("UploadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename + "!", 1, stream, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename + "!", 1, () => stream, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsNotType<DuplicateTransferException>(ex);
@@ -389,7 +374,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 s.SetProperty("UploadDictionary", queued);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username + "!", filename, 1, stream, 1));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username + "!", filename, 1, () => stream, 1));
 
                 Assert.NotNull(ex);
                 Assert.IsNotType<DuplicateTransferException>(ex);
@@ -497,7 +482,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, 1, stream, cancellationToken: cancellationToken));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync(username, filename, 1, () => stream, cancellationToken: cancellationToken));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -560,7 +545,7 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, stream));
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", 1, () => stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);


### PR DESCRIPTION
With uploads now being queued in addition to downloads, it doesn't make sense to create streams until the transfer has passed all checks and is actually ready to transfer.  Forcing consumers to supply a delegate to create the stream allows us to defer creation until this time; previously the stream must be created when the transfer is enqueued and held open while it is waiting.

Closes #660