### PR TITLE
Add support for supporter status in login response

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -12,9 +12,9 @@ echo "  nupkg: $LATEST"
 printf "  symbols: $LATEST_SYMBOLS\n\n"
 
 printf "pushing nupkg $LATEST\n\n"
-nuget push $LATEST -nosymbols -source ${NUGET_API} -apikey ${TOKEN_NUGET} -skipduplicate
+nuget push $LATEST -nosymbols -source ${NUGET_API} -skipduplicate
 
 printf "pushing symbols $LATEST_SYMBOLS\n\n"
-nuget push $LATEST_SYMBOLS -source ${NUGET_API} -apikey ${TOKEN_NUGET} -skipduplicate
+nuget push $LATEST_SYMBOLS -source ${NUGET_API} -skipduplicate
 
 printf "deployment complete."

--- a/src/Messaging/Messages/Server/LoginResponse.cs
+++ b/src/Messaging/Messages/Server/LoginResponse.cs
@@ -31,17 +31,35 @@ namespace Soulseek.Messaging.Messages
         /// <param name="succeeded">A value indicating whether the login was successful.</param>
         /// <param name="message">The reason for a login failure.</param>
         /// <param name="ipAddress">The client IP address, if the login was successful.</param>
-        public LoginResponse(bool succeeded, string message, IPAddress ipAddress = null)
+        /// <param name="hash">The MD5 hash of the username and password.</param>
+        /// <param name="isSupporter">
+        ///     A value indicating whether the user has purchased privileges, regardless of whether the user has active privileges
+        ///     at the present moment.
+        /// </param>
+        public LoginResponse(bool succeeded, string message, IPAddress ipAddress = null, string hash = null, bool? isSupporter = null)
         {
             Succeeded = succeeded;
             Message = message;
             IPAddress = ipAddress;
+            Hash = hash;
+            IsSupporter = isSupporter ?? false;
         }
+
+        /// <summary>
+        ///     Gets the MD5 hash of the username and password.
+        /// </summary>
+        public string Hash { get; }
 
         /// <summary>
         ///     Gets the client IP address, if the login was successful.
         /// </summary>
         public IPAddress IPAddress { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether the user has purchased privileges, regardless of whether the user has active
+        ///     privileges at the present moment.
+        /// </summary>
+        public bool IsSupporter { get; }
 
         /// <summary>
         ///     Gets the reason for a login failure.
@@ -72,15 +90,20 @@ namespace Soulseek.Messaging.Messages
             var msg = reader.ReadString();
 
             var ipAddress = default(IPAddress);
+            string hash = default;
+            bool isSupporter = false;
 
             if (succeeded)
             {
                 var ipBytes = reader.ReadBytes(4);
                 Array.Reverse(ipBytes);
                 ipAddress = new IPAddress(ipBytes);
+
+                hash = reader.ReadString();
+                isSupporter = reader.ReadByte() == 1;
             }
 
-            return new LoginResponse(succeeded, msg, ipAddress);
+            return new LoginResponse(succeeded, msg, ipAddress, hash, isSupporter);
         }
     }
 }

--- a/src/ServerInfo.cs
+++ b/src/ServerInfo.cs
@@ -35,12 +35,23 @@ namespace Soulseek
         /// <param name="parentMinSpeed">The ParentMinSpeed value.</param>
         /// <param name="parentSpeedRatio">The ParentSpeedRatio value.</param>
         /// <param name="wishlistInterval">The interval for wishlist searches, in miliseconds.</param>
-        public ServerInfo(int? parentMinSpeed, int? parentSpeedRatio, int? wishlistInterval)
+        /// <param name="isSupporter">
+        ///     A value indicating whether the user has purchased privileges, regardless of whether the user has active privileges
+        ///     at the present moment.
+        /// </param>
+        public ServerInfo(int? parentMinSpeed, int? parentSpeedRatio, int? wishlistInterval, bool? isSupporter)
         {
             ParentMinSpeed = parentMinSpeed;
             ParentSpeedRatio = parentSpeedRatio;
             WishlistInterval = wishlistInterval;
+            IsSupporter = isSupporter;
         }
