### PR TITLE
Add DownloadDenied and DownloadFailed events

### DIFF
--- a/src/EventArgs/DownloadDeniedEventArgs.cs
+++ b/src/EventArgs/DownloadDeniedEventArgs.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="DownloadDeniedEventArgs.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek
+{
+    /// <summary>
+    ///     Event arguments for events raised when a user reports that an upload has failed.
+    /// </summary>
+    public class DownloadDeniedEventArgs : UserEventArgs
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BrowseEventArgs"/> class.
+        /// </summary>
+        /// <param name="username">The username associated with the event.</param>
+        /// <param name="filename">The filename associated with the event.</param>
+        /// <param name="message">The message associated with the event.</param>
+        public DownloadDeniedEventArgs(string username, string filename, string message)
+            : base(username)
+        {
+            Filename = filename;
+            Message = message;
+        }
+
+        /// <summary>
+        ///     Gets the filename associated with the event.
+        /// </summary>
+        public string Filename { get; }
+
+        /// <summary>
+        ///     Gets the message associated with the event.
+        /// </summary>
+        public string Message { get; }
+    }
+}

--- a/src/EventArgs/DownloadFailedEventArgs.cs
+++ b/src/EventArgs/DownloadFailedEventArgs.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="DownloadFailedEventArgs.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek
+{
+    /// <summary>
+    ///     Event arguments for events raised when a user reports that an upload has failed.
+    /// </summary>
+    public class DownloadFailedEventArgs : UserEventArgs
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BrowseEventArgs"/> class.
+        /// </summary>
+        /// <param name="username">The username associated with the event.</param>
+        /// <param name="filename">The filename associated with the event.</param>
+        public DownloadFailedEventArgs(string username, string filename)
+            : base(username)
+        {
+            Filename = filename;
+        }
+
+        /// <summary>
+        ///     Gets the filename associated with the event.
+        /// </summary>
+        public string Filename { get; }
+    }
+}

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -77,6 +77,16 @@ namespace Soulseek
         event EventHandler<DistributedParentEventArgs> DistributedParentDisconnected;
 
         /// <summary>
+        ///     Occurs when a user reports that a download has been denied.
+        /// </summary>
+        event EventHandler<DownloadDeniedEventArgs> DownloadDenied;
+
+        /// <summary>
+        ///     Occurs when a user reports that a download has failed.
+        /// </summary>
+        event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
+        /// <summary>
         ///     Occurs when a global message is received.
         /// </summary>
         event EventHandler<string> GlobalMessageReceived;

