### PR TITLE
Add tests for RawSearchResponse

### DIFF
--- a/src/RawSearchResponse.cs
+++ b/src/RawSearchResponse.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="RawSearchResponse.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    ///     A raw response to a file search, presented as a stream of binary data.
+    /// </summary>
+    /// <remarks>
+    ///     This is a hack to simulate a discriminated union.
+    /// </remarks>
+    public class RawSearchResponse : SearchResponse
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RawSearchResponse"/> class.
+        /// </summary>
+        /// <remarks>
+        ///     The input stream will be disposed after the response is written.
+        /// </remarks>
+        /// <param name="length">The length of the response, in bytes.</param>
+        /// <param name="stream">The raw input stream.</param>
+        public RawSearchResponse(long length, Stream stream)
+            : base(string.Empty, 0, false, 0, 0, null)
+        {
+            if (length <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length), "The response length must be greater than zero");
+            }
+
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream), "The specified input stream is null");
+            }
+
+            Length = length;
+            Stream = stream;
+        }
+
+        /// <summary>
+        ///     Gets the length of the response, in bytes.
+        /// </summary>
+        public long Length { get; }
+
+        /// <summary>
+        ///     Gets the raw input stream providing the response.
+        /// </summary>
+        public Stream Stream { get; }
+    }
+}

--- a/src/SearchResponse.cs
+++ b/src/SearchResponse.cs
@@ -121,48 +121,4 @@ namespace Soulseek
             return SearchResponseFactory.ToByteArray(this);
         }
     }
-
-    /// <summary>
-    ///     A raw response to a file search, presented as a stream of binary data.
-    /// </summary>
-    /// <remarks>
-    ///     This is a hack to simulate a discriminated union.
-    /// </remarks>
-    public class RawSearchResponse : SearchResponse
-    {
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="RawSearchResponse"/> class.
-        /// </summary>
-        /// <remarks>
-        ///     The input stream will be disposed after the response is written.
-        /// </remarks>
-        /// <param name="length">The length of the response, in bytes.</param>
-        /// <param name="stream">The raw input stream.</param>
-        public RawSearchResponse(long length, Stream stream)
-            : base(string.Empty, 0, false, 0, 0, null)
-        {
-            if (length <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(length), "The response length must be greater than zero");
-            }
-
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream), "The specified input stream is null");
-            }
-
-            Length = length;
-            Stream = stream;
-        }
-
-        /// <summary>
-        ///     Gets the length of the response, in bytes.
-        /// </summary>
-        public long Length { get; }
-
-        /// <summary>
-        ///     Gets the raw input stream providing the response.
-        /// </summary>
-        public Stream Stream { get; }
-    }
 }

--- a/tests/Soulseek.Tests.Unit/RawSearchResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/RawSearchResponseTests.cs
@@ -1,0 +1,65 @@
+﻿// <copyright file="RawSearchResponseTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit
+{
+    using System;
+    using System.IO;
+    using AutoFixture.Xunit2;
+    using Xunit;
+
+    public class RawSearchResponseTests
+    {
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Instantiates with given data"), AutoData]
+        public void Instantiates_With_Given_Data(long length)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var r = new RawSearchResponse(length, stream);
+
+                Assert.Equal(length, r.Length);
+                Assert.Equal(stream, r.Stream);
+            }
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Throws if the given length is less than or equal to zero")]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Throws_If_The_Given_Length_Is_LTE_Zero(long length)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var ex = Record.Exception(() => new RawSearchResponse(length, stream));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentOutOfRangeException>(ex);
+            }
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Throws if the given stream is null"), AutoData]
+        public void Throws_If_The_Given_Stream_Is_Null(long length)
+        {
+            var ex = Record.Exception(() => new RawSearchResponse(length, null));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+    }
+}


### PR DESCRIPTION
Also moves the `RawSearchResponse` code into its own file.

Closes #754 