### PR TITLE
Bump openJDK version from 11 to 17 to satisfy sonarscanner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: apt-get update
       - run: apt-get install jq -y
       - run: mkdir -p /usr/share/man/man1
-      - run: apt-get install openjdk-21-jre-headless -y
+      - run: apt-get install openjdk-21-jre -y
       - run: echo 'export PATH=$HOME/.dotnet/tools:$PATH' >> $BASH_ENV
       - run: dotnet tool install --global dotnet-sonarscanner --version 5.4.1
       - run: bash ./bin/ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: apt-get update
       - run: apt-get install jq -y
       - run: mkdir -p /usr/share/man/man1
-      - run: apt-get install openjdk-11-jre-headless -y
+      - run: apt-get install openjdk-21-jre-headless -y
       - run: echo 'export PATH=$HOME/.dotnet/tools:$PATH' >> $BASH_ENV
       - run: dotnet tool install --global dotnet-sonarscanner --version 5.4.1
       - run: bash ./bin/ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: apt-get update
       - run: apt-get install jq -y
       - run: mkdir -p /usr/share/man/man1
-      - run: apt-get install openjdk-21-jre -y
+      - run: apt-get install openjdk-17-jre-headless -y
       - run: echo 'export PATH=$HOME/.dotnet/tools:$PATH' >> $BASH_ENV
       - run: dotnet tool install --global dotnet-sonarscanner --version 5.4.1
       - run: bash ./bin/ci


### PR DESCRIPTION
```
The version of Java (11.0.22) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
```

Looks like only 17 is in the distro repo.