### PR TITLE
Fix bug causing MaximumConcurrentDownloads to be unset when reconfiguring options

### DIFF
--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -470,6 +470,7 @@ namespace Soulseek
                 distributedChildLimit: distributedChildLimit ?? DistributedChildLimit,
                 maximumConcurrentUploads: MaximumConcurrentUploads,
                 maximumUploadSpeed: maximumUploadSpeed ?? MaximumUploadSpeed,
+                maximumConcurrentDownloads: MaximumConcurrentDownloads,
                 maximumDownloadSpeed: maximumDownloadSpeed ?? MaximumDownloadSpeed,
                 deduplicateSearchRequests: deduplicateSearchRequests ?? DeduplicateSearchRequests,
                 messageTimeout: MessageTimeout,

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.4.3</Version>
+    <Version>4.4.4</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
@@ -364,7 +364,17 @@ namespace Soulseek.Tests.Unit.Options
                 enqueueDownload: enqueueDownloadAction,
                 placeInQueueResolver: placeInQueueResponseResolver);
 
-            var o = new SoulseekClientOptions().With(patch);
+            var original = new SoulseekClientOptions(
+                maximumConcurrentUploads: 42,
+                maximumConcurrentDownloads: 24,
+                minimumDiagnosticLevel: DiagnosticLevel.None);
+
+            var o = original.With(patch);
+
+            // make sure the options that can't be patched did not change
+            Assert.Equal(42, o.MaximumConcurrentUploads);
+            Assert.Equal(24, o.MaximumConcurrentDownloads);
+            Assert.Equal(DiagnosticLevel.None, o.MinimumDiagnosticLevel);
 
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenPort, o.ListenPort);


### PR DESCRIPTION
Bumps version to 4.4.4.