### PR TITLE
Add Info diagnostics for user info, share contents, and folder contents responses

### DIFF
--- a/src/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Messaging/Handlers/PeerMessageHandler.cs
@@ -130,6 +130,8 @@ namespace Soulseek.Messaging.Handlers
                         }
 
                         await connection.WriteAsync(outgoingInfo.ToByteArray()).ConfigureAwait(false);
+                        Diagnostic.Info($"User info sent to {connection.Username}");
+
                         break;
 
                     case MessageCode.Peer.SearchRequest:
@@ -172,6 +174,8 @@ namespace Soulseek.Messaging.Handlers
                         }
 
                         await connection.WriteAsync(browseResponse.ToByteArray()).ConfigureAwait(false);
+                        Diagnostic.Info($"Share contents sent to {connection.Username}");
+
                         break;
 
                     case MessageCode.Peer.FolderContentsRequest:
@@ -196,6 +200,7 @@ namespace Soulseek.Messaging.Handlers
                             var folderContentsResponseMessage = new FolderContentsResponse(folderContentsRequest.Token, outgoingFolderContents);
 
                             await connection.WriteAsync(folderContentsResponseMessage).ConfigureAwait(false);
+                            Diagnostic.Info($"Folder contents for {folderContentsRequest.DirectoryName} sent to {connection.Username}");
                         }
 
                         break;


### PR DESCRIPTION
Most users will be curious to know when remote users fetch information about them.  This PR adds informational diagnostic messages after user info, share contents (browse) or folder contents responses are sent to a requesting user.

Closes #705 