### PR TITLE
Add remark about potential for EnqueueDownloadAsync() to block

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -630,8 +630,14 @@ namespace Soulseek
         ///     </para>
         /// </summary>
         /// <remarks>
-        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
-        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     <para>
+        ///         If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
+        ///         specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     </para>
+        ///     <para>
+        ///         The operation will be blocked if <see cref="SoulseekClientOptions.MaximumConcurrentDownloads"/> is exceeded,
+        ///         and will not continue until the number of active downloads has decreased below the limit.
+        ///     </para>
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
@@ -678,8 +684,14 @@ namespace Soulseek
         ///     </para>
         /// </summary>
         /// <remarks>
-        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
-        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     <para>
+        ///         If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
+        ///         specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     </para>
+        ///     <para>
+        ///         The operation will be blocked if <see cref="SoulseekClientOptions.MaximumConcurrentDownloads"/> is exceeded,
+        ///         and will not continue until the number of active downloads has decreased below the limit.
+        ///     </para>
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -1175,8 +1175,14 @@ namespace Soulseek
         ///     </para>
         /// </summary>
         /// <remarks>
-        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
-        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     <para>
+        ///         If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
+        ///         specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     </para>
+        ///     <para>
+        ///         The operation will be blocked if <see cref="SoulseekClientOptions.MaximumConcurrentDownloads"/> is exceeded,
+        ///         and will not continue until the number of active downloads has decreased below the limit.
+        ///     </para>
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>
@@ -1253,8 +1259,14 @@ namespace Soulseek
         ///     </para>
         /// </summary>
         /// <remarks>
-        ///     If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
-        ///     specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     <para>
+        ///         If <paramref name="size"/> is omitted, the size provided by the remote client is used. Transfers initiated without
+        ///         specifying a size are limited to 4gb or less due to a shortcoming of the SoulseekQt client.
+        ///     </para>
+        ///     <para>
+        ///         The operation will be blocked if <see cref="SoulseekClientOptions.MaximumConcurrentDownloads"/> is exceeded,
+        ///         and will not continue until the number of active downloads has decreased below the limit.
+        ///     </para>
         /// </remarks>
         /// <param name="username">The user from which to download the file.</param>
         /// <param name="remoteFilename">The file to download, as reported by the remote user.</param>


### PR DESCRIPTION
This method typically returns when the download has been enqueued remotely; if it is queued locally the outcome is indeterminate until the local queue is freed up.  Blocking until this happens is the most accurate behavior, but consumers should be aware when `await`ing these calls.