### PR TITLE
Tweak property getters, don't log distributed pings and pongs

### DIFF
--- a/src/Common/WaitKey.cs
+++ b/src/Common/WaitKey.cs
@@ -31,17 +31,18 @@ namespace Soulseek
         public WaitKey(params object[] tokenParts)
         {
             TokenParts = tokenParts;
+            Token = string.Join(":", TokenParts);
         }
 
         /// <summary>
         ///     Gets the wait token.
         /// </summary>
-        public string Token => string.Join(":", TokenParts);
+        public string Token { get; }
 
         /// <summary>
         ///     Gets the parts which make up the key.
         /// </summary>
-        public object[] TokenParts { get; private set; }
+        public object[] TokenParts { get; }
 
         public static bool operator !=(WaitKey lhs, WaitKey rhs)
         {

--- a/src/Diagnostics/DiagnosticEventArgs.cs
+++ b/src/Diagnostics/DiagnosticEventArgs.cs
@@ -36,6 +36,7 @@ namespace Soulseek.Diagnostics
             Message = message;
             Exception = exception;
             Timestamp = DateTime.UtcNow;
+            IncludesException = Exception != null;
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Soulseek.Diagnostics
         /// <summary>
         ///     Gets a value indicating whether an <see cref="Exception"/> is included with the event.
         /// </summary>
-        public bool IncludesException => Exception != null;
+        public bool IncludesException { get; }
 
         /// <summary>
         ///     Gets the diagnostic level of the event.

--- a/src/EventArgs/BrowseProgressUpdatedEventArgs.cs
+++ b/src/EventArgs/BrowseProgressUpdatedEventArgs.cs
@@ -33,6 +33,8 @@ namespace Soulseek
         {
             BytesTransferred = bytesTransferred;
             Size = size;
+            BytesRemaining = Size - BytesTransferred;
+            PercentComplete = (BytesTransferred / (double)Size) * 100d;
         }
 
         /// <summary>
@@ -43,12 +45,12 @@ namespace Soulseek
         /// <summary>
         ///     Gets the number of remaining bytes to be transferred.
         /// </summary>
-        public long BytesRemaining => Size - BytesTransferred;
+        public long BytesRemaining { get; }
 
         /// <summary>
         ///     Gets the progress of the data transfer as a percentage of current and total data length.
         /// </summary>
-        public double PercentComplete => (BytesTransferred / (double)Size) * 100d;
+        public double PercentComplete { get; }
 
         /// <summary>
         ///     Gets the total expected length of the data transfer.

--- a/src/EventArgs/DistributedParentEventArgs.cs
+++ b/src/EventArgs/DistributedParentEventArgs.cs
@@ -37,6 +37,7 @@ namespace Soulseek
             IPEndPoint = ipEndPoint;
             BranchLevel = branchLevel;
             BranchRoot = branchRoot;
+            IsBranchRoot = Username == BranchRoot && BranchLevel == 0;
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets a value indicating whether the parent is a branch root.
         /// </summary>
-        public bool IsBranchRoot => Username == BranchRoot && BranchLevel == 0;
+        public bool IsBranchRoot { get; }
 
         /// <summary>
         ///     Gets the username associated with the connection.

--- a/src/EventArgs/PrivilegeNotificationReceivedEventArgs.cs
+++ b/src/EventArgs/PrivilegeNotificationReceivedEventArgs.cs
@@ -31,6 +31,8 @@ namespace Soulseek
         {
             Username = username;
             Id = id;
+
+            RequiresAcknowlegement = Id.HasValue;
         }
 
         /// <summary>
@@ -46,6 +48,6 @@ namespace Soulseek
         /// <summary>
         ///     Gets a value indicating whether the notification must be acknowleged.
         /// </summary>
-        public bool RequiresAcknowlegement => Id.HasValue;
+        public bool RequiresAcknowlegement { get; }
     }
 }

--- a/src/File.cs
+++ b/src/File.cs
@@ -42,6 +42,15 @@ namespace Soulseek
 
             Attributes = (attributeList?.ToList() ?? new List<FileAttribute>()).AsReadOnly();
             AttributeCount = Attributes.Count;
+
+            BitDepth = GetAttributeValue(FileAttributeType.BitDepth);
+            BitRate = GetAttributeValue(FileAttributeType.BitRate);
+
+            var vbr = GetAttributeValue(FileAttributeType.VariableBitRate);
+            IsVariableBitRate = vbr == null ? (bool?)null : vbr != 0;
+
+            Length = GetAttributeValue(FileAttributeType.Length);
+            SampleRate = GetAttributeValue(FileAttributeType.SampleRate);
         }
 
         /// <summary>