--- a/src/Messaging/Handlers/IPeerMessageHandler.cs
+++ b/src/Messaging/Handlers/IPeerMessageHandler.cs
@@ -17,6 +17,7 @@
 
 namespace Soulseek.Messaging.Handlers
 {
+    using System;
     using Soulseek.Network;
 
     /// <summary>
@@ -24,6 +25,16 @@ namespace Soulseek.Messaging.Handlers
     /// </summary>
     internal interface IPeerMessageHandler : IMessageHandler
     {
+        /// <summary>
+        ///     Occurs when a user reports that a download has been denied.
+        /// </summary>
+        event EventHandler<DownloadDeniedEventArgs> DownloadDenied;
+
+        /// <summary>
+        ///     Occurs when a user reports that a download has failed.
+        /// </summary>
+        event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
         /// <summary>
         ///     Handles the receipt of incoming messages, prior to the body having been read and parsed.
         /// </summary>

--- a/src/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Messaging/Handlers/PeerMessageHandler.cs
@@ -49,6 +49,16 @@ namespace Soulseek.Messaging.Handlers
         /// </summary>
         public event EventHandler<DiagnosticEventArgs> DiagnosticGenerated;
 
+        /// <summary>
+        ///     Occurs when a user reports that a download has been denied.
+        /// </summary>
+        public event EventHandler<DownloadDeniedEventArgs> DownloadDenied;
+
+        /// <summary>
+        ///     Occurs when a user reports that a download has failed.
+        /// </summary>
+        public event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
         private IDiagnosticFactory Diagnostic { get; }
         private SoulseekClient SoulseekClient { get; }
 
@@ -261,6 +271,8 @@ namespace Soulseek.Messaging.Handlers
 
                         Diagnostic.Debug($"Download of {uploadDeniedResponse.Filename} from {connection.Username} was denied: {uploadDeniedResponse.Message}");
                         SoulseekClient.Waiter.Throw(new WaitKey(MessageCode.Peer.TransferRequest, connection.Username, uploadDeniedResponse.Filename), new TransferRejectedException(uploadDeniedResponse.Message));
+                        
+                        DownloadDenied?.Invoke(this, new DownloadDeniedEventArgs(connection.Username, uploadDeniedResponse.Filename, uploadDeniedResponse.Message));
                         break;
 
                     case MessageCode.Peer.PlaceInQueueResponse:
@@ -285,6 +297,8 @@ namespace Soulseek.Messaging.Handlers
                         }
 
                         Diagnostic.Debug(msg);
+
+                        DownloadFailed?.Invoke(this, new DownloadFailedEventArgs(connection.Username, uploadFailedResponse.Filename));
                         break;
 
                     default:

--- a/src/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Messaging/Handlers/PeerMessageHandler.cs
@@ -258,6 +258,8 @@ namespace Soulseek.Messaging.Handlers
 
                     case MessageCode.Peer.UploadDenied:
                         var uploadDeniedResponse = UploadDenied.FromByteArray(message);
+
+                        Diagnostic.Debug($"Download of {uploadDeniedResponse.Filename} from {connection.Username} was denied: {uploadDeniedResponse.Message}");
                         SoulseekClient.Waiter.Throw(new WaitKey(MessageCode.Peer.TransferRequest, connection.Username, uploadDeniedResponse.Filename), new TransferRejectedException(uploadDeniedResponse.Message));
                         break;
 

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3037,6 +3037,8 @@ namespace Soulseek
                     {
                         // if the remote user doesn't initiate a transfer connection, try to initiate one from this end. the
                         // remote client in this scenario is most likely Nicotine+.
+                        Diagnostic.Debug($"Attempting to initiate a second-chance transfer connection to {username} for download of {download.Filename}");
+
                         download.Connection = await PeerConnectionManager
                             .GetTransferConnectionAsync(username, endpoint, download.RemoteToken.Value, cancellationToken)
                             .ConfigureAwait(false);

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -120,6 +120,8 @@ namespace Soulseek
 
             PeerMessageHandler = peerMessageHandler ?? new PeerMessageHandler(this);
             PeerMessageHandler.DiagnosticGenerated += (sender, e) => DiagnosticGenerated?.Invoke(sender, e);
+            PeerMessageHandler.DownloadFailed += (sender, e) => DownloadFailed?.Invoke(this, e);
+            PeerMessageHandler.DownloadDenied += (sender, e) => DownloadDenied?.Invoke(this, e);
 
             DistributedMessageHandler = distributedMessageHandler ?? new DistributedMessageHandler(this);
             DistributedMessageHandler.DiagnosticGenerated += (sender, e) => DiagnosticGenerated?.Invoke(sender, e);
@@ -220,6 +222,16 @@ namespace Soulseek
         ///     Occurs when the parent is disconnected.
         /// </summary>
         public event EventHandler<DistributedParentEventArgs> DistributedParentDisconnected;
+
+        /// <summary>
+        ///     Occurs when a user reports that a download has been denied.
+        /// </summary>
+        public event EventHandler<DownloadDeniedEventArgs> DownloadDenied;
+
+        /// <summary>
+        ///     Occurs when a user reports that a download has failed.
+        /// </summary>
+        public event EventHandler<DownloadFailedEventArgs> DownloadFailed;
 
         /// <summary>
         ///     Occurs when a global message is received.

--- a/tests/Soulseek.Tests.Unit/EventArgs/UserEventArgsTests.cs
+++ b/tests/Soulseek.Tests.Unit/EventArgs/UserEventArgsTests.cs
@@ -32,5 +32,26 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(username, e.Username);
             Assert.Equal(token, e.Token);
         }
+
+        [Trait("Category", "DownloadDeniedEventArgs Instantiation")]
+        [Theory(DisplayName = "DownloadDeniedEventArgs Instantiates with the given data"), AutoData]
+        public void DownloadDeniedEventArgs_Instantiates_With_The_Given_Data(string username, string filename, string message)
+        {
+            var e = new DownloadDeniedEventArgs(username, filename, message);
+
+            Assert.Equal(username, e.Username);
+            Assert.Equal(filename, e.Filename);
+            Assert.Equal(message, e.Message);
+        }
+
+        [Trait("Category", "DownloadFailedEventArgs Instantiation")]
+        [Theory(DisplayName = "DownloadFailedEventArgs Instantiates with the given data"), AutoData]
+        public void DownloadFailedEventArgs_Instantiates_With_The_Given_Data(string username, string filename)
+        {
+            var e = new DownloadFailedEventArgs(username, filename);
+
+            Assert.Equal(username, e.Username);
+            Assert.Equal(filename, e.Filename);
+        }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -86,6 +86,49 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             }
         }
 
