### PR TITLE
Separate EventArgs from delegates

### DIFF
--- a/examples/Web/api/Controllers/SearchesController.cs
+++ b/examples/Web/api/Controllers/SearchesController.cs
@@ -53,8 +53,8 @@
             var id = request.Id ?? Guid.NewGuid();
 
             var options = request.ToSearchOptions(
-                responseReceived: (e) => Tracker.AddOrUpdate(id, e),
-                stateChanged: (e) => Tracker.AddOrUpdate(id, e));
+                responseReceived: (e) => Tracker.AddOrUpdate(id, e.Search),
+                stateChanged: (e) => Tracker.AddOrUpdate(id, e.Search));
 
             var results = new ConcurrentBag<SearchResponse>();
 

--- a/examples/Web/api/Controllers/TransfersController.cs
+++ b/examples/Web/api/Controllers/TransfersController.cs
@@ -101,13 +101,13 @@
 
                 var downloadTask = Client.DownloadAsync(username, request.Filename, () => stream, request.Size, 0, request.Token, new TransferOptions(disposeOutputStreamOnCompletion: true, stateChanged: (e) =>
                 {
-                    Tracker.AddOrUpdate(e, cts);
+                    Tracker.AddOrUpdate(e.Transfer, cts);
 
                     if (e.Transfer.State.HasFlag(TransferStates.Queued) || e.Transfer.State == TransferStates.Initializing)
                     {
                         waitUntilEnqueue.TrySetResult(true);
                     }
-                }, progressUpdated: (e) => Tracker.AddOrUpdate(e, cts)), cts.Token);
+                }, progressUpdated: (e) => Tracker.AddOrUpdate(e.Transfer, cts)), cts.Token);
 
                 // wait until either the waitUntilEnqueue task completes because the download was successfully queued, or the
                 // downloadTask throws due to an error prior to successfully queueing.

