### PR TITLE
Fix bug making it impossible to reduce maximum upload/download speed if no speed was specified at start

### DIFF
--- a/src/Common/TokenBucket.cs
+++ b/src/Common/TokenBucket.cs
@@ -49,7 +49,12 @@ namespace Soulseek
             CurrentCount = Capacity;
 
             Clock = new System.Timers.Timer(interval);
-            Clock.Elapsed += (sender, e) => Reset();
+            Clock.Elapsed += (sender, e) =>
+            {
+                CurrentCount = Capacity;
+                Reset();
+            };
+
             Clock.Start();
         }
 
@@ -124,6 +129,7 @@ namespace Soulseek
             }
 
             Capacity = capacity;
+            CurrentCount = Math.Min(CurrentCount, Capacity);
         }
 
         private void Dispose(bool disposing)
@@ -152,7 +158,6 @@ namespace Soulseek
                 if (CurrentCount == 0)
                 {
                     await waitForReset.Task.ConfigureAwait(false);
-                    CurrentCount = Capacity;
                 }
 
                 // take the minimum of requested count or CurrentCount, deduct it from

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.4.4</Version>
+    <Version>4.4.5</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>


### PR DESCRIPTION
The internal `TokenBucket` implementation is initialized with a high capacity, equal to `int.MaxValue`, if no value is specified in options.  Reconfiguring options after start is supposed to resize the buckets, and it does, however the previous implementation didn't change capacity, and capacity was only reset once the bucket was completed.

This change resets the current bucket count to the capacity each time the timer ticks, and reduces the capacity when resizing the bucket, if the new size is smaller than the current capacity.