### PR TITLE
Improve accuracy of rate limiting

### DIFF
--- a/src/Common/ITokenBucket.cs
+++ b/src/Common/ITokenBucket.cs
@@ -27,34 +27,33 @@ namespace Soulseek
     internal interface ITokenBucket
     {
         /// <summary>
-        ///     Returns the specified number of tokens to the bucket.
+        ///     Gets the bucket capacity.
         /// </summary>
-        /// <param name="count">The number of tokens to return.</param>
-        void Return(long count);
+        public long Capacity { get; }
 
         /// <summary>
-        ///     Sets the token count to the supplied <paramref name="count"/>.
+        ///     Asynchronously retrieves the specified token <paramref name="count"/> from the bucket.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         If the requested <paramref name="count"/> exceeds the bucket <see cref="Capacity"/>, the request is lowered to
+        ///         the capacity of the bucket.
+        ///     </para>
+        ///     <para>If the bucket has tokens available, but fewer than the requested amount, the available tokens are returned.</para>
+        ///     <para>
+        ///         If the bucket has no tokens available, execution waits for the bucket to be replenished before servicing the request.
+        ///     </para>
+        /// </remarks>
+        /// <param name="count">The number of tokens to retrieve.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A Task that completes when tokens have been provided.</returns>
+        Task<int> GetAsync(int count, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Sets the bucket capacity to the supplied <paramref name="capacity"/>.
         /// </summary>
         /// <remarks>Change takes effect on the next reset.</remarks>
-        /// <param name="count">The new number of tokens.</param>
-        void SetCount(long count);
-
-        /// <summary>
-        ///     Asynchronously waits for a single token from the bucket.
-        /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A Task that completes when the token has been provided.</returns>
-        Task WaitAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
-        ///     Asynchronously waits for the requested token <paramref name="count"/> from the bucket.
-        /// </summary>
-        /// <param name="count">The number of tokens for which to wait.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>A Task that completes when the requested number of tokens have been provided.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///     Thrown when the requested number of tokens exceeds the bucket capacity.
-        /// </exception>
-        Task WaitAsync(long count, CancellationToken cancellationToken = default);
+        /// <param name="capacity">The bucket capacity.</param>
+        void SetCapacity(long capacity);
     }
 }