--- a/examples/Web/api/DTO/SearchRequest.cs
+++ b/examples/Web/api/DTO/SearchRequest.cs
@@ -76,7 +76,7 @@ namespace WebAPI.DTO
         public SearchOptions ToSearchOptions(
             Func<SearchResponse, bool> responseFilter = null,
             Func<File, bool> fileFilter = null,
-            Action<SearchStateChangedEventArgs> stateChanged = null,
+            Action<(SearchStates PreviousState, Search Search)> stateChanged = null,
             Action<(Search Search, SearchResponse Response)> responseReceived = null)
         {
             var def = new SearchOptions();

--- a/examples/Web/api/DTO/SearchRequest.cs
+++ b/examples/Web/api/DTO/SearchRequest.cs
@@ -77,7 +77,7 @@ namespace WebAPI.DTO
             Func<SearchResponse, bool> responseFilter = null,
             Func<File, bool> fileFilter = null,
             Action<SearchStateChangedEventArgs> stateChanged = null,
-            Action<SearchResponseReceivedEventArgs> responseReceived = null)
+            Action<(Search Search, SearchResponse Response)> responseReceived = null)
         {
             var def = new SearchOptions();
 

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -593,8 +593,8 @@
             var cts = new CancellationTokenSource();
 
             var topts = new TransferOptions(
-                stateChanged: (e) => tracker.AddOrUpdate(e, cts),
-                progressUpdated: (e) => tracker.AddOrUpdate(e, cts),
+                stateChanged: (e) => tracker.AddOrUpdate(e.Transfer, cts),
+                progressUpdated: (e) => tracker.AddOrUpdate(e.Transfer, cts),
                 slotAwaiter: async (tx, cancellationToken) =>
                 {
                     Console.WriteLine($"[UPLOAD SLOT REQUESTED] [{username}/{filename}]");

--- a/examples/Web/api/Trackers/ISearchTracker.cs
+++ b/examples/Web/api/Trackers/ISearchTracker.cs
@@ -18,8 +18,8 @@
         ///     Adds or updates a tracked search.
         /// </summary>
         /// <param name="id"></param>
-        /// <param name="args"></param>
-        void AddOrUpdate(Guid id, SearchEventArgs args);
+        /// <param name="search"></param>
+        void AddOrUpdate(Guid id, Search search);
 
         /// <summary>
         ///     Removes all tracked searches.

--- a/examples/Web/api/Trackers/ITransferTracker.cs
+++ b/examples/Web/api/Trackers/ITransferTracker.cs
@@ -17,9 +17,9 @@
         /// <summary>
         ///     Adds or updates a tracked transfer.
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="transfer"></param>
         /// <param name="cancellationTokenSource"></param>
-        void AddOrUpdate(TransferEventArgs args, CancellationTokenSource cancellationTokenSource);
+        void AddOrUpdate(Transfer transfer, CancellationTokenSource cancellationTokenSource);
 
         /// <summary>
         ///     Removes a tracked transfer.

--- a/examples/Web/api/Trackers/SearchTracker.cs
+++ b/examples/Web/api/Trackers/SearchTracker.cs
@@ -19,10 +19,10 @@
         ///     Adds or updates a tracked search.
         /// </summary>
         /// <param name="id"></param>
-        /// <param name="args"></param>
-        public void AddOrUpdate(Guid id, SearchEventArgs args)
+        /// <param name="search"></param>
+        public void AddOrUpdate(Guid id, Search search)
         {
-            Searches.AddOrUpdate(id, args.Search, (token, search) => args.Search);
+            Searches.AddOrUpdate(id, search, (token, search) => search);
         }
 
         /// <summary>

--- a/examples/Web/api/Trackers/TransferTracker.cs
+++ b/examples/Web/api/Trackers/TransferTracker.cs
@@ -105,16 +105,16 @@
         /// <summary>
         ///     Adds or updates a tracked transfer.
         /// </summary>
-        /// <param name="args"></param>
+        /// <param name="transfer"></param>
         /// <param name="cancellationTokenSource"></param>
-        public void AddOrUpdate(TransferEventArgs args, CancellationTokenSource cancellationTokenSource)
+        public void AddOrUpdate(Transfer transfer, CancellationTokenSource cancellationTokenSource)
         {
-            Transfers.TryGetValue(args.Transfer.Direction, out var direction);
+            Transfers.TryGetValue(transfer.Direction, out var direction);
 
-            direction.AddOrUpdate(args.Transfer.Username, GetNewDictionaryForUser(args, cancellationTokenSource), (user, dict) =>
+            direction.AddOrUpdate(transfer.Username, GetNewDictionaryForUser(transfer, cancellationTokenSource), (user, dict) =>
             {
-                var transfer = DTO.Transfer.FromSoulseekTransfer(args.Transfer);
-                dict.AddOrUpdate(transfer.Id, (transfer, cancellationTokenSource), (id, record) => (transfer, cancellationTokenSource));
+                var tx = DTO.Transfer.FromSoulseekTransfer(transfer);
+                dict.AddOrUpdate(tx.Id, (tx, cancellationTokenSource), (id, record) => (tx, cancellationTokenSource));
                 return dict;
             });
         }
@@ -169,11 +169,11 @@
             return false;
         }
 
-        private static ConcurrentDictionary<string, (DTO.Transfer Transfer, CancellationTokenSource CancellationTokenSource)> GetNewDictionaryForUser(TransferEventArgs args, CancellationTokenSource cancellationTokenSource)
+        private static ConcurrentDictionary<string, (DTO.Transfer Transfer, CancellationTokenSource CancellationTokenSource)> GetNewDictionaryForUser(Transfer transfer, CancellationTokenSource cancellationTokenSource)
         {
             var r = new ConcurrentDictionary<string, (DTO.Transfer Transfer, CancellationTokenSource CancellationTokenSource)>();
-            var transfer = DTO.Transfer.FromSoulseekTransfer(args.Transfer);
-            r.AddOrUpdate(transfer.Id, (transfer, cancellationTokenSource), (id, record) => (transfer, record.CancellationTokenSource));
+            var tx = DTO.Transfer.FromSoulseekTransfer(transfer);
+            r.AddOrUpdate(tx.Id, (tx, cancellationTokenSource), (id, record) => (tx, record.CancellationTokenSource));
             return r;
         }
     }

--- a/src/Options/BrowseOptions.cs
+++ b/src/Options/BrowseOptions.cs
@@ -31,7 +31,7 @@ namespace Soulseek
         /// <param name="progressUpdated">The Action to invoke when the browse response receives data.</param>
         public BrowseOptions(
             int responseTimeout = 60000,
-            Action<BrowseProgressUpdatedEventArgs> progressUpdated = null)
+            Action<(string Username, long BytesTransferred, long BytesRemaining, double PercentComplete, long Size)> progressUpdated = null)
         {
             ResponseTimeout = responseTimeout;
             ProgressUpdated = progressUpdated;
@@ -40,7 +40,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the Action to invoke when the browse response receives data.
         /// </summary>
-        public Action<BrowseProgressUpdatedEventArgs> ProgressUpdated { get; }
+        public Action<(string Username, long BytesTransferred, long BytesRemaining, double PercentComplete, long Size)> ProgressUpdated { get; }
 
         /// <summary>
         ///     Gets the timeout for the response, in milliseconds. (Default = 60000).

--- a/src/Options/SearchOptions.cs
+++ b/src/Options/SearchOptions.cs
@@ -59,7 +59,7 @@ namespace Soulseek
             Func<SearchResponse, bool> responseFilter = null,
             Func<File, bool> fileFilter = null,
             Action<SearchStateChangedEventArgs> stateChanged = null,
-            Action<SearchResponseReceivedEventArgs> responseReceived = null)
+            Action<(Search Search, SearchResponse Response)> responseReceived = null)
         {
             SearchTimeout = searchTimeout;
             ResponseLimit = responseLimit;
@@ -130,7 +130,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the Action to invoke when a new search response is received.
         /// </summary>
-        public Action<SearchResponseReceivedEventArgs> ResponseReceived { get; }
+        public Action<(Search Search, SearchResponse Response)> ResponseReceived { get; }
 
         /// <summary>
         ///     Gets the search timeout value, in milliseconds, used to determine when the search is complete. (Default = 15000).

--- a/src/Options/SearchOptions.cs
+++ b/src/Options/SearchOptions.cs
@@ -58,7 +58,7 @@ namespace Soulseek
             bool removeSingleCharacterSearchTerms = true,
             Func<SearchResponse, bool> responseFilter = null,
             Func<File, bool> fileFilter = null,
-            Action<SearchStateChangedEventArgs> stateChanged = null,
+            Action<(SearchStates PreviousState, Search Search)> stateChanged = null,
             Action<(Search Search, SearchResponse Response)> responseReceived = null)
         {
             SearchTimeout = searchTimeout;
@@ -141,6 +141,6 @@ namespace Soulseek
         /// <summary>
         ///     Gets the Action to invoke when the search changes state.
         /// </summary>
-        public Action<SearchStateChangedEventArgs> StateChanged { get; }
+        public Action<(SearchStates PreviousState, Search Search)> StateChanged { get; }
     }
 }