+        [Trait("Category", "DownloadDenied")]
+        [Theory(DisplayName = "Raises DownloadDenied on UploadDenied"), AutoData]
+        public void Raises_DownloadDenied_On_UploadDenied(string username, string filename, string message)
+        {
+            var (handler, mocks) = GetFixture(username);
+
+            using (var client = new SoulseekClient(options: null))
+            {
+                DownloadDeniedEventArgs args = default;
+
+                PeerMessageHandler l = new PeerMessageHandler(client);
+                l.DownloadDenied += (sender, e) => args = e;
+
+                l.HandleMessageRead(mocks.PeerConnection.Object, new UploadDenied(filename, message).ToByteArray());
+
+                Assert.NotNull(args);
+                Assert.Equal(username, args.Username);
+                Assert.Equal(filename, args.Filename);
+                Assert.Equal(message, args.Message);
+            }
+        }
+
+        [Trait("Category", "DownloadFailed")]
+        [Theory(DisplayName = "Raises DownloadFailed on UploadFailed"), AutoData]
+        public void Raises_DownloadFailed_On_UploadFailed(string username, string filename)
+        {
+            var (handler, mocks) = GetFixture(username);
+
+            using (var client = new SoulseekClient(options: null))
+            {
+                DownloadFailedEventArgs args = default;
+
+                PeerMessageHandler l = new PeerMessageHandler(client);
+                l.DownloadFailed += (sender, e) => args = e;
+
+                l.HandleMessageRead(mocks.PeerConnection.Object, new UploadFailed(filename).ToByteArray());
+
+                Assert.NotNull(args);
+                Assert.Equal(username, args.Username);
+                Assert.Equal(filename, args.Filename);
+            }
+        }
+
         [Trait("Category", "Diagnostic")]
         [Theory(DisplayName = "Does not throw raising DiagnosticGenerated if no handlers bound"), AutoData]
         public void Does_Not_Throw_Raising_DiagnosticGenerated_If_No_Handlers_Bound(string message)

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -596,6 +596,44 @@ namespace Soulseek.Tests.Unit
             }
         }
 
+        [Trait("Category", "DownloadFailed")]
+        [Fact(DisplayName = "Raises DownloadFailed when user sends UploadFailed")]
+        public void Raises_DownloadFailed_When_User_Sends_UploadFailed()
+        {
+            var handlerMock = new Mock<IPeerMessageHandler>();
+
+            using (var s = new SoulseekClient(peerMessageHandler: handlerMock.Object))
+            {
+                DownloadFailedEventArgs args = null;
+                s.DownloadFailed += (sender, e) => args = e;
+
+                var expected = new DownloadFailedEventArgs("user", "file");
+                handlerMock.Raise(m => m.DownloadFailed += null, expected);
+
+                Assert.NotNull(args);
+                Assert.Equal(expected, args);
+            }
+        }
+
+        [Trait("Category", "DownloadRejected")]
+        [Fact(DisplayName = "Raises DownloadDenied when user sends UploadDenied")]
+        public void Raises_DownloadDenied_When_User_Sends_UploadDenied()
+        {
+            var handlerMock = new Mock<IPeerMessageHandler>();
+
+            using (var s = new SoulseekClient(peerMessageHandler: handlerMock.Object))
+            {
+                DownloadDeniedEventArgs args = null;
+                s.DownloadDenied += (sender, e) => args = e;
+
+                var expected = new DownloadDeniedEventArgs("user", "file", "message");
+                handlerMock.Raise(m => m.DownloadDenied += null, expected);
+
+                Assert.NotNull(args);
+                Assert.Equal(expected, args);
+            }
+        }
+
         [Trait("Category", "KickedFromServer")]
         [Fact(DisplayName = "Disconnects when kicked from server")]
         public void Disconnects_When_Kicked_From_Server()


### PR DESCRIPTION
Improves logging of these messages, and of the "second chance" connection required for older versions of Nicotine+

Closes #668 