### PR TITLE
Add an option to control how upload input stream seeking works

### DIFF
--- a/src/Options/TransferOptions.cs
+++ b/src/Options/TransferOptions.cs
@@ -50,6 +50,9 @@ namespace Soulseek
         /// <param name="maximumLingerTime">
         ///     The maximum linger time, in milliseconds, that a connection will attempt to cleanly close following a transfer.
         /// </param>
+        /// <param name="seekInputStreamAutomatically">
+        ///     A value indicating whether the input stream should be automatically seeked to the desired start offset, if one is specified.
+        /// </param>
         /// <param name="disposeInputStreamOnCompletion">
         ///     A value indicating whether the input stream should be closed upon transfer completion.
         /// </param>
@@ -64,9 +67,11 @@ namespace Soulseek
             Action<Transfer> slotReleased = null,
             Action<Transfer, int, int, int> reporter = null,
             int maximumLingerTime = 3000,
+            bool seekInputStreamAutomatically = true,
             bool disposeInputStreamOnCompletion = false,
             bool disposeOutputStreamOnCompletion = false)
         {
+            SeekInputStreamAutomatically = seekInputStreamAutomatically;
             DisposeInputStreamOnCompletion = disposeInputStreamOnCompletion;
             DisposeOutputStreamOnCompletion = disposeOutputStreamOnCompletion;
             Governor = governor ?? defaultGovernor;
@@ -113,6 +118,12 @@ namespace Soulseek
         public Action<Transfer, int, int, int> Reporter { get; }
 
         /// <summary>
+        ///     Gets a value indicating whether the input stream should be automatically seeked to the desired start offset, if
+        ///     one is specified.
+        /// </summary>
+        public bool SeekInputStreamAutomatically { get; }
+
+        /// <summary>
         ///     Gets the delegate used to await a slot to start the transfer (uploads only). (Default = a delegate returning Task.CompletedTask).
         /// </summary>
         public Func<Transfer, CancellationToken, Task> SlotAwaiter { get; }
@@ -146,6 +157,7 @@ namespace Soulseek
                 slotReleased: SlotReleased,
                 reporter: Reporter,
                 maximumLingerTime: MaximumLingerTime,
+                seekInputStreamAutomatically: SeekInputStreamAutomatically,
                 disposeInputStreamOnCompletion: DisposeInputStreamOnCompletion,
                 disposeOutputStreamOnCompletion: DisposeOutputStreamOnCompletion);
         }
@@ -172,6 +184,7 @@ namespace Soulseek
                 slotReleased: SlotReleased,
                 reporter: Reporter,
                 maximumLingerTime: MaximumLingerTime,
+                seekInputStreamAutomatically: SeekInputStreamAutomatically,
                 disposeInputStreamOnCompletion: disposeInputStreamOnCompletion ?? DisposeInputStreamOnCompletion,
                 disposeOutputStreamOnCompletion: disposeOutputStreamOnCompletion ?? DisposeOutputStreamOnCompletion);
         }

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.0.0-pre.2</Version>
+    <Version>6.0.0-pre.3</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -4135,13 +4135,16 @@ namespace Soulseek
                     Diagnostic.Debug($"Resolving input stream for upload of {Path.GetFileName(upload.Filename)} to {username}");
                     inputStream = await inputStreamFactory(upload.StartOffset).ConfigureAwait(false);
 
-                    if (upload.StartOffset > 0 && !inputStream.CanSeek)
+                    if (upload.StartOffset > 0 && options.SeekInputStreamAutomatically)
                     {
-                        throw new TransferException($"Requested non-zero start offset but input stream does not support seeking");
-                    }
+                        if (!inputStream.CanSeek)
+                        {
+                            throw new TransferException($"Requested non-zero start offset but input stream does not support seeking");
+                        }
 
-                    Diagnostic.Debug($"Seeking upload of {Path.GetFileName(upload.Filename)} to {username} to starting offset of {startOffset} bytes");
-                    inputStream.Seek(startOffset, SeekOrigin.Begin);
+                        Diagnostic.Debug($"Seeking upload of {Path.GetFileName(upload.Filename)} to {username} to starting offset of {startOffset} bytes");
+                        inputStream.Seek(startOffset, SeekOrigin.Begin);
+                    }
 
                     UpdateState(TransferStates.InProgress);
                     UpdateProgress(startOffset);

--- a/tests/Soulseek.Tests.Unit/Options/TransferOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/TransferOptionsTests.cs
@@ -28,6 +28,7 @@ namespace Soulseek.Tests.Unit.Options
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with given data"), AutoData]
         public void Instantiates_Given_Data(
+            bool seekInput,
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
@@ -46,9 +47,11 @@ namespace Soulseek.Tests.Unit.Options
                 slotReleased,
                 reporter,
                 maximumLingerTime,
+                seekInput,
                 disposeInput,
                 disposeOutput);
 
