### PR TITLE
Argument validation for messages is too strict.

### DIFF
--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2189,7 +2189,7 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="username"/> or <paramref name="message"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="username"/> or <paramref name="message"/> is null or empty.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
@@ -2202,9 +2202,9 @@ namespace Soulseek
                 throw new ArgumentException("The username must not be a null or empty string, or one consisting only of whitespace", nameof(username));
             }
 
-            if (string.IsNullOrWhiteSpace(message))
+            if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentException("The message must not be a null or empty string, or one consisting only of whitespace", nameof(message));
+                throw new ArgumentException("The message must not be a null or empty string", nameof(message));
             }
 
             if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
@@ -2223,7 +2223,7 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="roomName"/> or <paramref name="message"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="roomName"/> or <paramref name="message"/> is null or empty.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
@@ -2236,9 +2236,9 @@ namespace Soulseek
                 throw new ArgumentException("The room name must not be a null or empty string, or one consisting only of whitespace", nameof(roomName));
             }
 
-            if (string.IsNullOrWhiteSpace(message))
+            if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentException("The message must not be a null or empty string, or one consisting only of whitespace", nameof(message));
+                throw new ArgumentException("The message must not be a null or empty string", nameof(message));
             }
 
             if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
@@ -2292,7 +2292,7 @@ namespace Soulseek
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The Task representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when the <paramref name="roomName"/> or <paramref name="message"/> is null, empty, or consists only of whitespace.
+        ///     Thrown when the <paramref name="roomName"/> or <paramref name="message"/> is null or empty.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
         /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
@@ -2305,9 +2305,9 @@ namespace Soulseek
                 throw new ArgumentException("The room name must not be a null or empty string, or one consisting only of whitespace", nameof(roomName));
             }
 
-            if (string.IsNullOrWhiteSpace(message))
+            if (string.IsNullOrEmpty(message))
             {
-                throw new ArgumentException("The message must not be a null or empty string, or one consisting only of whitespace", nameof(message));
+                throw new ArgumentException("The message must not be a null or empty string", nameof(message));
             }
 
             if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))


### PR DESCRIPTION
The argument validation logic for sending chat, ticker, and private messages is too strict.  (1) The library imo should only filter out what is not allowed by the protocol which is an empty string.  It should not filter out whitespace since that is allowed.  (2) It is not uncommon to send a " " in chat (roughly means "well anyway...") and other clients support it.