@@ -57,12 +66,12 @@ namespace Soulseek
         /// <summary>
         ///     Gets the value of the <see cref="FileAttributeType.BitDepth"/> attribute.
         /// </summary>
-        public int? BitDepth => GetAttributeValue(FileAttributeType.BitDepth);
+        public int? BitDepth { get; }
 
         /// <summary>
         ///     Gets the value of the <see cref="FileAttributeType.BitRate"/> attribute.
         /// </summary>
-        public int? BitRate => GetAttributeValue(FileAttributeType.BitRate);
+        public int? BitRate { get; }
 
         /// <summary>
         ///     Gets the file code.
@@ -83,24 +92,17 @@ namespace Soulseek
         ///     Gets a value indicating whether the <see cref="FileAttributeType.VariableBitRate"/> attribute value indicates a
         ///     file with a variable bit rate.
         /// </summary>
-        public bool? IsVariableBitRate
-        {
-            get
-            {
-                var val = GetAttributeValue(FileAttributeType.VariableBitRate);
-                return val == null ? (bool?)null : val != 0;
-            }
-        }
+        public bool? IsVariableBitRate { get; }
 
         /// <summary>
         ///     Gets the value of the <see cref="FileAttributeType.Length"/> attribute.
         /// </summary>
-        public int? Length => GetAttributeValue(FileAttributeType.Length);
+        public int? Length { get; }
 
         /// <summary>
         ///     Gets the value of the <see cref="FileAttributeType.SampleRate"/> attribute.
         /// </summary>
-        public int? SampleRate => GetAttributeValue(FileAttributeType.SampleRate);
+        public int? SampleRate { get; }
 
         /// <summary>
         ///     Gets the file size in bytes.

