### PR TITLE
Obsolete MinimumPeerFreeUploadSlots search filter

### DIFF
--- a/src/Options/SearchOptions.cs
+++ b/src/Options/SearchOptions.cs
@@ -66,7 +66,6 @@ namespace Soulseek
             FileLimit = fileLimit;
             FilterResponses = filterResponses;
             MinimumResponseFileCount = minimumResponseFileCount;
-            MinimumPeerFreeUploadSlots = minimumPeerFreeUploadSlots;
             MaximumPeerQueueLength = maximumPeerQueueLength;
             MinimumPeerUploadSpeed = minimumPeerUploadSpeed;
             ResponseFilter = responseFilter;
@@ -99,6 +98,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the minimum number of free upload slots a peer must have in order for a response to be processed. (Default = 0).
         /// </summary>
+        [Obsolete("This no longer does anything, and will be removed in the next major release.")]
         public int MinimumPeerFreeUploadSlots { get; }
 
         /// <summary>

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -219,7 +219,6 @@ namespace Soulseek
         {
             if (Options.FilterResponses && (
                     response.FileCount + response.LockedFileCount < Options.MinimumResponseFileCount ||
-                    response.FreeUploadSlots < Options.MinimumPeerFreeUploadSlots ||
                     response.UploadSpeed < Options.MinimumPeerUploadSpeed ||
                     response.QueueLength >= Options.MaximumPeerQueueLength))
             {

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.1.2</Version>
+    <Version>5.1.3</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/tests/Soulseek.Tests.Unit/Options/SearchOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SearchOptionsTests.cs
@@ -59,7 +59,6 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(responseLimit, o.ResponseLimit);
             Assert.Equal(filterResponses, o.FilterResponses);
             Assert.Equal(minimumResponseFileCount, o.MinimumResponseFileCount);
-            Assert.Equal(minimumPeerFreeUploadSlots, o.MinimumPeerFreeUploadSlots);
             Assert.Equal(maximumPeerQueueLength, o.MaximumPeerQueueLength);
             Assert.Equal(minimumPeerUploadSpeed, o.MinimumPeerUploadSpeed);
             Assert.Equal(responseFilter, o.ResponseFilter);

--- a/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
@@ -110,26 +110,6 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "ResponseMeetsOptionCriteria")]
-        [Theory(DisplayName = "Response filter respects MinimumPeerFreeUploadSlots option")]
-        [InlineData(0, 1, false)]
-        [InlineData(1, 1, true)]
-        [InlineData(1, 0, true)]
-        public void Response_Filter_Respects_MinimumPeerFreeUploadSlots_Option(int actual, int option, bool expected)
-        {
-            var fixture = new Fixture();
-            var file = fixture.Create<File>();
-
-            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumPeerFreeUploadSlots: option));
-            var response = new SearchResponse("u", 1, actual, 1, 1, DuplicateFile(file, 1));
-
-            var filter = s.InvokeMethod<bool>("ResponseMeetsOptionCriteria", response);
-
-            Assert.Equal(expected, filter);
-
-            s.Dispose();
-        }
-
-        [Trait("Category", "ResponseMeetsOptionCriteria")]
         [Theory(DisplayName = "Response filter respects MinimumPeerUploadSpeed option")]
         [InlineData(0, 1, false)]
         [InlineData(1, 1, true)]


### PR DESCRIPTION
This value isn't an integer, so setting this to anything other than 0 or 1 will result in no search results being returned.

This PR removes the filtering based on this value and marks the property `Obsolete`.  #750 will delete this code and remove the property from the constructor of `SearchOptions`.