### PR TITLE
Refactor login sequence so that it no longer depends on unrelated server messages

### DIFF
--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -1,4 +1,4 @@
-﻿namespace WebAPI
+namespace WebAPI
 {
     using System;
     using System.Collections.Concurrent;
@@ -294,6 +294,11 @@
                     Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [DIAGNOSTIC:{e.GetType().Name}] [{args.Level}] {args.Message}");
                     Console.ResetColor();
                 }
+            };
+
+            Client.ServerInfoReceived += (e, args) =>
+            {
+                Console.WriteLine($"[SERVER INFO] {JsonSerializer.Serialize(args)}");
             };
 
             // bind transfer events.  see TransferStateChangedEventArgs and TransferProgressEventArgs.

--- a/src/Messaging/Handlers/IServerMessageHandler.cs
+++ b/src/Messaging/Handlers/IServerMessageHandler.cs
@@ -132,6 +132,11 @@ namespace Soulseek.Messaging.Handlers
         event EventHandler<RoomTickerRemovedEventArgs> RoomTickerRemoved;
 
         /// <summary>
+        ///     Occurs when the server sends operational information.
+        /// </summary>
+        event EventHandler<ServerInfo> ServerInfoReceived;
+
+        /// <summary>
         ///     Occurs when a user fails to connect.
         /// </summary>
         event EventHandler<UserCannotConnectEventArgs> UserCannotConnect;

--- a/src/Messaging/Handlers/ServerMessageHandler.cs
+++ b/src/Messaging/Handlers/ServerMessageHandler.cs
@@ -157,6 +157,11 @@ namespace Soulseek.Messaging.Handlers
         public event EventHandler<RoomTickerRemovedEventArgs> RoomTickerRemoved;
 
         /// <summary>
+        ///     Occurs when the server sends operational information.
+        /// </summary>
+        public event EventHandler<ServerInfo> ServerInfoReceived;
+
+        /// <summary>
         ///     Occurs when a user fails to connect.
         /// </summary>
         public event EventHandler<UserCannotConnectEventArgs> UserCannotConnect;
@@ -203,8 +208,20 @@ namespace Soulseek.Messaging.Handlers
                 switch (code)
                 {
                     case MessageCode.Server.ParentMinSpeed:
+                        var parentMinSpeed = IntegerResponse.FromByteArray<MessageCode.Server>(message);
+                        ServerInfoReceived?.Invoke(this, new ServerInfo(parentMinSpeed: parentMinSpeed));
+                        break;
+
                     case MessageCode.Server.ParentSpeedRatio:
+                        var parentSpeedRatio = IntegerResponse.FromByteArray<MessageCode.Server>(message);
+                        ServerInfoReceived?.Invoke(this, new ServerInfo(parentSpeedRatio: parentSpeedRatio));
+                        break;
+
                     case MessageCode.Server.WishlistInterval:
+                        var wishlistInterval = IntegerResponse.FromByteArray<MessageCode.Server>(message);
+                        ServerInfoReceived?.Invoke(this, new ServerInfo(wishlistInterval: wishlistInterval));
+                        break;
+
                     case MessageCode.Server.CheckPrivileges:
                         SoulseekClient.Waiter.Complete(new WaitKey(code), IntegerResponse.FromByteArray<MessageCode.Server>(message));
                         break;

--- a/src/Messaging/Handlers/ServerMessageHandler.cs
+++ b/src/Messaging/Handlers/ServerMessageHandler.cs
@@ -258,7 +258,6 @@ namespace Soulseek.Messaging.Handlers
 
                     case MessageCode.Server.ExcludedSearchPhrases:
                         var excludedSearchPhraseList = ExcludedSearchPhrasesNotification.FromByteArray(message);
-                        SoulseekClient.Waiter.Complete(new WaitKey(code), excludedSearchPhraseList);
                         ExcludedSearchPhrasesReceived?.Invoke(this, excludedSearchPhraseList);
                         break;
 
@@ -293,7 +292,6 @@ namespace Soulseek.Messaging.Handlers
 
                     case MessageCode.Server.PrivilegedUsers:
                         var privilegedUserList = PrivilegedUserListNotification.FromByteArray(message);
-                        SoulseekClient.Waiter.Complete(new WaitKey(code), privilegedUserList);
                         PrivilegedUserListReceived?.Invoke(this, privilegedUserList);
                         break;
 

--- a/src/ServerInfo.cs
+++ b/src/ServerInfo.cs
@@ -34,12 +34,16 @@ namespace Soulseek
         /// </summary>
         /// <param name="parentMinSpeed">The ParentMinSpeed value.</param>
         /// <param name="parentSpeedRatio">The ParentSpeedRatio value.</param>
-        /// <param name="wishlistInterval">The interval for wishlist searches, in miliseconds.</param>
+        /// <param name="wishlistInterval">The interval for wishlist searches, in seconds.</param>
         /// <param name="isSupporter">
-        ///     A value indicating whether the user has purchased privileges, regardless of whether the user has active privileges
-        ///     at the present moment.
+        ///     A value indicating whether the logged in user has ever purchased privileges, regardless of whether the user has active
+        ///     privileges at the present moment.
         /// </param>
-        public ServerInfo(int? parentMinSpeed, int? parentSpeedRatio, int? wishlistInterval, bool? isSupporter)
+        public ServerInfo(
+            int? parentMinSpeed = null,
+            int? parentSpeedRatio = null,
+            int? wishlistInterval = null,
+            bool? isSupporter = null)
         {
             ParentMinSpeed = parentMinSpeed;
             ParentSpeedRatio = parentSpeedRatio;
@@ -64,8 +68,32 @@ namespace Soulseek
         public int? ParentSpeedRatio { get; }
 
         /// <summary>
-        ///     Gets the interval for wishlist searches, in miliseconds.
+        ///     Gets the interval for wishlist searches, in seconds.
         /// </summary>
         public int? WishlistInterval { get; }
+
+        /// <summary>
+        ///     Creates a clone of this instance with the specified substitutions.
+        /// </summary>
+        /// <param name="parentMinSpeed">The ParentMinSpeed value.</param>
+        /// <param name="parentSpeedRatio">The ParentSpeedRatio value.</param>
+        /// <param name="wishlistInterval">The interval for wishlist searches, in seconds.</param>
+        /// <param name="isSupporter">
+        ///     A value indicating whether the logged in user has ever purchased privileges, regardless of whether the user has active
+        ///     privileges at the present moment.
+        /// </param>
+        /// <returns>The cloned instance.</returns>
+        internal ServerInfo With(
+            int? parentMinSpeed = null,
+            int? parentSpeedRatio = null,
+            int? wishlistInterval = null,
+            bool? isSupporter = null)
+        {
+            return new ServerInfo(
+                parentMinSpeed: parentMinSpeed ?? ParentMinSpeed,
+                parentSpeedRatio: parentSpeedRatio ?? ParentSpeedRatio,
+                wishlistInterval: wishlistInterval ?? WishlistInterval,
+                isSupporter: isSupporter ?? IsSupporter);
+        }
     }
 }

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SoulseekClient.cs" company="JP Dillingham">
+// <copyright file="SoulseekClient.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -184,6 +184,17 @@ namespace Soulseek
             ServerMessageHandler.GlobalMessageReceived += (sender, e) => GlobalMessageReceived?.Invoke(this, e);
             ServerMessageHandler.DistributedNetworkReset += (sender, e) => DistributedNetworkReset?.Invoke(this, e);
             ServerMessageHandler.ExcludedSearchPhrasesReceived += (sender, e) => ExcludedSearchPhrasesReceived?.Invoke(this, e);