--- a/src/Common/ITokenBucket.cs
+++ b/src/Common/ITokenBucket.cs
@@ -27,11 +27,17 @@ namespace Soulseek
     internal interface ITokenBucket
     {
         /// <summary>
+        ///     Returns the specified number of tokens to the bucket.
+        /// </summary>
+        /// <param name="count">The number of tokens to return.</param>
+        void Return(long count);
+
+        /// <summary>
         ///     Sets the token count to the supplied <paramref name="count"/>.
         /// </summary>
         /// <remarks>Change takes effect on the next reset.</remarks>
         /// <param name="count">The new number of tokens.</param>
-        void SetCount(int count);
+        void SetCount(long count);
 
         /// <summary>
         ///     Asynchronously waits for a single token from the bucket.
@@ -49,6 +55,6 @@ namespace Soulseek
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the requested number of tokens exceeds the bucket capacity.
         /// </exception>
-        Task WaitAsync(int count, CancellationToken cancellationToken = default);
+        Task WaitAsync(long count, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Common/TokenBucket.cs
+++ b/src/Common/TokenBucket.cs
@@ -31,7 +31,7 @@ namespace Soulseek
         /// </summary>
         /// <param name="count">The initial number of tokens.</param>
         /// <param name="interval">The interval at which tokens are replenished.</param>
-        public TokenBucket(int count, int interval)
+        public TokenBucket(long count, int interval)
         {
             if (count < 1)
             {
@@ -52,8 +52,8 @@ namespace Soulseek
         }
 
         private System.Timers.Timer Clock { get; set; }
-        private int Count { get; set; }
-        private int CurrentCount { get; set; }
+        private long Count { get; set; }
+        private long CurrentCount { get; set; }
         private bool Disposed { get; set; }
         private SemaphoreSlim SyncRoot { get; } = new SemaphoreSlim(1, 1);
         private TaskCompletionSource<bool> WaitForReset { get; set; } = new TaskCompletionSource<bool>();
@@ -68,11 +68,23 @@ namespace Soulseek
         }
 
         /// <summary>
+        ///     Returns the specified number of tokens to the bucket.
+        /// </summary>
+        /// <param name="count">The number of tokens to return.</param>
+        public void Return(long count)
+        {
+            if (count > 0)
+            {
+                CurrentCount += count;
+            }
+        }
+
+        /// <summary>
         ///     Sets the token count to the supplied <paramref name="count"/>.
         /// </summary>
         /// <remarks>Change takes effect on the next reset.</remarks>
         /// <param name="count">The new number of tokens.</param>
-        public void SetCount(int count)
+        public void SetCount(long count)
         {
             if (count < 1)
             {
@@ -99,7 +111,7 @@ namespace Soulseek
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the requested number of tokens exceeds the bucket capacity.
         /// </exception>
-        public Task WaitAsync(int count, CancellationToken cancellationToken = default)
+        public Task WaitAsync(long count, CancellationToken cancellationToken = default)
         {
             if (count > Count)
             {
@@ -140,7 +152,7 @@ namespace Soulseek
             }
         }
 
-        private async Task WaitInternalAsync(int count, CancellationToken cancellationToken = default)
+        private async Task WaitInternalAsync(long count, CancellationToken cancellationToken = default)
         {
             Task waitTask = Task.CompletedTask;
 

--- a/src/Network/Tcp/IConnection.cs
+++ b/src/Network/Tcp/IConnection.cs
@@ -20,7 +20,6 @@ namespace Soulseek.Network.Tcp
     using System;
     using System.IO;
     using System.Net;
-    using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -147,6 +146,7 @@ namespace Soulseek.Network.Tcp
         /// <param name="length">The number of bytes to read.</param>
         /// <param name="outputStream">The stream to which the read data is to be written.</param>
         /// <param name="governor">The delegate used to govern transfer speed.</param>
+        /// <param name="reporter">The delegate used to report bytes read each iteration.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task representing the asynchronous operation, including the read bytes.</returns>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="length"/> is less than 1.</exception>
@@ -159,7 +159,7 @@ namespace Soulseek.Network.Tcp
         ///     is not connected.
         /// </exception>
         /// <exception cref="ConnectionReadException">Thrown when an unexpected error occurs.</exception>
-        Task ReadAsync(long length, Stream outputStream, Func<CancellationToken, Task> governor, CancellationToken? cancellationToken = null);
+        Task ReadAsync(long length, Stream outputStream, Func<CancellationToken, Task> governor, Action<int> reporter, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Waits for the connection to disconnect, returning the message or throwing the Exception which caused the disconnect.
@@ -191,6 +191,7 @@ namespace Soulseek.Network.Tcp
         /// <param name="length">The number of bytes to write.</param>
         /// <param name="inputStream">The stream from which the written data is to be read.</param>
         /// <param name="governor">The delegate used to govern transfer speed.</param>
+        /// <param name="reporter">The delegate used to report bytes read each iteration.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="length"/> is less than 1.</exception>
@@ -203,6 +204,6 @@ namespace Soulseek.Network.Tcp
         ///     is not connected.
         /// </exception>
         /// <exception cref="ConnectionWriteException">Thrown when an unexpected error occurs.</exception>
-        Task WriteAsync(long length, Stream inputStream, Func<CancellationToken, Task> governor, CancellationToken? cancellationToken = null);
+        Task WriteAsync(long length, Stream inputStream, Func<CancellationToken, Task> governor, Action<int> reporter, CancellationToken? cancellationToken = null);
     }
 }

--- a/src/Network/Tcp/IConnection.cs
+++ b/src/Network/Tcp/IConnection.cs
@@ -146,7 +146,6 @@ namespace Soulseek.Network.Tcp
         /// <param name="length">The number of bytes to read.</param>
         /// <param name="outputStream">The stream to which the read data is to be written.</param>
         /// <param name="governor">The delegate used to govern transfer speed.</param>
-        /// <param name="reporter">The delegate used to report bytes read each iteration.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task representing the asynchronous operation, including the read bytes.</returns>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="length"/> is less than 1.</exception>
@@ -159,7 +158,7 @@ namespace Soulseek.Network.Tcp
         ///     is not connected.
         /// </exception>
         /// <exception cref="ConnectionReadException">Thrown when an unexpected error occurs.</exception>
-        Task ReadAsync(long length, Stream outputStream, Func<CancellationToken, Task> governor, Action<int> reporter, CancellationToken? cancellationToken = null);
+        Task ReadAsync(long length, Stream outputStream, Func<int, CancellationToken, Task<int>> governor, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Waits for the connection to disconnect, returning the message or throwing the Exception which caused the disconnect.
@@ -191,7 +190,6 @@ namespace Soulseek.Network.Tcp
         /// <param name="length">The number of bytes to write.</param>
         /// <param name="inputStream">The stream from which the written data is to be read.</param>
         /// <param name="governor">The delegate used to govern transfer speed.</param>
-        /// <param name="reporter">The delegate used to report bytes read each iteration.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A Task representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">Thrown when the specified <paramref name="length"/> is less than 1.</exception>
@@ -204,6 +202,6 @@ namespace Soulseek.Network.Tcp
         ///     is not connected.
         /// </exception>
         /// <exception cref="ConnectionWriteException">Thrown when an unexpected error occurs.</exception>
-        Task WriteAsync(long length, Stream inputStream, Func<CancellationToken, Task> governor, Action<int> reporter, CancellationToken? cancellationToken = null);
+        Task WriteAsync(long length, Stream inputStream, Func<int, CancellationToken, Task<int>> governor, CancellationToken? cancellationToken = null);
     }
 }

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3173,11 +3173,11 @@ namespace Soulseek
                         },
                         reporter: (bytesRead) =>
                         {
-                            var tokensToReturn = Options.TransferConnectionOptions.ReadBufferSize - bytesRead;
+                            var toReturn = Options.TransferConnectionOptions.ReadBufferSize - bytesRead;
 
-                            if (tokensToReturn > 0)
+                            if (toReturn > 0)
                             {
-                                DownloadTokenBucket.Return(tokensToReturn);
+                                DownloadTokenBucket.Return(toReturn);
                             }
                         },
                         cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -112,19 +112,8 @@ namespace Soulseek
             UploadSemaphoreCleanupTimer.Elapsed += (sender, e) => _ = CleanupUploadSemaphoresAsync();
             UploadSemaphoreCleanupTimer.Start();
 
-            UploadTokenBucket = uploadTokenBucket;
-            if (uploadTokenBucket == null)
-            {
-                var uploadTokens = Math.Max((int)Math.Ceiling((double)(Options.MaximumUploadSpeed * 1024L / Options.TransferConnectionOptions.WriteBufferSize)), 1);
-                UploadTokenBucket = new TokenBucket(uploadTokens, 1000);
-            }
-
-            DownloadTokenBucket = downloadTokenBucket;
-            if (downloadTokenBucket == null)
-            {
-                var downloadTokens = Math.Max((int)Math.Ceiling((double)(Options.MaximumDownloadSpeed * 1024L / Options.TransferConnectionOptions.ReadBufferSize)), 1);
-                DownloadTokenBucket = new TokenBucket(downloadTokens, 1000);
-            }
+            UploadTokenBucket = uploadTokenBucket ?? new TokenBucket(Options.MaximumUploadSpeed * 1024L, 1000);
+            DownloadTokenBucket = downloadTokenBucket ?? new TokenBucket(Options.MaximumDownloadSpeed * 1024L, 1000);
 
             ServerConnection = serverConnection;
 
@@ -3017,8 +3006,6 @@ namespace Soulseek
 
         private async Task<Transfer> DownloadToStreamAsync(string username, string remoteFilename, Func<Stream> outputStreamFactory, long? size, long startOffset, int token, TransferOptions options, CancellationToken cancellationToken)
         {
-            options = options.WithAdditionalGovernor((_, cancellationToken) => DownloadTokenBucket.WaitAsync(cancellationToken));
-
             var download = new TransferInternal(TransferDirection.Download, username, remoteFilename, token, options)
             {
                 StartOffset = startOffset,
@@ -3176,7 +3163,24 @@ namespace Soulseek
                     UpdateState(TransferStates.InProgress);
                     UpdateProgress(download.StartOffset);
 
-                    await download.Connection.ReadAsync(download.Size.Value - startOffset, outputStream, (cancelToken) => options.Governor(new Transfer(download), cancelToken), cancellationToken).ConfigureAwait(false);
+                    await download.Connection.ReadAsync(
+                        length: download.Size.Value - startOffset, 
+                        outputStream: outputStream,
+                        governor: async (cancelToken) =>
+                        {
+                            await options.Governor(new Transfer(download), cancelToken).ConfigureAwait(false);
+                            await DownloadTokenBucket.WaitAsync(Options.TransferConnectionOptions.ReadBufferSize, cancellationToken).ConfigureAwait(false);
+                        },
+                        reporter: (bytesRead) =>
+                        {
+                            var tokensToReturn = Options.TransferConnectionOptions.ReadBufferSize - bytesRead;
+
+                            if (tokensToReturn > 0)
+                            {
+                                DownloadTokenBucket.Return(tokensToReturn);
+                            }
+                        },
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
 
                     download.State = TransferStates.Succeeded;
 
@@ -3883,8 +3887,6 @@ namespace Soulseek
 
         private async Task<Transfer> UploadFromStreamAsync(string username, string remoteFilename, long size, Func<Stream> inputStreamFactory, int token, TransferOptions options, CancellationToken cancellationToken)
         {
-            options = options.WithAdditionalGovernor((_, cancellationToken) => UploadTokenBucket.WaitAsync(cancellationToken));
-
             var upload = new TransferInternal(TransferDirection.Upload, username, remoteFilename, token, options)
             {
                 Size = size,
@@ -4044,7 +4046,25 @@ namespace Soulseek
 
                     if (size - startOffset > 0)
                     {
-                        await upload.Connection.WriteAsync(size - startOffset, inputStream, (cancelToken) => options.Governor(new Transfer(upload), cancelToken), cancellationToken).ConfigureAwait(false);
+                        await upload.Connection.WriteAsync(
+                            length: size - startOffset,
+                            inputStream: inputStream,
+                            governor: async (cancelToken) =>
+                            {
+                                await options.Governor(new Transfer(upload), cancelToken).ConfigureAwait(false);
+                                await UploadTokenBucket.WaitAsync(Options.TransferConnectionOptions.WriteBufferSize, cancellationToken).ConfigureAwait(false);
+                            },
+                            reporter: (bytesWritten) =>
+                            {
+                                var toReturn = Options.TransferConnectionOptions.WriteBufferSize - bytesWritten;
+
+                                if (toReturn > 0)
+                                {
+                                    Console.WriteLine($"returning {toReturn}");
+                                    UploadTokenBucket.Return(Options.TransferConnectionOptions.WriteBufferSize - bytesWritten);
+                                }
+                            },
+                            cancellationToken: cancellationToken).ConfigureAwait(false);
                     }
 
                     upload.State = TransferStates.Succeeded;

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -855,7 +855,7 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<byte[]>(new TimeoutException()));
 
             var waiter = new Mock<IWaiter>();
@@ -1075,7 +1075,7 @@ namespace Soulseek.Tests.Unit.Client
                 m => m.ReadAsync(
                     size,
                     It.IsAny<Stream>(),
-                    It.IsAny<Func<CancellationToken, Task>>(),
+                    It.IsAny<Func<int, CancellationToken, Task<int>>>(),
                     It.IsAny<CancellationToken?>()),
                 Times.Once);
         }
@@ -1139,7 +1139,7 @@ namespace Soulseek.Tests.Unit.Client
                 m => m.ReadAsync(
                     givenSize,
                     It.IsAny<Stream>(),
-                    It.IsAny<Func<CancellationToken, Task>>(),
+                    It.IsAny<Func<int, CancellationToken, Task<int>>>(),
                     It.IsAny<CancellationToken?>()),
                 Times.Once);
         }
@@ -1634,7 +1634,7 @@ namespace Soulseek.Tests.Unit.Client
                 m => m.ReadAsync(
                     size,
                     It.IsAny<Stream>(),
-                    It.IsAny<Func<CancellationToken, Task>>(),
+                    It.IsAny<Func<int, CancellationToken, Task<int>>>(),
                     It.IsAny<CancellationToken?>()),
                 Times.Once);
         }
