### PR TITLE
Correct handling of queue length in search responses

### DIFF
--- a/examples/Web/api/Program.cs
+++ b/examples/Web/api/Program.cs
@@ -26,6 +26,7 @@
                         logging.ClearProviders();
                     }
                 })
+                .UseUrls("http://localhost:5000")
                 .UseStartup<Startup>();
     }
 }

--- a/src/Messaging/Messages/Peer/SearchResponseFactory.cs
+++ b/src/Messaging/Messages/Peer/SearchResponseFactory.cs
@@ -51,16 +51,12 @@ namespace Soulseek.Messaging.Messages
 
             var freeUploadSlots = reader.ReadByte();
             var uploadSpeed = reader.ReadInteger();
+            var queueLength = reader.ReadInteger();
 
-            long queueLength;
-
-            if (reader.Remaining == 4)
+            if (reader.HasMoreData)
             {
-                queueLength = reader.ReadInteger();
-            }
-            else
-            {
-                queueLength = reader.ReadLong();
+                // most clients send an unknown integer between queue length and the locked file count
+                _ = reader.ReadInteger();
             }
 
             IEnumerable<File> lockedFileList = Enumerable.Empty<File>();
@@ -71,7 +67,7 @@ namespace Soulseek.Messaging.Messages
                 lockedFileList = reader.ReadFiles(count);
             }
 
-            return new SearchResponse(username, token, freeUploadSlots, uploadSpeed, queueLength, fileList, lockedFileList);
+            return new SearchResponse(username, token, hasFreeUploadSlot: freeUploadSlots > 0, uploadSpeed, queueLength, fileList, lockedFileList);
         }
 
         /// <summary>
@@ -93,7 +89,7 @@ namespace Soulseek.Messaging.Messages
             }
 
             builder
-                .WriteByte((byte)searchResponse.FreeUploadSlots)
+                .WriteByte((byte)(searchResponse.HasFreeUploadSlot ? 1 : 0))
                 .WriteInteger(searchResponse.UploadSpeed)
                 .WriteLong(searchResponse.QueueLength);
 

--- a/src/Messaging/Messages/Peer/SearchResponseFactory.cs
+++ b/src/Messaging/Messages/Peer/SearchResponseFactory.cs
@@ -91,7 +91,8 @@ namespace Soulseek.Messaging.Messages
             builder
                 .WriteByte((byte)(searchResponse.HasFreeUploadSlot ? 1 : 0))
                 .WriteInteger(searchResponse.UploadSpeed)
-                .WriteLong(searchResponse.QueueLength);
+                .WriteInteger(searchResponse.QueueLength)
+                .WriteInteger(0); // unknown value included for compatibility
 
             builder.WriteInteger(searchResponse.LockedFileCount);
 

--- a/src/SearchResponse.cs
+++ b/src/SearchResponse.cs
@@ -17,6 +17,7 @@
 
 namespace Soulseek
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -35,13 +36,43 @@ namespace Soulseek
         /// <param name="queueLength">The length of the peer's upload queue.</param>
         /// <param name="fileList">The file list.</param>
         /// <param name="lockedFileList">The optional locked file list.</param>