+            Assert.Equal(seekInput, o.SeekInputStreamAutomatically);
             Assert.Equal(disposeInput, o.DisposeInputStreamOnCompletion);
             Assert.Equal(disposeOutput, o.DisposeOutputStreamOnCompletion);
             Assert.Equal(governor, o.Governor);
@@ -83,6 +86,7 @@ namespace Soulseek.Tests.Unit.Options
         [Trait("Category", "WithAdditionalStateChanged")]
         [Theory(DisplayName = "WithAdditionalStateChanged returns copy other than StateChanged"), AutoData]
         public void WithAdditionalStateChanged_Returns_Copy_Other_Than_StateChanged(
+            bool seekInput,
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
@@ -99,11 +103,13 @@ namespace Soulseek.Tests.Unit.Options
                 slotAwaiter: acquireSlot,
                 slotReleased: slotReleased,
                 maximumLingerTime: maximumLingerTime,
+                seekInputStreamAutomatically: seekInput,
                 disposeInputStreamOnCompletion: disposeInput,
                 disposeOutputStreamOnCompletion: disposeOutput);
 
             var o = n.WithAdditionalStateChanged(null);
 
+            Assert.Equal(seekInput, o.SeekInputStreamAutomatically);
             Assert.Equal(disposeInput, o.DisposeInputStreamOnCompletion);
             Assert.Equal(disposeOutput, o.DisposeOutputStreamOnCompletion);
             Assert.Equal(governor, o.Governor);
@@ -148,6 +154,7 @@ namespace Soulseek.Tests.Unit.Options
         [Trait("Category", "WithDisposalOptions")]
         [Theory(DisplayName = "WithDisposalOptions returns unchanged copy if both options are null"), AutoData]
         public void WithAdditionalStateChanged_Returns_Unchanged_Copy_If_Both_Options_Are_Null(
+            bool seekInput,
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
@@ -164,6 +171,7 @@ namespace Soulseek.Tests.Unit.Options
                 slotAwaiter: acquireSlot,
                 slotReleased: slotReleased,
                 maximumLingerTime: maximumLingerTime,
+                seekInputStreamAutomatically: seekInput,
                 disposeInputStreamOnCompletion: disposeInput,
                 disposeOutputStreamOnCompletion: disposeOutput);
 
@@ -175,6 +183,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(acquireSlot, o.SlotAwaiter);
             Assert.Equal(slotReleased, o.SlotReleased);
             Assert.Equal(maximumLingerTime, o.MaximumLingerTime);
+            Assert.Equal(seekInput, o.SeekInputStreamAutomatically);
             Assert.Equal(disposeInput, o.DisposeInputStreamOnCompletion);
             Assert.Equal(disposeOutput, o.DisposeOutputStreamOnCompletion);
         }
@@ -182,6 +191,7 @@ namespace Soulseek.Tests.Unit.Options
         [Trait("Category", "WithDisposalOptions")]
         [Theory(DisplayName = "WithDisposalOptions returns changed copy if both options are specified"), AutoData]
         public void WithAdditionalStateChanged_Returns_Changed_Copy_If_Both_Options_Are_Specified(
+            bool seekInput,
             bool disposeInput,
             bool disposeOutput,
             Func<Transfer, int, CancellationToken, Task<int>> governor,
@@ -198,6 +208,7 @@ namespace Soulseek.Tests.Unit.Options
                 slotAwaiter: acquireSlot,
                 slotReleased: slotReleased,
                 maximumLingerTime: maximumLingerTime,
+                seekInputStreamAutomatically: seekInput,
                 disposeInputStreamOnCompletion: !disposeInput,
                 disposeOutputStreamOnCompletion: !disposeOutput);
 
@@ -211,6 +222,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(acquireSlot, o.SlotAwaiter);
             Assert.Equal(slotReleased, o.SlotReleased);
             Assert.Equal(maximumLingerTime, o.MaximumLingerTime);
+            Assert.Equal(seekInput, o.SeekInputStreamAutomatically);
             Assert.Equal(disposeInput, o.DisposeInputStreamOnCompletion);
             Assert.Equal(disposeOutput, o.DisposeOutputStreamOnCompletion);
         }


### PR DESCRIPTION
`TransferOptions` now includes `SeekInputStreamAutomatically`, which defaults to true.  When true this option will automatically seek the given input stream for uploads to the correct offset, which is the same behavior that's always been present.

Setting `SeekInputStreamAutomatically` to false won't seek, and whatever is supplying the input stream will need to seek itself, using the new offset value added in #765 