--- a/src/Options/TransferOptions.cs
+++ b/src/Options/TransferOptions.cs
@@ -58,7 +58,7 @@ namespace Soulseek
         /// </param>
         public TransferOptions(
             Func<Transfer, int, CancellationToken, Task<int>> governor = null,
-            Action<TransferStateChangedEventArgs> stateChanged = null,
+            Action<(TransferStates PreviousState, Transfer Transfer)> stateChanged = null,
             Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated = null,
             Func<Transfer, CancellationToken, Task> slotAwaiter = null,
             Action<Transfer> slotReleased = null,
@@ -125,14 +125,14 @@ namespace Soulseek
         /// <summary>
         ///     Gets the delegate to invoke when the transfer changes state. (Default = no action).
         /// </summary>
-        public Action<TransferStateChangedEventArgs> StateChanged { get; }
+        public Action<(TransferStates PreviousState, Transfer Transfer)> StateChanged { get; }
 
         /// <summary>
         ///     Returns a clone of this instance with <see cref="StateChanged"/> wrapped in a new delegate that first invokes <paramref name="stateChanged"/>.
         /// </summary>
         /// <param name="stateChanged">A new delegate to execute prior to the existing delegate.</param>
         /// <returns>A clone of this instance with the combined StateChanged delegates.</returns>
-        public TransferOptions WithAdditionalStateChanged(Action<TransferStateChangedEventArgs> stateChanged)
+        public TransferOptions WithAdditionalStateChanged(Action<(TransferStates PreviousState, Transfer Transfer)> stateChanged)
         {
             return new TransferOptions(
                 governor: Governor,

--- a/src/Options/TransferOptions.cs
+++ b/src/Options/TransferOptions.cs
@@ -59,7 +59,7 @@ namespace Soulseek
         public TransferOptions(
             Func<Transfer, int, CancellationToken, Task<int>> governor = null,
             Action<TransferStateChangedEventArgs> stateChanged = null,
-            Action<TransferProgressUpdatedEventArgs> progressUpdated = null,
+            Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated = null,
             Func<Transfer, CancellationToken, Task> slotAwaiter = null,
             Action<Transfer> slotReleased = null,
             Action<Transfer, int, int, int> reporter = null,
@@ -104,7 +104,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the delegate to invoke when the transfer receives data. (Default = no action).
         /// </summary>
-        public Action<TransferProgressUpdatedEventArgs> ProgressUpdated { get; }
+        public Action<(long PreviousBytesTransferred, Transfer Transfer)> ProgressUpdated { get; }
 
         /// <summary>
         ///     Gets the delegate, accepting the number of bytes attempted, granted, and transferred for each chunk, used to

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3065,10 +3065,10 @@ namespace Soulseek
             void UpdateState(TransferStates state)
             {
                 download.State = state;
-                var args = new TransferStateChangedEventArgs(previousState: lastState, transfer: new Transfer(download));
+                var e = new TransferStateChangedEventArgs(previousState: lastState, transfer: new Transfer(download));
                 lastState = state;
-                options.StateChanged?.Invoke(args);
-                TransferStateChanged?.Invoke(this, args);
+                options.StateChanged?.Invoke((e.PreviousState, e.Transfer));
+                TransferStateChanged?.Invoke(this, e);
             }
 
             void UpdateProgress(long bytesDownloaded)
@@ -3991,10 +3991,10 @@ namespace Soulseek
             void UpdateState(TransferStates state)
             {
                 upload.State = state;
-                var args = new TransferStateChangedEventArgs(previousState: lastState, transfer: new Transfer(upload));
+                var e = new TransferStateChangedEventArgs(previousState: lastState, transfer: new Transfer(upload));
                 lastState = state;
-                options.StateChanged?.Invoke(args);
-                TransferStateChanged?.Invoke(this, args);
+                options.StateChanged?.Invoke((e.PreviousState, e.Transfer));
+                TransferStateChanged?.Invoke(this, e);
             }
 
             void UpdateProgress(long bytesUploaded)

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2746,9 +2746,9 @@ namespace Soulseek
                     completionEventFired = true;
                 }
 
-                var eventArgs = new BrowseProgressUpdatedEventArgs(username, args.CurrentLength, args.TotalLength);
-                options.ProgressUpdated?.Invoke(eventArgs);
-                BrowseProgressUpdated?.Invoke(this, eventArgs);
+                var e = new BrowseProgressUpdatedEventArgs(username, args.CurrentLength, args.TotalLength);
+                options.ProgressUpdated?.Invoke((e.Username, e.BytesTransferred, e.BytesRemaining, e.PercentComplete, e.Size));
+                BrowseProgressUpdated?.Invoke(this, e);
             }
 
             try

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3842,10 +3842,10 @@ namespace Soulseek
             void UpdateState(SearchStates state)
             {
                 search.State = state;
-                var args = new SearchStateChangedEventArgs(previousState: lastState, search: new Search(search));
+                var e = new SearchStateChangedEventArgs(previousState: lastState, search: new Search(search));
                 lastState = state;
-                options.StateChanged?.Invoke(args);
-                SearchStateChanged?.Invoke(this, args);
+                options.StateChanged?.Invoke((e.PreviousState, e.Search));
+                SearchStateChanged?.Invoke(this, e);
             }
 
             try

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3075,9 +3075,9 @@ namespace Soulseek
             {
                 var lastBytes = download.BytesTransferred;
                 download.UpdateProgress(bytesDownloaded);
-                var eventArgs = new TransferProgressUpdatedEventArgs(lastBytes, new Transfer(download));
-                options.ProgressUpdated?.Invoke(eventArgs);
-                TransferProgressUpdated?.Invoke(this, eventArgs);
+                var e = new TransferProgressUpdatedEventArgs(lastBytes, new Transfer(download));
+                options.ProgressUpdated?.Invoke((e.PreviousBytesTransferred, e.Transfer));
+                TransferProgressUpdated?.Invoke(this, e);
             }
 
             var transferStartRequestedWaitKey = new WaitKey(MessageCode.Peer.TransferRequest, download.Username, download.Filename);
@@ -4001,9 +4001,9 @@ namespace Soulseek
             {
                 var lastBytes = upload.BytesTransferred;
                 upload.UpdateProgress(bytesUploaded);
-                var eventArgs = new TransferProgressUpdatedEventArgs(lastBytes, new Transfer(upload));
-                options.ProgressUpdated?.Invoke(eventArgs);
-                TransferProgressUpdated?.Invoke(this, eventArgs);
+                var e = new TransferProgressUpdatedEventArgs(lastBytes, new Transfer(upload));
+                options.ProgressUpdated?.Invoke((e.PreviousBytesTransferred, e.Transfer));
+                TransferProgressUpdated?.Invoke(this, e);
             }
 
             IPEndPoint endpoint = null;

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3862,9 +3862,9 @@ namespace Soulseek
                 {
                     responseReceived(response);
 
-                    var eventArgs = new SearchResponseReceivedEventArgs(response, new Search(search));
-                    options.ResponseReceived?.Invoke(eventArgs);
-                    SearchResponseReceived?.Invoke(this, eventArgs);
+                    var e = new SearchResponseReceivedEventArgs(response, new Search(search));
+                    options.ResponseReceived?.Invoke((e.Search, e.Response));
+                    SearchResponseReceived?.Invoke(this, e);
                 };
 
                 Searches.TryAdd(search.Token, search);

--- a/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/BrowseAsyncTests.cs
@@ -222,7 +222,7 @@ namespace Soulseek.Tests.Unit.Client
                 s.SetProperty("Username", localUsername);
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                var events = new List<BrowseProgressUpdatedEventArgs>();
+                var events = new List<(string Username, long BytesTransferred, long BytesRemaining, double PercentComplete, long Size)>();
 
                 await s.BrowseAsync(username, new BrowseOptions(progressUpdated: (args) => events.Add(args)));
 

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -1021,14 +1021,22 @@ namespace Soulseek.Tests.Unit.Client
 
                 Exception caught = null;
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, "local", 0L, 0, token, new TransferOptions(stateChanged: (args) =>
-                {
-                    if (args.Transfer.State.HasFlag(TransferStates.Completed) && !args.Transfer.State.HasFlag(TransferStates.Succeeded))
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>(
+                    "DownloadToFileAsync",
+                    username,
+                    filename,
+                    "local",
+                    0L,
+                    0,
+                    token,
+                    new TransferOptions(stateChanged: (args) =>
                     {
-                        caught = args.Transfer.Exception;
-                    }
-                }),
-                null));
+                        if (args.Transfer.State.HasFlag(TransferStates.Completed) && !args.Transfer.State.HasFlag(TransferStates.Succeeded))
+                        {
+                            caught = args.Transfer.Exception;
+                        }
+                    }),
+                    null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TransferRejectedException>(ex);

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -2446,14 +2446,20 @@ namespace Soulseek.Tests.Unit.Client
 
                 Exception caught = null;
 