+
+        /// <summary>
+        ///     Gets a value indicating whether the user has purchased privileges, regardless of whether the user has active
+        ///     privileges at the present moment.
+        /// </summary>
+        public bool? IsSupporter { get; private set; }
 
         /// <summary>
         ///     Gets the ParentMinSpeed value.

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -462,7 +462,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets information sent by the server upon login.
         /// </summary>
-        public ServerInfo ServerInfo { get; private set; } = new ServerInfo(parentMinSpeed: null, parentSpeedRatio: null, wishlistInterval: null);
+        public ServerInfo ServerInfo { get; private set; } = new ServerInfo(parentMinSpeed: null, parentSpeedRatio: null, wishlistInterval: null, isSupporter: null);
 
         /// <summary>
         ///     Gets the current state of the underlying TCP connection.
@@ -2986,7 +2986,8 @@ namespace Soulseek
                         var serverInfo = new ServerInfo(
                             await parentMinSpeedWait.ConfigureAwait(false),
                             await parentSpeedRatioWait.ConfigureAwait(false),
-                            await wishlistIntervalWait.ConfigureAwait(false) * 1000);
+                            await wishlistIntervalWait.ConfigureAwait(false) * 1000,
+                            response.IsSupporter);
 
                         ServerInfo = serverInfo;
                         ServerInfoReceived?.Invoke(this, serverInfo);

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -300,7 +300,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
         [Trait("Category", "Message")]
         [Theory(DisplayName = "Handles ServerLogin"), AutoData]
-        public void Handles_ServerLogin(bool success, string message, IPAddress ip)
+        public void Handles_ServerLogin(bool success, string message, IPAddress ip, string hash, bool isSupporter)
         {
             LoginResponse result = null;
 
@@ -317,6 +317,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
                 .WriteByte((byte)(success ? 1 : 0))
                 .WriteString(message)
                 .WriteBytes(ipBytes)
+                .WriteString(hash)
+                .WriteByte((byte)(isSupporter ? 1 : 0))
                 .Build();
 
             handler.HandleMessageRead(null, msg);
@@ -324,6 +326,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             Assert.Equal(success, result.Succeeded);
             Assert.Equal(message, result.Message);
             Assert.Equal(ip, result.IPAddress);
+            Assert.Equal(hash, result.Hash);
+            Assert.Equal(isSupporter, result.IsSupporter);
         }
 
         [Trait("Category", "Message")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/LoginResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/LoginResponseTests.cs
@@ -106,6 +106,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
                 .WriteByte(1)
                 .WriteString(string.Empty)
                 .WriteBytes(ipBytes)
+                .WriteString("foo")
+                .WriteByte(1)
                 .Build();
 
             var response = LoginResponse.FromByteArray(msg);
@@ -113,6 +115,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.True(response.Succeeded);
             Assert.Equal(string.Empty, response.Message);
             Assert.Equal(ip, response.IPAddress);
+            Assert.Equal("foo", response.Hash);
+            Assert.Equal(true, response.IsSupporter);
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/ServerInfoTests.cs
+++ b/tests/Soulseek.Tests.Unit/ServerInfoTests.cs
@@ -24,13 +24,14 @@ namespace Soulseek.Tests.Unit
     {
         [Trait("Category", "ServerInfo")]
         [Theory(DisplayName = "Instantiates with given values"), AutoData]
-        public void ServerInfo_Initializes_With_Nulls(int parentMinSpeed, int parentSpeedRatio, int wishlistInterval)
+        public void ServerInfo_Initializes_With_Nulls(int parentMinSpeed, int parentSpeedRatio, int wishlistInterval, bool isSupporter)
         {
-            var info = new ServerInfo(parentMinSpeed, parentSpeedRatio, wishlistInterval);
+            var info = new ServerInfo(parentMinSpeed, parentSpeedRatio, wishlistInterval, isSupporter);
 
             Assert.Equal(parentMinSpeed, info.ParentMinSpeed);
             Assert.Equal(parentSpeedRatio, info.ParentSpeedRatio);
             Assert.Equal(wishlistInterval, info.WishlistInterval);
+            Assert.Equal(isSupporter, info.IsSupporter);
         }
     }
 }


### PR DESCRIPTION
This is an old branch I found sitting here unmerged.  I really don't have much recollection of this, but I'm guessing @mathiascode does, since they probably told me about this!