### PR TITLE
Disconnect distributed children on broadcast failure

### DIFF
--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -457,9 +457,11 @@ namespace Soulseek.Network
 
             async Task Write(KeyValuePair<string, Lazy<Task<IMessageConnection>>> child, byte[] bytes, CancellationToken? cancellationToken)
             {
+                IMessageConnection connection = default;
+
                 try
                 {
-                    var connection = await child.Value.Value.ConfigureAwait(false);
+                    connection = await child.Value.Value.ConfigureAwait(false);
 
                     if (connection.State == ConnectionState.Connected)
                     {
@@ -468,7 +470,7 @@ namespace Soulseek.Network
                 }
                 catch (Exception ex)
                 {
-                    Diagnostic.Debug($"Failed to broadcast message to {child.Key}: {ex.Message}", ex);
+                    connection?.Disconnect($"Broadcast failure: {ex.Message}");
                 }
             }
 


### PR DESCRIPTION
The distributed network is extremely noisy, and one of the more annoying quirks is that when a child connection "goes bad" there's a tendency to spam dozens of error messages.  I had originally intended to just not log when a broadcast failed, but after a second thought I'm not going to log, _and_ I'm going to disconnect the child.

Given the rate at which we broadcast messages and the number of children we typically have connected, it really doesn't make sense for a slow or buggy connection to remain open and potentially cause issues with the client.

Closes #725