-                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, "local", token, new TransferOptions(stateChanged: (args) =>
-                {
-                    if (args.Transfer.State.HasFlag(TransferStates.Completed) && !args.Transfer.State.HasFlag(TransferStates.Succeeded))
+                var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>(
+                    "UploadFromFileAsync",
+                    username,
+                    filename,
+                    "local",
+                    token,
+                    new TransferOptions(stateChanged: (args) =>
                     {
-                        caught = args.Transfer.Exception;
-                    }
-                }),
-                null));
+                        if (args.Transfer.State.HasFlag(TransferStates.Completed) && !args.Transfer.State.HasFlag(TransferStates.Succeeded))
+                        {
+                            caught = args.Transfer.Exception;
+                        }
+                    }),
+                    null));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);

--- a/tests/Soulseek.Tests.Unit/Options/BrowseOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/BrowseOptionsTests.cs
@@ -26,7 +26,7 @@ namespace Soulseek.Tests.Unit.Options
         [Theory(DisplayName = "Instantiates properly"), AutoData]
         public void Instantiates_Properly(int timeout)
         {
-            void Action(BrowseProgressUpdatedEventArgs args)
+            void Action((string Username, long BytesTransferred, long BytesRemaining, double PercentComplete, long Size) args)
             {
                 // noop
             }

--- a/tests/Soulseek.Tests.Unit/Options/SearchOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SearchOptionsTests.cs
@@ -37,7 +37,7 @@ namespace Soulseek.Tests.Unit.Options
             int fileLimit,
             bool removeSingleCharacterSearchTerms,
             Func<File, bool> fileFilter,
-            Action<SearchStateChangedEventArgs> stateChanged,
+            Action<(SearchStates PreviousState, Search Search)> stateChanged,
             Action<(Search Search, SearchResponse Response)> responseReceived)
         {
             var o = new SearchOptions(

--- a/tests/Soulseek.Tests.Unit/Options/SearchOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SearchOptionsTests.cs
@@ -38,7 +38,7 @@ namespace Soulseek.Tests.Unit.Options
             bool removeSingleCharacterSearchTerms,
             Func<File, bool> fileFilter,
             Action<SearchStateChangedEventArgs> stateChanged,
-            Action<SearchResponseReceivedEventArgs> responseReceived)
+            Action<(Search Search, SearchResponse Response)> responseReceived)
         {
             var o = new SearchOptions(
                 searchTimeout,

--- a/tests/Soulseek.Tests.Unit/Options/TransferOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/TransferOptionsTests.cs
@@ -31,7 +31,7 @@ namespace Soulseek.Tests.Unit.Options
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
-            Action<TransferStateChangedEventArgs> stateChanged,
+            Action<(TransferStates PreviousState, Transfer Transfer)> stateChanged,
             int maximumLingerTime,
             Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
@@ -86,7 +86,7 @@ namespace Soulseek.Tests.Unit.Options
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
-            Action<TransferStateChangedEventArgs> stateChanged,
+            Action<(TransferStates PreviousState, Transfer Transfer)> stateChanged,
             int maximumLingerTime,
             Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
@@ -126,7 +126,7 @@ namespace Soulseek.Tests.Unit.Options
 
             var o = n.WithAdditionalStateChanged((_) => { two = true; });
 
-            o.StateChanged(null);
+            o.StateChanged(default);
 
             Assert.True(one);
             Assert.True(two);
@@ -140,7 +140,7 @@ namespace Soulseek.Tests.Unit.Options
 
             var o = n.WithAdditionalStateChanged(null);
 
-            var ex = Record.Exception(() => o.StateChanged(null));
+            var ex = Record.Exception(() => o.StateChanged(default));
 
             Assert.Null(ex);
         }
@@ -151,7 +151,7 @@ namespace Soulseek.Tests.Unit.Options
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
-            Action<TransferStateChangedEventArgs> stateChanged,
+            Action<(TransferStates PreviousState, Transfer Transfer)> stateChanged,
             int maximumLingerTime,
             Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
@@ -185,7 +185,7 @@ namespace Soulseek.Tests.Unit.Options
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
-            Action<TransferStateChangedEventArgs> stateChanged,
+            Action<(TransferStates PreviousState, Transfer Transfer)> stateChanged,
             int maximumLingerTime,
             Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,

--- a/tests/Soulseek.Tests.Unit/Options/TransferOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/TransferOptionsTests.cs
@@ -33,7 +33,7 @@ namespace Soulseek.Tests.Unit.Options
             Func<Transfer, int, CancellationToken, Task<int>> governor,
             Action<TransferStateChangedEventArgs> stateChanged,
             int maximumLingerTime,
-            Action<TransferProgressUpdatedEventArgs> progressUpdated,
+            Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
             Action<Transfer, int, int, int> reporter,
             Action<Transfer> slotReleased)
