### PR TITLE
Fix bug causing infinite loop on large uploads

### DIFF
--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -701,7 +701,7 @@ namespace Soulseek.Network.Tcp
             {
                 ResetInactivityTime();
 
-                var totalBytesWritten = 0;
+                long totalBytesWritten = 0;
 
                 while (totalBytesWritten < length)
                 {


### PR DESCRIPTION
With large transfers `totalBytesWritten` would overflow and never satisfy the while condition.