### PR TITLE
Add support for server message code 160 'ExcludedSearchPhrases' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ The external interface of the library is sparse and well documented; the best re
 * [SearchOptions](https://github.com/jpdillingham/Soulseek.NET/blob/master/src/Options/SearchOptions.cs)
 * [TransferOptions](https://github.com/jpdillingham/Soulseek.NET/blob/master/src/Options/TransferOptions.cs)
 
+## Excluded Search Phrases
+
+Starting around the beginning of 2024, the Soulseek server has begun sending a list of 'excluded search phrases' as a way to restrict content exchanged on the network and appease copyright trolls.
+
+This list of phrases is delivered in the event `ExcludedSearchPhrassReceived`, and it is my expectation that any outgoing search results _must_ be filtered to exclude files that contain any of the excluded phrases in the path or filename.
+
+I appreciate everyone's cooperation and commitment to ensuring the long term health of the Soulseek network.
+
 # Example Web Application
 
 Note that the example application as been superseded by [slskd](https://github.com/slskd/slskd) and will no longer be maintained.

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -92,6 +92,11 @@ namespace Soulseek
         event EventHandler<DownloadFailedEventArgs> DownloadFailed;
 
         /// <summary>
+        ///     Occurs when the server sends a list of excluded ("banned") search phrases.
+        /// </summary>
+        event EventHandler<IReadOnlyCollection<string>> ExcludedSearchPhrasesReceived;
+
+        /// <summary>
         ///     Occurs when a global message is received.
         /// </summary>
         event EventHandler<string> GlobalMessageReceived;

--- a/src/Messaging/Handlers/IServerMessageHandler.cs
+++ b/src/Messaging/Handlers/IServerMessageHandler.cs
@@ -31,6 +31,11 @@ namespace Soulseek.Messaging.Handlers
         event EventHandler DistributedNetworkReset;
 
         /// <summary>
+        ///     Occurs when the server sends a list of excluded ("banned") search phrases.
+        /// </summary>
+        event EventHandler<IReadOnlyCollection<string>> ExcludedSearchPhrasesReceived;
+
+        /// <summary>
         ///     Occurs when a global message is received.
         /// </summary>
         event EventHandler<string> GlobalMessageReceived;

--- a/src/Messaging/Handlers/ServerMessageHandler.cs
+++ b/src/Messaging/Handlers/ServerMessageHandler.cs
@@ -56,6 +56,11 @@ namespace Soulseek.Messaging.Handlers
         public event EventHandler DistributedNetworkReset;
 
         /// <summary>
+        ///     Occurs when the server sends a list of excluded ("banned") search phrases.
+        /// </summary>
+        public event EventHandler<IReadOnlyCollection<string>> ExcludedSearchPhrasesReceived;
+
+        /// <summary>
         ///     Occurs when a global message is received.
         /// </summary>
         public event EventHandler<string> GlobalMessageReceived;
@@ -232,6 +237,12 @@ namespace Soulseek.Messaging.Handlers
                     case MessageCode.Server.PrivateRoomToggle:
                         var acceptInvitations = PrivateRoomToggle.FromByteArray(message).AcceptInvitations;
                         SoulseekClient.Waiter.Complete(new WaitKey(code), acceptInvitations);
+                        break;
+
+                    case MessageCode.Server.ExcludedSearchPhrases:
+                        var excludedSearchPhraseList = ExcludedSearchPhrasesNotification.FromByteArray(message);
+                        SoulseekClient.Waiter.Complete(new WaitKey(code), excludedSearchPhraseList);
+                        ExcludedSearchPhrasesReceived?.Invoke(this, excludedSearchPhraseList);
                         break;
 
                     case MessageCode.Server.GlobalAdminMessage:

--- a/src/Messaging/MessageCode.cs
+++ b/src/Messaging/MessageCode.cs
@@ -652,6 +652,11 @@ namespace Soulseek.Messaging
             RelatedSearch = 153,
 
             /// <summary>
+            ///     160
+            /// </summary>
+            ExcludedSearchPhrases = 160,
+
+            /// <summary>
             ///     1001
             /// </summary>
             CannotConnect = 1001,

--- a/src/Messaging/Messages/Server/ExcludedSearchPhrasesNotification.cs
+++ b/src/Messaging/Messages/Server/ExcludedSearchPhrasesNotification.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="ExcludedSearchPhrasesNotification.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Messaging.Messages
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    ///     A list of excluded ("banned") search phrases.
+    /// </summary>
+    internal sealed class ExcludedSearchPhrasesNotification : IIncomingMessage
+    {
+        /// <summary>
+        ///     Creates a new instance of <see cref="ExcludedSearchPhrasesNotification"/> from the specified <paramref name="bytes"/>.
+        /// </summary>
+        /// <param name="bytes">The byte array from which to parse.</param>
+        /// <returns>The parsed instance.</returns>
+        public static IReadOnlyCollection<string> FromByteArray(byte[] bytes)
+        {
+            var reader = new MessageReader<MessageCode.Server>(bytes);
+            var code = reader.ReadCode();
+
+            if (code != MessageCode.Server.ExcludedSearchPhrases)
+            {
+                throw new MessageException($"Message Code mismatch creating {nameof(ExcludedSearchPhrasesNotification)} (expected: {(int)MessageCode.Server.ExcludedSearchPhrases}, received: {(int)code}");
+            }
+
+            var count = reader.ReadInteger();
+            var list = new List<string>();
+
+            for (int i = 0; i < count; i++)
+            {
+                list.Add(reader.ReadString());
+            }
+
+            return list.AsReadOnly();
+        }
+    }
+}

--- a/src/SearchResponder.cs
+++ b/src/SearchResponder.cs
@@ -21,7 +21,6 @@ namespace Soulseek
     using System.Threading;
     using System.Threading.Tasks;
     using Soulseek.Diagnostics;
-    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
 
     /// <summary>
@@ -165,6 +164,10 @@ namespace Soulseek
                     throw;
                 }
 
+                // clients may choose to return a RawSearchResponse to the resolver. this is a way for clients to send a byte array directly to the network,
+                // bypassing serialization. the use case is a bit imaginary, but the same was done for RawBrowseResponse to allow slskd to cache the browse
+                // response to disk, avoiding serializing to json and deserializing to BrowseResponse each time; it's a performance optimization. this seemed
+                // like a good idea at the time but now that i'm reviewing it ~1.5 years later i'm wondering what i was thinking :)
                 if (searchResponse is RawSearchResponse rawSearchResponse)
                 {
                     await peerConnection.WriteAsync(rawSearchResponse.Length, rawSearchResponse.Stream).ConfigureAwait(false);

--- a/src/ServerInfo.cs
+++ b/src/ServerInfo.cs
@@ -48,10 +48,10 @@ namespace Soulseek
         }
 
         /// <summary>
-        ///     Gets a value indicating whether the user has purchased privileges, regardless of whether the user has active
+        ///     Gets a value indicating whether the logged in user has ever purchased privileges, regardless of whether the user has active
         ///     privileges at the present moment.
         /// </summary>
-        public bool? IsSupporter { get; private set; }
+        public bool? IsSupporter { get; }
 
         /// <summary>
         ///     Gets the ParentMinSpeed value.

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -183,6 +183,7 @@ namespace Soulseek
             ServerMessageHandler.DiagnosticGenerated += (sender, e) => DiagnosticGenerated?.Invoke(sender, e);
             ServerMessageHandler.GlobalMessageReceived += (sender, e) => GlobalMessageReceived?.Invoke(this, e);
             ServerMessageHandler.DistributedNetworkReset += (sender, e) => DistributedNetworkReset?.Invoke(this, e);
+            ServerMessageHandler.ExcludedSearchPhrasesReceived += (sender, e) => ExcludedSearchPhrasesReceived?.Invoke(this, e);
 
             ServerMessageHandler.KickedFromServer += (sender, e) =>
             {
@@ -256,6 +257,11 @@ namespace Soulseek
         ///     Occurs when a user reports that a download has failed.
         /// </summary>
         public event EventHandler<DownloadFailedEventArgs> DownloadFailed;
+
+        /// <summary>
+        ///     Occurs when the server sends a list of excluded ("banned") search phrases.
+        /// </summary>
+        public event EventHandler<IReadOnlyCollection<string>> ExcludedSearchPhrasesReceived;
 
         /// <summary>
         ///     Occurs when a global message is received.

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -505,6 +505,37 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         }
 
         [Trait("Category", "Message")]
+        [Theory(DisplayName = "Raises ExcludedSearchPhrasesReceived"), AutoData]
+        public void Raises_ExcludedSearchPhrasesReceived(string[] names)
+        {
+            IReadOnlyCollection<string> result = null;
+            var (handler, mocks) = GetFixture();
+
+            mocks.Waiter.Setup(m => m.Complete(It.IsAny<WaitKey>(), It.IsAny<IReadOnlyCollection<string>>()))
+                .Callback<WaitKey, IReadOnlyCollection<string>>((key, response) => result = response);
+
+            var builder = new MessageBuilder()
+                .WriteCode(MessageCode.Server.ExcludedSearchPhrases)
+                .WriteInteger(names.Length);
+
+            foreach (var name in names)
+            {
+                builder.WriteString(name);
+            }
+
+            var msg = builder.Build();
+
+            handler.ExcludedSearchPhrasesReceived += (sender, e) => result = e;
+
+            handler.HandleMessageRead(null, msg);
+
+            foreach (var name in names)
+            {
+                Assert.Contains(result, n => n == name);
+            }
+        }
+
+        [Trait("Category", "Message")]
         [Theory(DisplayName = "Creates connection on ConnectToPeerResponse 'P'"), AutoData]
         public void Creates_Connection_On_ConnectToPeerResponse_P(string username, int token, IPAddress ip, int port)
         {

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/ExcludedSearchPhrasesTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/ExcludedSearchPhrasesTests.cs
@@ -1,0 +1,78 @@
+﻿// <copyright file="ExcludedSearchPhrasesTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit.Messaging.Messages
+{
+    using System.Linq;
+    using Soulseek.Messaging;
+    using Soulseek.Messaging.Messages;
+    using Xunit;
+
+    public class ExcludedSearchPhrasesTests
+    {
+        [Trait("Category", "Parse")]
+        [Fact(DisplayName = "Parse throws MessageExcepton on code mismatch")]
+        public void Parse_Throws_MessageException_On_Code_Mismatch()
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Peer.BrowseRequest)
+                .Build();
+
+            var ex = Record.Exception(() => ExcludedSearchPhrasesNotification.FromByteArray(msg));
+
+            Assert.NotNull(ex);
+            Assert.IsType<MessageException>(ex);
+        }
+
+        [Trait("Category", "Parse")]
+        [Fact(DisplayName = "Parse throws MessageReadException on missing data")]
+        public void Parse_Throws_MessageReadException_On_Missing_Data()
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Server.ExcludedSearchPhrases)
+                .WriteInteger(1)
+                .Build();
+
+            var ex = Record.Exception(() => ExcludedSearchPhrasesNotification.FromByteArray(msg));
+
+            Assert.NotNull(ex);
+            Assert.IsType<MessageReadException>(ex);
+        }
+
+        [Trait("Category", "Parse")]
+        [Fact(DisplayName = "Parse returns expected data")]
+        public void Parse_Returns_Expected_Data()
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Server.ExcludedSearchPhrases)
+                .WriteInteger(4)
+                .WriteString("larry")
+                .WriteString("moe")
+                .WriteString("curly")
+                .WriteString("shemp")
+                .Build();
+
+            var response = ExcludedSearchPhrasesNotification.FromByteArray(msg).ToList();
+
+            Assert.Equal(4, response.Count);
+            Assert.Contains("larry", response);
+            Assert.Contains("moe", response);
+            Assert.Contains("curly", response);
+            Assert.Contains("shemp", response);
+        }
+    }
+}

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -1137,6 +1137,24 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "ServerMessageHandler Event")]
+        [Theory(DisplayName = "ExcludedSearchPhrasesReceived fires when handler raises"), AutoData]
+        public void ExcludedSearchPhrasesReceived_Fires_When_Handler_Raises(string[] usernames)
+        {
+            var mock = new Mock<IServerMessageHandler>();
+            var expectedArgs = usernames.ToList().AsReadOnly();
+            IReadOnlyCollection<string> actualArgs = null;
+
+            using (var s = new SoulseekClient(serverMessageHandler: mock.Object))
+            {
+                s.ExcludedSearchPhrasesReceived += (sender, args) => actualArgs = args;
+                mock.Raise(m => m.ExcludedSearchPhrasesReceived += null, mock.Object, expectedArgs);
+
+                Assert.NotNull(actualArgs);
+                Assert.Equal(expectedArgs, actualArgs);
+            }
+        }
+
+        [Trait("Category", "ServerMessageHandler Event")]
         [Theory(DisplayName = "PrivilegedUserListReceived does not throw if event not bound"), AutoData]
         public void PrivilegedUserListReceived_Does_Not_Throw_If_Event_Not_Bound(string[] usernames)
         {
@@ -1146,6 +1164,21 @@ namespace Soulseek.Tests.Unit
             using (var s = new SoulseekClient(serverMessageHandler: mock.Object))
             {
                 var ex = Record.Exception(() => mock.Raise(m => m.PrivilegedUserListReceived += null, mock.Object, expectedArgs));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "ServerMessageHandler Event")]
+        [Theory(DisplayName = "ExcludedSearchPhrasesReceived does not throw if event not bound"), AutoData]
+        public void ExcludedSearchPhrasesReceived_Does_Not_Throw_If_Event_Not_Bound(string[] usernames)
+        {
+            var mock = new Mock<IServerMessageHandler>();
+            var expectedArgs = usernames.ToList().AsReadOnly();
+
+            using (var s = new SoulseekClient(serverMessageHandler: mock.Object))
+            {
+                var ex = Record.Exception(() => mock.Raise(m => m.ExcludedSearchPhrasesReceived += null, mock.Object, expectedArgs));
 
                 Assert.Null(ex);
             }


### PR DESCRIPTION
Adds a new event `ExcludedSearchPhrasesReceived` with an argument of type `IReadOnlyCollection<string>`.  This is functionally identical to the existing `PrivilegedUserListReceived` event.

This message has been newly implemented server side to help the Soulseek folks avoid copyright trolls.  The intent is for clients to receive this list of phrases and then to ensure outgoing search results are filtered of files containing any of the phrases.

For the greater good of the Soulseek network I ask that anyone using this library implements this functionality.

Closes #803 