### PR TITLE
Don't try to broadcast to unconnected connections

### DIFF
--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -460,7 +460,11 @@ namespace Soulseek.Network
                 try
                 {
                     var connection = await child.Value.Value.ConfigureAwait(false);
-                    await connection.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+
+                    if (connection.State == ConnectionState.Connected)
+                    {
+                        await connection.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
I believe this is the root cause of the log noise described in #725.

```
Failed to broadcast message to <user>: Operation timed out after 30000 milliseconds
```

I didn't realize it until this morning but there's no reason for a write to wait 30 seconds before timing out; the 30 second timeout is from the connection logic itself.  A connection would come in and get added to the child connection dictionary in a half-open state, then we'd start broadcasting messages to it which would buffer until either connected, or if the connection failed, each of the buffered broadcasts would fail simultaneously and dump messages to the logs.