### PR TITLE
Log encoding fallbacks at the Debug level

### DIFF
--- a/src/Messaging/MessageBuilder.cs
+++ b/src/Messaging/MessageBuilder.cs
@@ -214,7 +214,7 @@ namespace Soulseek.Messaging
                 // in this case we'll fail 'up' to UTF-8, instead of encoding to ISO-8859-1 while allowing replacements,
                 // which is almost certainly wrong.
                 bytes = Encoding.GetEncoding(CharacterEncoding.UTF8).GetBytes(value);
-                GlobalDiagnostic.Warning($"Failed to encode {encoding} for string {value}; resorted to fallback encoding {CharacterEncoding.UTF8} (base64: {Convert.ToBase64String(bytes)})", ex);
+                GlobalDiagnostic.Debug($"Failed to encode {encoding} for string {value}; resorted to fallback encoding {CharacterEncoding.UTF8} (base64: {Convert.ToBase64String(bytes)})", ex);
             }
 
             return WriteBytes(BitConverter.GetBytes(bytes.Length))

--- a/src/Messaging/MessageReader.cs
+++ b/src/Messaging/MessageReader.cs
@@ -234,7 +234,7 @@ namespace Soulseek.Messaging
                 var requestedEncoding = encoding;
                 encoding = CharacterEncoding.ISO88591;
                 retVal = Encoding.GetEncoding(encoding).GetString(bytes);
-                GlobalDiagnostic.Warning($"Failed to decode {requestedEncoding} for string {retVal}; resorted to fallback encoding {CharacterEncoding.ISO88591} (base64: {Convert.ToBase64String(bytes)})", ex);
+                GlobalDiagnostic.Debug($"Failed to decode {requestedEncoding} for string {retVal}; resorted to fallback encoding {CharacterEncoding.ISO88591} (base64: {Convert.ToBase64String(bytes)})", ex);
             }
 
             Position += length;

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.1.0</Version>
+    <Version>6.1.1</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>


### PR DESCRIPTION
These are currently being logged as `Warning` and it is cluttering logs