### PR TITLE
Remove redundant calls in Dispose.  When getting a connection to remo…

### DIFF
--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -647,7 +647,14 @@ namespace Soulseek.Network
             {
                 if (ChildConnectionDictionary.TryRemove(ChildConnectionDictionary.Keys.First(), out var value))
                 {
-                    (await value.Value.ConfigureAwait(false))?.Dispose();
+                    try
+                    {
+                        (await value.Value.ConfigureAwait(false))?.Dispose();
+                    }
+                    catch
+                    {
+                        // noop
+                    }
                 }
             }
 

--- a/src/Network/PeerConnectionManager.cs
+++ b/src/Network/PeerConnectionManager.cs
@@ -653,7 +653,14 @@ namespace Soulseek.Network
             {
                 if (MessageConnectionDictionary.TryRemove(MessageConnectionDictionary.Keys.First(), out var connection))
                 {
-                    (await connection.Value.ConfigureAwait(false))?.Dispose();
+                    try
+                    {
+                        (await connection.Value.ConfigureAwait(false))?.Dispose();
+                    }
+                    catch
+                    {
+                        // noop
+                    }
                 }
             }
         }

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2611,12 +2611,10 @@ namespace Soulseek
                     Disconnect("Client is being disposed", new ObjectDisposedException(GetType().Name));
                     Listener?.Stop();
 
-                    PeerConnectionManager.RemoveAndDisposeAll();
                     PeerConnectionManager.Dispose();
 
                     DistributedConnectionManager.Dispose();
 
-                    Waiter.CancelAll();
                     Waiter.Dispose();
 
                     ServerConnection?.Dispose();


### PR DESCRIPTION
…ve, there is a potential timing issue where if task is not yet completed and the connection fails, an exception will be thrown.  Catch it so we can continue disposing.

For #703