--- a/src/Messaging/Handlers/DistributedMessageHandler.cs
+++ b/src/Messaging/Handlers/DistributedMessageHandler.cs
@@ -18,8 +18,6 @@
 namespace Soulseek.Messaging.Handlers
 {
     using System;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Soulseek.Diagnostics;
     using Soulseek.Messaging.Messages;
     using Soulseek.Network;
@@ -72,7 +70,10 @@ namespace Soulseek.Messaging.Handlers
             var connection = (IMessageConnection)sender;
             var code = new MessageReader<MessageCode.Distributed>(message).ReadCode();
 
-            Diagnostic.Debug($"Distributed child message received: {code} from {connection.Username} ({connection.IPEndPoint}) (id: {connection.Id})");
+            if (code != MessageCode.Distributed.Ping)
+            {
+                Diagnostic.Debug($"Distributed child message received: {code} from {connection.Username} ({connection.IPEndPoint}) (id: {connection.Id})");
+            }
 
             try
             {
@@ -106,7 +107,11 @@ namespace Soulseek.Messaging.Handlers
         {
             var connection = (IMessageConnection)sender;
             var code = new MessageReader<MessageCode.Distributed>(args.Message).ReadCode();
-            Diagnostic.Debug($"Distributed child message sent: {code} to {connection.Username} ({connection.IPEndPoint}) (id: {connection.Id})");
+
+            if (code != MessageCode.Distributed.Ping)
+            {
+                Diagnostic.Debug($"Distributed child message sent: {code} to {connection.Username} ({connection.IPEndPoint}) (id: {connection.Id})");
+            }
         }
 
         /// <summary>
@@ -129,7 +134,7 @@ namespace Soulseek.Messaging.Handlers
             var connection = (IMessageConnection)sender;
             var code = new MessageReader<MessageCode.Distributed>(message).ReadCode();
 
-            if (code != MessageCode.Distributed.SearchRequest && code != MessageCode.Distributed.EmbeddedMessage)
+            if (code != MessageCode.Distributed.SearchRequest && code != MessageCode.Distributed.EmbeddedMessage && code != MessageCode.Distributed.Ping)
             {
                 Diagnostic.Debug($"Distributed message received: {code} from {connection.Username} ({connection.IPEndPoint}) (id: {connection.Id})");
             }

--- a/src/Messaging/Messages/Server/ConnectToPeerResponse.cs
+++ b/src/Messaging/Messages/Server/ConnectToPeerResponse.cs
@@ -54,12 +54,15 @@ namespace Soulseek.Messaging.Messages
             Token = token;
             IPEndPoint = endpoint;
             IsPrivileged = isPrivileged;
+
+            IPAddress = IPEndPoint.Address;
+            Port = IPEndPoint.Port;
         }
 
         /// <summary>
         ///     Gets the IP address to which to connect.
         /// </summary>
-        public IPAddress IPAddress => IPEndPoint.Address;
+        public IPAddress IPAddress { get; }
 
         /// <summary>
         ///     Gets the IP endpoint to which to connect.
@@ -74,7 +77,7 @@ namespace Soulseek.Messaging.Messages
         /// <summary>
         ///     Gets the port to which to connect.
         /// </summary>
-        public int Port => IPEndPoint.Port;
+        public int Port { get; }
 
         /// <summary>
         ///     Gets the unique connection token.

--- a/src/Messaging/Messages/Server/LoginRequest.cs
+++ b/src/Messaging/Messages/Server/LoginRequest.cs
@@ -31,17 +31,19 @@ namespace Soulseek.Messaging.Messages
         {
             Username = username;
             Password = password;
+
+            Hash = $"{Username}{Password}".ToMD5Hash();
         }
 
         /// <summary>
         ///     Gets the MD5 hash of the username and password.
         /// </summary>
-        public string Hash => $"{Username}{Password}".ToMD5Hash();
+        public string Hash { get; }
 
         /// <summary>
         ///     Gets the minor client version.
         /// </summary>
-        public int MinorVersion => 100;
+        public int MinorVersion { get; } = 100;
 
         /// <summary>
         ///     Gets the password.
@@ -56,7 +58,7 @@ namespace Soulseek.Messaging.Messages
         /// <summary>
         ///     Gets the client version.
         /// </summary>
-        public int Version => 170;
+        public int Version { get; } = 170;
 
         /// <summary>
         ///     Constructs a <see cref="byte"/> array from this message.

--- a/src/Messaging/Messages/Server/UserAddressResponse.cs
+++ b/src/Messaging/Messages/Server/UserAddressResponse.cs
@@ -45,12 +45,15 @@ namespace Soulseek.Messaging.Messages
         {
             Username = username;
             IPEndPoint = endpoint;
+
+            IPAddress = IPEndPoint.Address;
+            Port = IPEndPoint.Port;
         }
 
         /// <summary>
         ///     Gets the IP address of the peer.
         /// </summary>
-        public IPAddress IPAddress => IPEndPoint.Address;
+        public IPAddress IPAddress { get; }
 
         /// <summary>
         ///     Gets the IP endpoint of the peer.
@@ -60,7 +63,7 @@ namespace Soulseek.Messaging.Messages
         /// <summary>
         ///     Gets the port on which the peer is listening.
         /// </summary>
-        public int Port => IPEndPoint.Port;
+        public int Port { get; }
 
         /// <summary>
         ///     Gets the requested peer username.

--- a/src/Network/MessageConnection.cs
+++ b/src/Network/MessageConnection.cs
@@ -132,7 +132,7 @@ namespace Soulseek.Network
         /// <summary>
         ///     Gets the username of the peer associated with the connection, if applicable.
         /// </summary>
-        public string Username { get; private set; } = string.Empty;
+        public string Username { get; } = string.Empty;
 
         /// <summary>
         ///     Begins the internal continuous read loop, if it has not yet started.
@@ -199,7 +199,7 @@ namespace Soulseek.Network
 
             try
             {
-                while (true)
+                while (!Disposed)
                 {
                     try
                     {

--- a/src/Network/MessageConnectionEventArgs.cs
+++ b/src/Network/MessageConnectionEventArgs.cs
@@ -42,6 +42,8 @@ namespace Soulseek.Network
             Code = code;
             CurrentLength = currentLength;
             TotalLength = totalLength;
+
+            PercentComplete = (CurrentLength / (double)TotalLength) * 100d;
         }
 
         /// <summary>
@@ -57,7 +59,7 @@ namespace Soulseek.Network
         /// <summary>
         ///     Gets the progress of the data transfer as a percentage of current and total data length.
         /// </summary>
-        public double PercentComplete => (CurrentLength / (double)TotalLength) * 100d;
+        public double PercentComplete { get; }
 
         /// <summary>
         ///     Gets the total expected length of the data transfer.

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -607,7 +607,7 @@ namespace Soulseek.Network.Tcp
 
             try
             {
-                while (totalBytesRead < length)
+                while (!Disposed && totalBytesRead < length)
                 {
                     var bytesRemaining = length - totalBytesRead;
                     var bytesToRead = bytesRemaining >= buffer.Length ? buffer.Length : (int)bytesRemaining; // cast to int is safe because of the check against buffer length.
@@ -707,7 +707,7 @@ namespace Soulseek.Network.Tcp
 
             try
             {
-                while (totalBytesWritten < length)
+                while (!Disposed && totalBytesWritten < length)
                 {
                     var bytesRemaining = length - totalBytesWritten;
                     var bytesToRead = bytesRemaining >= buffer.Length ? buffer.Length : (int)bytesRemaining;

--- a/src/Network/Tcp/ConnectionEventArgs.cs
+++ b/src/Network/Tcp/ConnectionEventArgs.cs
@@ -40,6 +40,8 @@ namespace Soulseek.Network.Tcp
         {
             CurrentLength = currentLength;
             TotalLength = totalLength;
+
+            PercentComplete = (CurrentLength / (double)TotalLength) * 100d;
         }
 
         /// <summary>
@@ -50,7 +52,7 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Gets the progress of the data transfer as a percentage of current and total data length.
         /// </summary>
-        public double PercentComplete => (CurrentLength / (double)TotalLength) * 100d;
+        public double PercentComplete { get; }
 
         /// <summary>
         ///     Gets the total expected length of the data transfer.

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -206,10 +206,11 @@ namespace Soulseek
         public async Task WaitForCompletion(CancellationToken cancellationToken)
         {
             var cancellationTaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var taskCompletionSource = TaskCompletionSource;
 
             using (cancellationToken.Register(() => cancellationTaskCompletionSource.TrySetException(new OperationCanceledException("Operation cancelled"))))
             {
-                var completedTask = await Task.WhenAny(TaskCompletionSource.Task, cancellationTaskCompletionSource.Task).ConfigureAwait(false);
+                var completedTask = await Task.WhenAny(taskCompletionSource.Task, cancellationTaskCompletionSource.Task).ConfigureAwait(false);
                 await completedTask.ConfigureAwait(false);
             }
         }

--- a/src/Transfer.cs
+++ b/src/Transfer.cs
@@ -76,6 +76,11 @@ namespace Soulseek
             RemoteToken = remoteToken;
             IPEndPoint = ipEndPoint;
             Exception = exception;
+
+            BytesRemaining = Size - BytesTransferred;
+            ElapsedTime = StartTime == null ? null : (TimeSpan?)((EndTime ?? DateTime.UtcNow) - StartTime.Value);
+            PercentComplete = Size == 0 ? 0 : (BytesTransferred / (double)Size) * 100;
+            RemainingTime = AverageSpeed == 0 ? null : (TimeSpan?)TimeSpan.FromSeconds(BytesRemaining / AverageSpeed);
         }
 
         /// <summary>
@@ -109,7 +114,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the number of remaining bytes to be transferred.
         /// </summary>
-        public long BytesRemaining => Size - BytesTransferred;
+        public long BytesRemaining { get; }
 
         /// <summary>
         ///     Gets the total number of bytes transferred.
@@ -124,7 +129,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the current duration of the transfer, if it has been started.
         /// </summary>
-        public TimeSpan? ElapsedTime => StartTime == null ? null : (TimeSpan?)((EndTime ?? DateTime.UtcNow) - StartTime.Value);
+        public TimeSpan? ElapsedTime { get; }
 
         /// <summary>
         ///     Gets the UTC time at which the transfer transitioned into the <see cref="TransferStates.Completed"/> state.
@@ -149,12 +154,12 @@ namespace Soulseek
         /// <summary>
         ///     Gets the current progress in percent.
         /// </summary>
-        public double PercentComplete => Size == 0 ? 0 : (BytesTransferred / (double)Size) * 100;
+        public double PercentComplete { get; }
 
         /// <summary>
         ///     Gets the projected remaining duration of the transfer.
         /// </summary>
-        public TimeSpan? RemainingTime => AverageSpeed == 0 ? null : (TimeSpan?)TimeSpan.FromSeconds(BytesRemaining / AverageSpeed);
+        public TimeSpan? RemainingTime { get; }
 
         /// <summary>
         ///     Gets the remote unique token for the transfer.

--- a/src/TransferInternal.cs
+++ b/src/TransferInternal.cs
@@ -50,6 +50,8 @@ namespace Soulseek
             Token = token;
 
             Options = options ?? new TransferOptions();
+
+            WaitKey = new WaitKey(Constants.WaitKey.Transfer, Direction, Username, Filename, Token);
         }
 
         /// <summary>
@@ -192,7 +194,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the wait key for the transfer.
         /// </summary>
-        public WaitKey WaitKey => new WaitKey(Constants.WaitKey.Transfer, Direction, Username, Filename, Token);
+        public WaitKey WaitKey { get; }
 
         /// <summary>
         ///     Updates the transfer progress.


### PR DESCRIPTION
This PR makes a number of small tweaks to avoid lambda expressions in property getters, and instead sets those values in the constructor where possible.

Also closes #741