@@ -1698,7 +1698,7 @@ namespace Soulseek.Tests.Unit.Client
                 m => m.ReadAsync(
                     givenSize,
                     It.IsAny<Stream>(),
-                    It.IsAny<Func<CancellationToken, Task>>(),
+                    It.IsAny<Func<int, CancellationToken, Task<int>>>(),
                     It.IsAny<CancellationToken?>()),
                 Times.Once);
         }
@@ -1829,7 +1829,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(ConnectionState.Connected);
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new byte[size]))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
 
@@ -1892,7 +1892,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(ConnectionState.Connected);
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(BitConverter.GetBytes(token)))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
 
@@ -1950,7 +1950,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(ConnectionState.Connected);
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(BitConverter.GetBytes(token)))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
 
@@ -2013,7 +2013,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(ConnectionState.Connected);
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(BitConverter.GetBytes(token)))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
 
@@ -2231,7 +2231,7 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<byte[]>(new NullReferenceException()));
 
             var waiter = new Mock<IWaiter>();
@@ -2287,7 +2287,7 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<byte[]>(new TimeoutException()));
 
             var waiter = new Mock<IWaiter>();
@@ -2341,7 +2341,7 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException<byte[]>(new OperationCanceledException()));
 
             var waiter = new Mock<IWaiter>();

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -399,14 +399,14 @@ namespace Soulseek.Tests.Unit.Client
 
             var patch = new SoulseekClientOptionsPatch(maximumUploadSpeed: speed);
 
