### PR TITLE
Fix bug in exception message when failing DNS resolution

### DIFF
--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.1.1</Version>
+    <Version>6.1.2</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -822,7 +822,7 @@ namespace Soulseek
                 }
                 catch (SocketException ex)
                 {
-                    throw new AddressException($"Failed to resolve address '{Address}': {ex.Message}", ex);
+                    throw new AddressException($"Failed to resolve address '{address}': {ex.Message}", ex);
                 }
             }
 


### PR DESCRIPTION
A few people created issues in the slskd repo during the recent DNS outage of the Soulseek server(s); part of the issue is that the exception message they were seeing didn't make a lot of sense:

```bash
Soulseek.AddressException: Failed to resolve address '': Resource temporarily unavailable
```

Had this said `Failed to resolve address 'vps.slsknet.org'` as intended, this likely wouldn't have been an issue.  This PR fixes the message.