+        [Obsolete("FreeUploadSlots is either 1 or 0; use the HasFreeUploadSlot overload. This constructor will be removed in the next major release.")]
         public SearchResponse(string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
         {
             Username = username;
             Token = token;
-            FreeUploadSlots = freeUploadSlots;
             UploadSpeed = uploadSpeed;
             QueueLength = queueLength;
+
+            HasFreeUploadSlot = freeUploadSlots > 0;
+            FreeUploadSlots = freeUploadSlots;
+
+            Files = (fileList?.ToList() ?? new List<File>()).AsReadOnly();
+            FileCount = Files.Count;
+
+            LockedFiles = (lockedFileList?.ToList() ?? new List<File>()).AsReadOnly();
+            LockedFileCount = LockedFiles.Count;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="SearchResponse"/> class.
+        /// </summary>
+        /// <param name="username">The username of the responding peer.</param>
+        /// <param name="token">The unique search token.</param>
+        /// <param name="hasFreeUploadSlot">A value indicating whether the peer has a free upload slot.</param>
+        /// <param name="uploadSpeed">The upload speed of the peer.</param>
+        /// <param name="queueLength">The length of the peer's upload queue.</param>
+        /// <param name="fileList">The file list.</param>
+        /// <param name="lockedFileList">The optional locked file list.</param>
+        public SearchResponse(string username, int token, bool hasFreeUploadSlot, int uploadSpeed, long queueLength, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
+        {
+            Username = username;
+            Token = token;
+            UploadSpeed = uploadSpeed;
+            QueueLength = queueLength;
+
+            HasFreeUploadSlot = hasFreeUploadSlot;
+            FreeUploadSlots = hasFreeUploadSlot ? 1 : 0;
 
             Files = (fileList?.ToList() ?? new List<File>()).AsReadOnly();
             FileCount = Files.Count;
@@ -57,7 +88,7 @@ namespace Soulseek
         /// <param name="fileList">The file list with which to replace the existing file list.</param>
         /// <param name="lockedFileList">The optional locked file list with which to replace the existing locked file list.</param>
         internal SearchResponse(SearchResponse searchResponse, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
-            : this(searchResponse.Username, searchResponse.Token, searchResponse.FreeUploadSlots, searchResponse.UploadSpeed, searchResponse.QueueLength, fileList, lockedFileList)
+            : this(searchResponse.Username, searchResponse.Token, hasFreeUploadSlot: searchResponse.FreeUploadSlots > 0, searchResponse.UploadSpeed, searchResponse.QueueLength, fileList, lockedFileList)
         {
         }
 
@@ -75,7 +106,13 @@ namespace Soulseek
         /// <summary>
         ///     Gets the number of free upload slots for the peer.
         /// </summary>
+        [Obsolete("FreeUploadSlots is either 1 or 0; use HasFreeUploadSlot. This constructor will be removed in the next major release.")]
         public int FreeUploadSlots { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether the peer has a free upload slot.
+        /// </summary>
+        public bool HasFreeUploadSlot { get; }
 
         /// <summary>
         ///     Gets the number of files contained within the result, as counted by the original response from the peer and prior

--- a/src/SearchResponse.cs
+++ b/src/SearchResponse.cs
@@ -37,7 +37,7 @@ namespace Soulseek
         /// <param name="fileList">The file list.</param>
         /// <param name="lockedFileList">The optional locked file list.</param>
         [Obsolete("FreeUploadSlots is either 1 or 0; use the HasFreeUploadSlot overload. This constructor will be removed in the next major release.")]
-        public SearchResponse(string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
+        public SearchResponse(string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
         {
             Username = username;
             Token = token;
@@ -64,7 +64,7 @@ namespace Soulseek
         /// <param name="queueLength">The length of the peer's upload queue.</param>
         /// <param name="fileList">The file list.</param>
         /// <param name="lockedFileList">The optional locked file list.</param>
-        public SearchResponse(string username, int token, bool hasFreeUploadSlot, int uploadSpeed, long queueLength, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
+        public SearchResponse(string username, int token, bool hasFreeUploadSlot, int uploadSpeed, int queueLength, IEnumerable<File> fileList, IEnumerable<File> lockedFileList = null)
         {
             Username = username;
             Token = token;
@@ -128,7 +128,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the length of the peer's upload queue.
         /// </summary>
-        public long QueueLength { get; }
+        public int QueueLength { get; }
 
         /// <summary>
         ///     Gets the unique search token.

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -508,7 +508,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
         [Trait("Category", "Message")]
         [Theory(DisplayName = "Sends resolved SearchResponse"), AutoData]
-        public void Sends_Resolved_SearchResponse(string query, string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Sends_Resolved_SearchResponse(string query, string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var files = new List<File>()
             {
@@ -535,7 +535,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
         [Trait("Category", "Message")]
         [Theory(DisplayName = "Ignores PeerSearchRequest if search response resolver is null"), AutoData]
-        public void Ignores_PeerSearchRequest_If_Search_Response_Resolver_Is_Null(string query, string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Ignores_PeerSearchRequest_If_Search_Response_Resolver_Is_Null(string query, string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var files = new List<File>()
             {
@@ -564,7 +564,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
         [Trait("Category", "Message")]
         [Theory(DisplayName = "Ignores PeerSearchRequest if search response is empty"), AutoData]
-        public void Ignores_PeerSearchRequest_If_Search_Response_Is_Empty(string query, string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Ignores_PeerSearchRequest_If_Search_Response_Is_Empty(string query, string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var files = new List<File>();
 
@@ -589,7 +589,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
         [Trait("Category", "Message")]
         [Theory(DisplayName = "Creates diagnostic on failed search response resolution"), AutoData]
-        public void Creates_Diagnostic_On_Failed_Search_Response_Resolution(string query, string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Creates_Diagnostic_On_Failed_Search_Response_Resolution(string query, string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var files = new List<File>();
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/SearchResponseFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/SearchResponseFactoryTests.cs
@@ -111,7 +111,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "Parse")]
         [Theory(DisplayName = "Parse returns expected data"), AutoData]
-        public void Parse_Returns_Expected_Data(string username, int token, byte freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Parse_Returns_Expected_Data(string username, int token, bool freeUploadSlots, int uploadSpeed, long queueLength)
         {
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -125,7 +125,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 .WriteInteger(1) // attribute count
                 .WriteInteger((int)FileAttributeType.BitDepth) // attribute[0].type
                 .WriteInteger(4) // attribute[0].value
-                .WriteByte(freeUploadSlots)
+                .WriteByte((byte)(freeUploadSlots ? 1 : 0))
                 .WriteInteger(uploadSpeed)
                 .WriteLong(queueLength)
                 .WriteBytes(new byte[4]) // unknown 4 bytes
@@ -137,7 +137,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(username, r.Username);
             Assert.Equal(token, r.Token);
             Assert.Equal(1, r.FileCount);
-            Assert.Equal(freeUploadSlots, r.FreeUploadSlots);
+            Assert.Equal(freeUploadSlots, r.FreeUploadSlots > 0);
             Assert.Equal(uploadSpeed, r.UploadSpeed);
             Assert.Equal(queueLength, r.QueueLength);
 
@@ -157,7 +157,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "Parse")]
         [Theory(DisplayName = "Parse handles legacy responses with 4 byte queue length"), AutoData]
-        public void Parse_Handles_Legacy_Responses_With_4_Byte_Queue_Length(string username, int token, byte freeUploadSlots, int uploadSpeed, int queueLength)
+        public void Parse_Handles_Legacy_Responses_With_4_Byte_Queue_Length(string username, int token, bool freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -171,7 +171,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 .WriteInteger(1) // attribute count
                 .WriteInteger((int)FileAttributeType.BitDepth) // attribute[0].type
                 .WriteInteger(4) // attribute[0].value
-                .WriteByte(freeUploadSlots)
+                .WriteByte((byte)(freeUploadSlots ? 1 : 0))
                 .WriteInteger(uploadSpeed)
                 .WriteInteger(queueLength)
                 .Compress()
@@ -182,7 +182,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(username, r.Username);
             Assert.Equal(token, r.Token);
             Assert.Equal(1, r.FileCount);
-            Assert.Equal(freeUploadSlots, r.FreeUploadSlots);
+            Assert.Equal(freeUploadSlots, r.FreeUploadSlots > 0);
             Assert.Equal(uploadSpeed, r.UploadSpeed);
             Assert.Equal(queueLength, r.QueueLength);
 
@@ -202,14 +202,14 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "Parse")]
         [Theory(DisplayName = "Parse handles empty responses"), AutoData]
-        public void Parse_Handles_Empty_Responses(string username, int token, byte freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Parse_Handles_Empty_Responses(string username, int token, bool freeUploadSlots, int uploadSpeed, long queueLength)
         {
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
                 .WriteString(username)
                 .WriteInteger(token)
                 .WriteInteger(0) // file count
-                .WriteByte(freeUploadSlots)
+                .WriteByte((byte)(freeUploadSlots ? 1 : 0))
                 .WriteInteger(uploadSpeed)
                 .WriteLong(queueLength)
                 .WriteBytes(new byte[4]) // unknown 4 bytes
@@ -221,7 +221,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(username, r.Username);
             Assert.Equal(token, r.Token);
             Assert.Equal(0, r.FileCount);
-            Assert.Equal(freeUploadSlots, r.FreeUploadSlots);
+            Assert.Equal(freeUploadSlots, r.FreeUploadSlots > 0);
             Assert.Equal(uploadSpeed, r.UploadSpeed);
             Assert.Equal(queueLength, r.QueueLength);
 
@@ -423,7 +423,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "ToByteArray")]
         [Theory(DisplayName = "ToByteArray returns expected data"), AutoData]
-        public void ToByteArray_Returns_Expected_Data(string username, int token, byte freeUploadSlots, int uploadSpeed, long queueLength)
+        public void ToByteArray_Returns_Expected_Data(string username, int token, byte freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var list = new List<File>()
             {
@@ -467,7 +467,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "ToByteArray")]
         [Theory(DisplayName = "ToByteArray handles locked files"), AutoData]
-        public void ToByteArray_Handles_Locked_Files(string username, int token, byte freeUploadSlots, int uploadSpeed, long queueLength)
+        public void ToByteArray_Handles_Locked_Files(string username, int token, bool freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var list = new List<File>()
             {
@@ -479,7 +479,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
-            var s = new SearchResponse(username, token, freeUploadSlots, uploadSpeed, queueLength, list, locked);
+            var s = new SearchResponse(username, token, hasFreeUploadSlot: freeUploadSlots, uploadSpeed, queueLength, list, locked);
             var m = s.ToByteArray();
 
             var reader = new MessageReader<MessageCode.Peer>(m);
@@ -502,7 +502,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(FileAttributeType.BitDepth, (FileAttributeType)reader.ReadInteger());
             Assert.Equal(1, reader.ReadInteger());
 
-            Assert.Equal(freeUploadSlots, reader.ReadByte()); // code
+            Assert.Equal(freeUploadSlots, reader.ReadByte() > 0); // code
             Assert.Equal(uploadSpeed, reader.ReadInteger()); // upload speed
             Assert.Equal(queueLength, reader.ReadLong()); // queue length
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/SearchResponseFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/SearchResponseFactoryTests.cs
@@ -466,6 +466,50 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         }
 
         [Trait("Category", "ToByteArray")]
+        [Theory(DisplayName = "ToByteArray returns expected data when HasFreeUploadSlot = false"), AutoData]
+        public void ToByteArray_Returns_Expected_Data_When_HasFreeUploadSlot_False(string username, int token, byte freeUploadSlots, int uploadSpeed, int queueLength)
+        {
+            var list = new List<File>();
+
+            var s = new SearchResponse(username, token, hasFreeUploadSlot: false, uploadSpeed, queueLength, list);
+            var m = s.ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Peer>(m);
+            reader.Decompress();
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Peer.SearchResponse, code);
+
+            Assert.Equal(username, reader.ReadString());
+            Assert.Equal(token, reader.ReadInteger());
+            Assert.Equal(0, reader.ReadInteger());
+
+            Assert.Equal(0, reader.ReadByte());
+        }
+
+        [Trait("Category", "ToByteArray")]
+        [Theory(DisplayName = "ToByteArray returns expected data when HasFreeUploadSlot = true"), AutoData]
+        public void ToByteArray_Returns_Expected_Data_When_HasFreeUploadSlot_True(string username, int token, byte freeUploadSlots, int uploadSpeed, int queueLength)
+        {
+            var list = new List<File>();
+
+            var s = new SearchResponse(username, token, hasFreeUploadSlot: true, uploadSpeed, queueLength, list);
+            var m = s.ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Peer>(m);
+            reader.Decompress();
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Peer.SearchResponse, code);
+
+            Assert.Equal(username, reader.ReadString());
+            Assert.Equal(token, reader.ReadInteger());
+            Assert.Equal(0, reader.ReadInteger());
+
+            Assert.Equal(1, reader.ReadByte());
+        }
+
+        [Trait("Category", "ToByteArray")]
         [Theory(DisplayName = "ToByteArray handles locked files"), AutoData]
         public void ToByteArray_Handles_Locked_Files(string username, int token, bool freeUploadSlots, int uploadSpeed, int queueLength)
         {

--- a/tests/Soulseek.Tests.Unit/SearchResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponseTests.cs
@@ -26,7 +26,7 @@ namespace Soulseek.Tests.Unit
     {
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with given data"), AutoData]
-        public void Instantiates_With_Given_Data(string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength, File file)
+        public void Instantiates_With_Given_Data(string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength, File file)
         {
             var list = new List<File>()
             {
@@ -60,7 +60,7 @@ namespace Soulseek.Tests.Unit
 
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with given response and list, replacing filecount with list length"), AutoData]
-        public void Instantiates_With_Given_Response_And_List(string username, int token, int freeUploadSlots, int uploadSpeed, long queueLength)
+        public void Instantiates_With_Given_Response_And_List(string username, int token, int freeUploadSlots, int uploadSpeed, int queueLength)
         {
             var r1 = new SearchResponse(username, token, freeUploadSlots, uploadSpeed, queueLength, null);
 
@@ -72,9 +72,46 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(r1.Username, r2.Username);
             Assert.Equal(r1.Token, r2.Token);
             Assert.Equal(1, r2.FileCount);
-            Assert.Equal(r1.FreeUploadSlots, r2.FreeUploadSlots);
             Assert.Equal(r1.UploadSpeed, r2.UploadSpeed);
             Assert.Equal(r1.QueueLength, r2.QueueLength);
+
+            Assert.Equal(freeUploadSlots > 0 ? 1 : 0, r2.FreeUploadSlots);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Instantiates with HasFreeUploadSlot true if FreeUploadSlots GT 1"), AutoData]
+        public void Instantiates_With_HasFreeUploadSlot_True_If_FreeUploadSlots_GT_1(string username, int token, int uploadSpeed, int queueLength)
+        {
+            var r = new SearchResponse(username, token, freeUploadSlots: 1, uploadSpeed, queueLength, null);
+
+            Assert.True(r.HasFreeUploadSlot);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Instantiates with HasFreeUploadSlot false if FreeUploadSlots EQ 0"), AutoData]
+        public void Instantiates_With_HasFreeUploadSlot_False_If_FreeUploadSlots_EQ_0(string username, int token, int uploadSpeed, int queueLength)
+        {
+            var r = new SearchResponse(username, token, freeUploadSlots: 0, uploadSpeed, queueLength, null);
+
+            Assert.False(r.HasFreeUploadSlot);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Instantiates with FreeUploadSlots 1 if HasFreeUploadSlot true"), AutoData]
+        public void Instantiates_With_FreeUploadSlots_1_If_HasFreeUploadSlot_True(string username, int token, int uploadSpeed, int queueLength)
+        {
+            var r = new SearchResponse(username, token, hasFreeUploadSlot: true, uploadSpeed, queueLength, null);
+
+            Assert.Equal(1, r.FreeUploadSlots);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Instantiates with FreeUploadSlots 1 if HasFreeUploadSlot true"), AutoData]
+        public void Instantiates_With_FreeUploadSlots_0_If_HasFreeUploadSlot_False(string username, int token, int uploadSpeed, int queueLength)
+        {
+            var r = new SearchResponse(username, token, hasFreeUploadSlot: false, uploadSpeed, queueLength, null);
+
+            Assert.Equal(0, r.FreeUploadSlots);
         }
     }
 }


### PR DESCRIPTION
It was previously believed that queue length was a 64 bit integer (with some clients providing only a 32 bit integer); this isn't the case.  Queue length is always 32 bits, and most clients send an unknown 32 bit integer immediately following that's always zero.

This PR changes the data type of various queue length properties and parameters to integer from long, which is technically a breaking change but is also a bug fix, so I'm not bumping the major version.

It's also been learned that `freeUploadSlots` is a boolean in nature but was previously treated as an integer in some cases.  This property has been marked obsolete, and a new boolean `HasFreeUploadSlot` has been added to replace it.