-            var expected = Math.Max((int)Math.Ceiling((double)(speed * 1024L / client.Options.TransferConnectionOptions.WriteBufferSize)), 1);
+            var expected = speed * 1024L;
 
             using (client)
             {
                 await client.ReconfigureOptionsAsync(patch);
             }
 
-            mocks.UploadTokenBucket.Verify(m => m.SetCount(expected), Times.Once);
+            mocks.UploadTokenBucket.Verify(m => m.SetCapacity(expected), Times.Once);
         }
 
         [Trait("Category", "ReconfigureOptions")]
@@ -422,7 +422,7 @@ namespace Soulseek.Tests.Unit.Client
                 await client.ReconfigureOptionsAsync(patch);
             }
 
-            mocks.UploadTokenBucket.Verify(m => m.SetCount(It.IsAny<int>()), Times.Never);
+            mocks.UploadTokenBucket.Verify(m => m.SetCapacity(It.IsAny<int>()), Times.Never);
         }
 
         [Trait("Category", "ReconfigureOptions")]
@@ -433,14 +433,14 @@ namespace Soulseek.Tests.Unit.Client
 
             var patch = new SoulseekClientOptionsPatch(maximumDownloadSpeed: speed);
 
-            var expected = Math.Max((int)Math.Ceiling((double)(speed * 1024L / client.Options.TransferConnectionOptions.ReadBufferSize)), 1);
+            var expected = speed * 1024L;
 
             using (client)
             {
                 await client.ReconfigureOptionsAsync(patch);
             }
 