@@ -88,7 +88,7 @@ namespace Soulseek.Tests.Unit.Options
             Func<Transfer, int, CancellationToken, Task<int>> governor,
             Action<TransferStateChangedEventArgs> stateChanged,
             int maximumLingerTime,
-            Action<TransferProgressUpdatedEventArgs> progressUpdated,
+            Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
             Action<Transfer> slotReleased)
         {
@@ -153,7 +153,7 @@ namespace Soulseek.Tests.Unit.Options
             Func<Transfer, int, CancellationToken, Task<int>> governor,
             Action<TransferStateChangedEventArgs> stateChanged,
             int maximumLingerTime,
-            Action<TransferProgressUpdatedEventArgs> progressUpdated,
+            Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
             Action<Transfer> slotReleased)
         {
@@ -187,7 +187,7 @@ namespace Soulseek.Tests.Unit.Options
             Func<Transfer, int, CancellationToken, Task<int>> governor,
             Action<TransferStateChangedEventArgs> stateChanged,
             int maximumLingerTime,
-            Action<TransferProgressUpdatedEventArgs> progressUpdated,
+            Action<(long PreviousBytesTransferred, Transfer Transfer)> progressUpdated,
             Func<Transfer, CancellationToken, Task> acquireSlot,
             Action<Transfer> slotReleased)
         {


### PR DESCRIPTION
This PR swaps `EventArgs` subclasses used in option delegates for tuples of the same shape.  This shouldn't be too disruptive to consumers since the same properties exist, but it will be a breaking change.

Closes #726 