### PR TITLE
Add AverageBroadcastLatency for distributed child connections

### DIFF
--- a/src/DistributedNetworkInfo.cs
+++ b/src/DistributedNetworkInfo.cs
@@ -30,6 +30,7 @@ namespace Soulseek
         /// <summary>
         ///     Initializes a new instance of the <see cref="DistributedNetworkInfo"/> class.
         /// </summary>
+        /// <param name="averageBroadcastLatency">The average child broadcast latency.</param>
         /// <param name="branchLevel">The current distributed branch level.</param>
         /// <param name="branchRoot">The current distributed branch root.</param>
         /// <param name="isBranchRoot">A value indicating whether the client is currently operating as a branch root.</param>
@@ -39,6 +40,7 @@ namespace Soulseek
         /// <param name="parent">The current parent connection.</param>
         /// <param name="hasParent">A value indicating whether a parent connection is established.</param>
         public DistributedNetworkInfo(
+            double? averageBroadcastLatency,
             int branchLevel,
             string branchRoot,
             bool isBranchRoot,
@@ -48,6 +50,7 @@ namespace Soulseek
             (string Username, IPEndPoint IPEndPoint) parent,
             bool hasParent)
         {
+            AverageBroadcastLatency = averageBroadcastLatency;
             BranchLevel = branchLevel;
             BranchRoot = branchRoot;
             CanAcceptChildren = canAcceptChildren;
@@ -57,6 +60,11 @@ namespace Soulseek
             IsBranchRoot = isBranchRoot;
             Parent = parent;
         }
+
+        /// <summary>
+        ///     Gets the average child broadcast latency.
+        /// </summary>
+        public double? AverageBroadcastLatency { get; }
 
         /// <summary>
         ///     Gets the current distributed branch level.
@@ -100,6 +108,7 @@ namespace Soulseek
 
         internal static DistributedNetworkInfo FromDistributedConnectionManager(IDistributedConnectionManager manager)
             => new DistributedNetworkInfo(
+                averageBroadcastLatency: manager.AverageBroadcastLatency,
                 branchLevel: manager.BranchLevel,
                 branchRoot: manager.BranchRoot,
                 isBranchRoot: manager.IsBranchRoot,

--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -21,6 +21,7 @@ namespace Soulseek.Network
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Diagnostics;
     using System.Linq;
     using System.Net;
     using System.Text;
@@ -41,6 +42,7 @@ namespace Soulseek.Network
         private static readonly int StatusAgeLimit = 300000; // 5 minutes
         private static readonly int StatusDebounceTime = 5000; // 5 seconds
         private static readonly int WatchdogTime = 900000; // 15 minutes
+        private static readonly double LatencyAlpha = 2f / 10;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DistributedConnectionManager"/> class.
@@ -118,6 +120,11 @@ namespace Soulseek.Network
         ///     Occurs when the state of the distributed network changes.
         /// </summary>
         public event EventHandler<DistributedNetworkInfo> StateChanged;
+
+        /// <summary>
+        ///     Gets the average child broadcast latency.
+        /// </summary>
+        public double? AverageBroadcastLatency { get; private set; } = null;
 
         /// <summary>
         ///     Gets the current distributed branch level.
@@ -451,7 +458,7 @@ namespace Soulseek.Network
         /// <param name="bytes">The bytes to write.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The operation context.</returns>
-        public Task BroadcastMessageAsync(byte[] bytes, CancellationToken? cancellationToken = null)
+        public async Task BroadcastMessageAsync(byte[] bytes, CancellationToken? cancellationToken = null)
         {
             cancellationToken ??= CancellationToken.None;
 
@@ -474,6 +481,9 @@ namespace Soulseek.Network
                 }
             }
 
+            var sw = new Stopwatch();
+            sw.Start();
+
             var tasks = new List<Task>();
 
             foreach (var child in ChildConnectionDictionary)
@@ -481,7 +491,19 @@ namespace Soulseek.Network
                 tasks.Add(Write(child, bytes, cancellationToken));
             }
 
-            return Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            sw.Stop();
+
+            if (!AverageBroadcastLatency.HasValue)
+            {
+                AverageBroadcastLatency = sw.ElapsedMilliseconds;
+            }
+            else
+            {
+                // EMA
+                AverageBroadcastLatency = ((sw.ElapsedMilliseconds - AverageBroadcastLatency) * LatencyAlpha) + AverageBroadcastLatency;
+            }
         }
 
         /// <summary>