-            mocks.DownloadTokenBucket.Verify(m => m.SetCount(expected), Times.Once);
+            mocks.DownloadTokenBucket.Verify(m => m.SetCapacity(expected), Times.Once);
         }
 
         [Trait("Category", "ReconfigureOptions")]
@@ -456,7 +456,7 @@ namespace Soulseek.Tests.Unit.Client
                 await client.ReconfigureOptionsAsync(patch);
             }
 
-            mocks.DownloadTokenBucket.Verify(m => m.SetCount(It.IsAny<int>()), Times.Never);
+            mocks.DownloadTokenBucket.Verify(m => m.SetCapacity(It.IsAny<int>()), Times.Never);
         }
 
         [Trait("Category", "ReconfigureOptions")]

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -1366,7 +1366,7 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.Equal(offset, stream.Position);
             }
 
-            transferConn.Verify(m => m.WriteAsync(size - offset, It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken?>()));
+            transferConn.Verify(m => m.WriteAsync(size - offset, It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken?>()));
         }
 
         [Trait("Category", "UploadFromFileAsync")]
@@ -1477,7 +1477,7 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(ConnectionState.Connected);
             transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken?>()))
                 .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
-            transferConn.Setup(m => m.WriteAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            transferConn.Setup(m => m.WriteAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Raises(m => m.DataWritten += null, this, new ConnectionDataEventArgs(1, 1));
             transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))

--- a/tests/Soulseek.Tests.Unit/Common/TokenBucketTests.cs
+++ b/tests/Soulseek.Tests.Unit/Common/TokenBucketTests.cs
@@ -86,11 +86,11 @@ namespace Soulseek.Tests.Unit
         {
             using (var t = new TokenBucket(10, 1000))
             {
-                var ex = Record.Exception(() => t.SetCount(0));
+                var ex = Record.Exception(() => t.SetCapacity(0));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
-                Assert.Equal("count", ((ArgumentOutOfRangeException)ex).ParamName);
+                Assert.Equal("capacity", ((ArgumentOutOfRangeException)ex).ParamName);
             }
         }
 