+
+            ServerMessageHandler.ServerInfoReceived += (sender, e) =>
+            {
+                ServerInfo = ServerInfo.With(
+                    parentMinSpeed: e.ParentMinSpeed,
+                    parentSpeedRatio: e.ParentSpeedRatio,
+                    wishlistInterval: e.WishlistInterval,
+                    isSupporter: e.IsSupporter);
+
+                ServerInfoReceived?.Invoke(this, ServerInfo);
+            };
 
             ServerMessageHandler.KickedFromServer += (sender, e) =>
             {

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -337,6 +337,29 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         }
 
         [Trait("Category", "Message")]
+        [Theory(DisplayName = "Handles IntegerResponse messages")]
+        [InlineData(MessageCode.Server.CheckPrivileges)]
+        internal void Handles_IntegerResponse_Messages(MessageCode.Server code)
+        {
+            int value = new Random().Next();
+            int? result = null;
+
+            var (handler, mocks) = GetFixture();
+
+            mocks.Waiter.Setup(m => m.Complete(It.IsAny<WaitKey>(), It.IsAny<int>()))
+                .Callback<WaitKey, int>((key, response) => result = response);
+
+            var msg = new MessageBuilder()
+                .WriteCode(code)
+                .WriteInteger(value)
+                .Build();
+
+            handler.HandleMessageRead(null, msg);
+
+            Assert.Equal(value, result);
+        }
+
+        [Trait("Category", "Message")]
         [Theory(DisplayName = "Does not throw on ServerInfo messages when ServerInfoReceived is unbound")]
         [InlineData(MessageCode.Server.ParentMinSpeed)]
         [InlineData(MessageCode.Server.ParentSpeedRatio)]
@@ -344,8 +367,6 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         internal void Does_Not_Throw_On_ServerInfo_When_ServerInfoReceived_Is_Unbound(MessageCode.Server code)
         {
             var (handler, mocks) = GetFixture();
-
-            // this is where we would bind the event handler, but we're not because that's what we're testing
 
             var msg = new MessageBuilder()
                 .WriteCode(code)

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -559,7 +559,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             var (handler, mocks) = GetFixture();
 
             var builder = new MessageBuilder()
-                .WriteCode(MessageCode.Server.ExcludedSearchPhrases)
+                .WriteCode(MessageCode.Server.PrivilegedUsers)
                 .WriteInteger(names.Length);
 
             foreach (var name in names)

--- a/tests/Soulseek.Tests.Unit/ServerInfoTests.cs
+++ b/tests/Soulseek.Tests.Unit/ServerInfoTests.cs
@@ -33,5 +33,38 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(wishlistInterval, info.WishlistInterval);
             Assert.Equal(isSupporter, info.IsSupporter);
         }