--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -42,7 +42,7 @@ namespace Soulseek.Network
         private static readonly int StatusAgeLimit = 300000; // 5 minutes
         private static readonly int StatusDebounceTime = 5000; // 5 seconds
         private static readonly int WatchdogTime = 900000; // 15 minutes
-        private static readonly double LatencyAlpha = 2f / 10;
+        private static readonly double LatencyAlpha = 0.005;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DistributedConnectionManager"/> class.

--- a/src/Network/IDistributedConnectionManager.cs
+++ b/src/Network/IDistributedConnectionManager.cs
@@ -67,6 +67,11 @@ namespace Soulseek.Network
         event EventHandler<DistributedNetworkInfo> StateChanged;
 
         /// <summary>
+        ///     Gets the average child broadcast latency.
+        /// </summary>
+        double? AverageBroadcastLatency { get; }
+
+        /// <summary>
         ///     Gets the current distributed branch level.
         /// </summary>
         int BranchLevel { get; }

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -583,17 +583,11 @@ namespace Soulseek.Tests.Unit.Network
 
             using (manager)
             {
-                Assert.Null(manager.AverageBroadcastLatency);
+                manager.SetProperty(nameof(manager.AverageBroadcastLatency), double.MaxValue);
 
                 await manager.BroadcastMessageAsync(bytes, CancellationToken.None);
 
-                var first = manager.AverageBroadcastLatency;
-
-                Assert.NotNull(first);
-
-                await manager.BroadcastMessageAsync(bytes, CancellationToken.None);
-
-                Assert.NotEqual(first, manager.AverageBroadcastLatency);
+                Assert.True(manager.AverageBroadcastLatency < double.MaxValue);
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -1065,7 +1065,7 @@ namespace Soulseek.Tests.Unit
                 bool fired = false;
 
                 s.DistributedNetworkStateChanged += (sender, args) => fired = true;
-                mock.Raise(m => m.StateChanged += null, mock.Object, new DistributedNetworkInfo(1, "root", true, 1, true, null, default, true));
+                mock.Raise(m => m.StateChanged += null, mock.Object, new DistributedNetworkInfo(0, 1, "root", true, 1, true, null, default, true));
 
                 Assert.True(fired);
             }
@@ -1079,7 +1079,7 @@ namespace Soulseek.Tests.Unit
 
             using (var s = new SoulseekClient(distributedConnectionManager: mock.Object))
             {
-                var ex = Record.Exception(() => mock.Raise(m => m.StateChanged += null, mock.Object, new DistributedNetworkInfo(1, "root", true, 1, true, null, default, true)));
+                var ex = Record.Exception(() => mock.Raise(m => m.StateChanged += null, mock.Object, new DistributedNetworkInfo(0, 1, "root", true, 1, true, null, default, true)));
 
                 Assert.Null(ex);
             }

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -2057,6 +2057,7 @@ namespace Soulseek.Tests.Unit
             string parentName,
             IPEndPoint parentIP,
             bool hasParent,
+            double? averageBroadcastLatency,
             List<(string Username, IPEndPoint IPEndPoint)> children)
         {
             var dcm = new Mock<IDistributedConnectionManager>();
@@ -2069,6 +2070,7 @@ namespace Soulseek.Tests.Unit
             dcm.Setup(m => m.Parent).Returns((parentName, parentIP));
             dcm.Setup(m => m.HasParent).Returns(hasParent);
             dcm.Setup(m => m.Children).Returns(children.AsReadOnly());
+            dcm.Setup(m => m.AverageBroadcastLatency).Returns(averageBroadcastLatency);
 
             using (var s = new SoulseekClient(distributedConnectionManager: dcm.Object))
             {
@@ -2082,6 +2084,7 @@ namespace Soulseek.Tests.Unit
                 Assert.Equal(parentName, info.Parent.Username);
                 Assert.Equal(parentIP, info.Parent.IPEndPoint);
                 Assert.Equal(hasParent, info.HasParent);
+                Assert.Equal(averageBroadcastLatency, info.AverageBroadcastLatency);
 
                 foreach (var child in children)
                 {


### PR DESCRIPTION
Users have the ability to specify how many child connections they'll accept.  This number should be dictated by a few factors, but one of them is whether the client can broadcast search requests to all clients in a timely manner, and presently users have no idea whether that's true.

This PR adds an `AverageBroadcastLatency` property to `DistributedConnectionManager` and exposes it through `DistributedNetworkInfo`.

Applications will receive the latest value in the payload of the `DistributedNetworkStateChanged` event, or can fetch it at any time through `ISoulseekClient.DistributedNetwork`.