@@ -100,35 +100,23 @@ namespace Soulseek.Tests.Unit
         {
             using (var t = new TokenBucket(10, 1000))
             {
-                var ex = Record.Exception(() => t.SetCount(-1));
+                var ex = Record.Exception(() => t.SetCapacity(-1));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
-                Assert.Equal("count", ((ArgumentOutOfRangeException)ex).ParamName);
+                Assert.Equal("capacity", ((ArgumentOutOfRangeException)ex).ParamName);
             }
         }
 
-        [Trait("Category", "SetCount")]
-        [Theory(DisplayName = "SetCount sets count"), AutoData]
-        public void SetCount_Sets_Count(int count)
+        [Trait("Category", "SetCapacity")]
+        [Theory(DisplayName = "SetCapacity sets capacity"), AutoData]
+        public void SetCapacity_Sets_Capacity(int count)
         {
             using (var t = new TokenBucket(10, 1000))
             {
-                t.SetCount(count);
+                t.SetCapacity(count);
 
-                Assert.Equal(count, t.GetProperty<int>("Count"));
-            }
-        }
-
-        [Trait("Category", "WaitAsync")]
-        [Fact(DisplayName = "WaitAsync decrements count by 1")]
-        public async Task WaitAsync_Decrements_Count_By_1()
-        {
-            using (var t = new TokenBucket(10, 10000))
-            {
-                await t.WaitAsync();
-
-                Assert.Equal(9, t.GetProperty<int>("CurrentCount"));
+                Assert.Equal(count, t.Capacity);
             }
         }
 