+
+        [Trait("Category", "ServerInfo")]
+        [Theory(DisplayName = "With overlays substitutions"), AutoData]
+        public void ServerInfo_With_Overlays(int parentMinSpeed, int parentSpeedRatio, int wishlistInterval, bool isSupporter)
+        {
+            var info = new ServerInfo();
+
+            Assert.Null(info.ParentMinSpeed);
+            Assert.Null(info.ParentSpeedRatio);
+            Assert.Null(info.WishlistInterval);
+            Assert.Null(info.IsSupporter);
+
+            info = info.With(parentMinSpeed: parentMinSpeed, parentSpeedRatio: parentSpeedRatio, wishlistInterval: wishlistInterval, isSupporter: isSupporter);
+
+            Assert.Equal(parentMinSpeed, info.ParentMinSpeed);
+            Assert.Equal(parentSpeedRatio, info.ParentSpeedRatio);
+            Assert.Equal(wishlistInterval, info.WishlistInterval);
+            Assert.Equal(isSupporter, info.IsSupporter);
+        }
+
+        [Trait("Category", "ServerInfo")]
+        [Theory(DisplayName = "With does not overlay nulls"), AutoData]
+        public void ServerInfo_With_Does_Not_Overlay_Nulls(int parentMinSpeed, int parentSpeedRatio, int wishlistInterval, bool isSupporter)
+        {
+            var info = new ServerInfo(parentMinSpeed, parentSpeedRatio, wishlistInterval, isSupporter);
+
+            info = info.With(parentMinSpeed: null, parentSpeedRatio: null, wishlistInterval: null, isSupporter: null);
+
+            Assert.Equal(parentMinSpeed, info.ParentMinSpeed);
+            Assert.Equal(parentSpeedRatio, info.ParentSpeedRatio);
+            Assert.Equal(wishlistInterval, info.WishlistInterval);
+            Assert.Equal(isSupporter, info.IsSupporter);
+        }
     }
 }

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -712,6 +712,41 @@ namespace Soulseek.Tests.Unit
             }
         }
 
+        [Trait("Category", "ServerInfoReceived")]
+        [Theory(DisplayName = "Raises ServerInfoReceived on receipt"), AutoData]
+        public void Raises_ServerInfoReceived_On_Receipt(ServerInfo info)
+        {
+            var handlerMock = new Mock<IServerMessageHandler>();
+
+            using (var s = new SoulseekClient(serverMessageHandler: handlerMock.Object))
+            {
+                ServerInfo args = default;
+                s.ServerInfoReceived += (sender, e) => args = e;
+
+                handlerMock.Raise(m => m.ServerInfoReceived += null, this, info);
+
+                Assert.NotNull(args);
+                Assert.Equal(info.ParentMinSpeed, args.ParentMinSpeed);
+                Assert.Equal(info.ParentSpeedRatio, args.ParentSpeedRatio);
+                Assert.Equal(info.WishlistInterval, args.WishlistInterval);
+                Assert.Equal(info.IsSupporter, args.IsSupporter);
+            }
+        }
+
+        [Trait("Category", "ServerInfoReceived")]
+        [Fact(DisplayName = "Does not throw when ServerInfoReceived and no handler bound")]
+        public void Does_Not_Throw_When_ServerInfoReceived_And_No_Handler_Bound()
+        {
+            var handlerMock = new Mock<IServerMessageHandler>();
+
+            using (var s = new SoulseekClient(serverMessageHandler: handlerMock.Object))
+            {
+                var ex = Record.Exception(() => handlerMock.Raise(m => m.ServerInfoReceived += null, this, new ServerInfo()));
+
+                Assert.Null(ex);
+            }
+        }
+
         [Trait("Category", "MessageRead")]
         [Fact(DisplayName = "MessageRead invokes HandleMessageRead")]
         public void MessageRead_Invokes_HandleMessageRead()


### PR DESCRIPTION
#805 improved logging in this area but after thinking about it for a while I no longer think it's a good idea to even couple these things to the login; the data isn't necessary for the client to function.

This PR moves the handling of `ParentMinSpeed`, `ParentSpeedRatio` and `WishlistInterval` out of band.

The `ServerInfoReceived` event will fire each time any of the four captured properties is received; the first time at successful login, setting `IsSupporter`, and then once for each of the other three.  The associated properties will remain `null` until the data is received, and if the server doesn't send it, no big deal.

The observed defaults for these properties are:
* `ParentMinSpeed`: 1
* `ParentSpeedRatio`: 50
* `WishlistInterval`: 720 (seconds, or 12 minutes)

This PR also corrects a mistake in the documentation; `WishlistInterval` is expressed in seconds, not milliseconds.  Anyone relying on this value to perform wishlist searches should make an adjustment immediately.