@@ -138,7 +126,7 @@ namespace Soulseek.Tests.Unit
         {
             using (var t = new TokenBucket(10, 10000))
             {
-                await t.WaitAsync(5);
+                await t.GetAsync(5);
 
                 Assert.Equal(5, t.GetProperty<int>("CurrentCount"));
             }
@@ -150,7 +138,7 @@ namespace Soulseek.Tests.Unit
         {
             using (var t = new TokenBucket(10, 10000))
             {
-                var ex = await Record.ExceptionAsync(() => t.WaitAsync(11));
+                var ex = await Record.ExceptionAsync(() => t.GetAsync(11));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentOutOfRangeException>(ex);
@@ -164,8 +152,8 @@ namespace Soulseek.Tests.Unit
         {
             using (var t = new TokenBucket(1, 10))
             {
-                await t.WaitAsync();
-                await t.WaitAsync();
+                await t.GetAsync(1);
+                await t.GetAsync(1);
 
                 Assert.True(true);
             }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -644,7 +644,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(length, stream, (s, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentException>(ex);
@@ -664,7 +664,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(1, null, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(1, null, (s, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentNullException>(ex);
@@ -685,7 +685,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(1, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(1, stream, (s, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);
@@ -716,7 +716,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Write")]
         [Theory(DisplayName = "Write from stream throws if TcpClient is not connected"), AutoData]
-        public async Task Write_From_Stream_Throws_If_TcpClient_Is_Not_Connected(IPEndPoint endpoint, int length, Func<CancellationToken, Task> governor)
+        public async Task Write_From_Stream_Throws_If_TcpClient_Is_Not_Connected(IPEndPoint endpoint, int length, Func<int, CancellationToken, Task<int>> governor)
         {
             var t = new Mock<ITcpClient>();
 
@@ -761,7 +761,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Write")]
         [Theory(DisplayName = "Write from stream throws if connection is not connected"), AutoData]
-        public async Task Write_From_Stream_Throws_If_Connection_Is_Not_Connected(IPEndPoint endpoint, int length, Func<CancellationToken, Task> governor)
+        public async Task Write_From_Stream_Throws_If_Connection_Is_Not_Connected(IPEndPoint endpoint, int length, Func<int, CancellationToken, Task<int>> governor)
         {
             var t = new Mock<ITcpClient>();
 
@@ -945,7 +945,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    await c.WriteAsync(1, stream, (ct) => Task.CompletedTask, cancellationToken);
+                    await c.WriteAsync(1, stream, (size, ct) => Task.FromResult(int.MaxValue), cancellationToken);
 
                     s.Verify(m => m.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), cancellationToken), Times.Once);
                 }
@@ -1035,7 +1035,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(writeBufferSize: 16)))
                 {
-                    await c.WriteAsync(32, stream, (ct) => Task.CompletedTask);
+                    await c.WriteAsync(32, stream, (ct, size) => Task.FromResult(int.MaxValue));
 
                     s.Verify(m => m.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
                 }
@@ -1060,7 +1060,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(data.Length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.WriteAsync(data.Length, stream, (ct, size) => Task.FromResult(int.MaxValue)));
 
                     Assert.Null(ex);
 
@@ -1125,7 +1125,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Read")]
         [Theory(DisplayName = "Read to stream throws if TcpClient is not connected"), AutoData]
-        public async Task Read_To_Stream_Throws_If_TcpClient_Is_Not_Connected(IPEndPoint endpoint, Func<CancellationToken, Task> governor)
+        public async Task Read_To_Stream_Throws_If_TcpClient_Is_Not_Connected(IPEndPoint endpoint, Func<int, CancellationToken, Task<int>> governor)
         {
             var t = new Mock<ITcpClient>();
 
@@ -1171,7 +1171,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Read")]
         [Theory(DisplayName = "Read to stream throws if connection is not connected"), AutoData]
-        public async Task Read_To_Stream_Throws_If_Connection_Is_Not_Connected(IPEndPoint endpoint, Func<CancellationToken, Task> governor)
+        public async Task Read_To_Stream_Throws_If_Connection_Is_Not_Connected(IPEndPoint endpoint, Func<int, CancellationToken, Task<int>> governor)
         {
             var t = new Mock<ITcpClient>();
 
@@ -1221,7 +1221,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
         [Trait("Category", "Read")]
         [Theory(DisplayName = "Read to stream does not throw if length is long and larger than int"), AutoData]
-        public async Task Read_To_Stream_Does_Not_Throw_If_Length_Is_Long_And_Larger_Than_Int(IPEndPoint endpoint, long length, Func<CancellationToken, Task> governor)
+        public async Task Read_To_Stream_Does_Not_Throw_If_Length_Is_Long_And_Larger_Than_Int(IPEndPoint endpoint, long length, Func<int, CancellationToken, Task<int>> governor)
         {
             var s = new Mock<INetworkStream>();
             s.Setup(m => m.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>()))
@@ -1291,7 +1291,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(1, stream, (size, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.Null(ex);
 
@@ -1373,7 +1373,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    await c.ReadAsync(1, stream, (ct) => Task.CompletedTask, cancellationToken);
+                    await c.ReadAsync(1, stream, (size, ct) => Task.FromResult(int.MaxValue), cancellationToken);
 
                     s.Verify(m => m.ReadAsync(It.IsAny<Memory<byte>>(), cancellationToken), Times.Once);
                 }
@@ -1426,7 +1426,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    await c.ReadAsync(3, stream, (ct) => Task.CompletedTask);
+                    await c.ReadAsync(3, stream, (size, ct) => Task.FromResult(int.MaxValue));
 
                     s.Verify(m => m.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
                 }
@@ -1452,7 +1452,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object, options: new ConnectionOptions(readBufferSize: 16)))
                 {
-                    await c.ReadAsync(32, stream, (ct) => Task.CompletedTask);
+                    await c.ReadAsync(32, stream, (size, ct) => Task.FromResult(int.MaxValue));
 
                     s.Verify(m => m.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
                 }
@@ -1631,7 +1631,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, (size, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentException>(ex);
@@ -1652,7 +1652,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, null, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, null, (size, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.NotNull(ex);
                     Assert.IsType<ArgumentNullException>(ex);
@@ -1674,7 +1674,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 using (var c = new Connection(endpoint, tcpClient: t.Object))
                 {
-                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, (ct) => Task.CompletedTask));
+                    var ex = await Record.ExceptionAsync(() => c.ReadAsync(length, stream, (size, ct) => Task.FromResult(int.MaxValue)));
 
                     Assert.NotNull(ex);
                     Assert.IsType<InvalidOperationException>(ex);


### PR DESCRIPTION
Changes the signature of the transfer governor in `TransferOptions` from:

```c#
Func<Transfer, CancellationToken, Task> Governor
```

To:

```c#
Func<Transfer, int, CancellationToken, Task<int>> Governor
```

When the governor is called it is passed an instance of the current `Transfer` and an `int` containing the number of bytes that will be attempted to be read or written (equal to the transfer read/write buffer size).  The governor now returns a `Task<int>` containing the number of bytes that have been "granted" for send or receive.

Implementing code should greatly benefit from the ability to influence both the time the governor call takes, but also how many bytes are allowed to be transmitted.

Closes #676 (again)