### PR TITLE
Add support for multiple directories in 'folder contents' response

### DIFF
--- a/examples/Web/api/Controllers/UserController.cs
+++ b/examples/Web/api/Controllers/UserController.cs
@@ -43,7 +43,7 @@
         [Authorize]
         [ProducesResponseType(typeof(UserAddress), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Address([FromRoute, Required]string username)
+        public async Task<IActionResult> Address([FromRoute, Required] string username)
         {
             try
             {
@@ -65,7 +65,7 @@
         [Authorize]
         [ProducesResponseType(typeof(IEnumerable<Directory>), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Browse([FromRoute, Required]string username)
+        public async Task<IActionResult> Browse([FromRoute, Required] string username)
         {
             try
             {
@@ -86,6 +86,34 @@
         }
 
         /// <summary>
+        ///     Retrieves the specified folder contents from the specified <paramref name="username"/>.
+        /// </summary>
+        /// <param name="username">The username of the user.</param>
+        /// <param name="folderName">The name of the folder.</param>
+        /// <returns></returns>
+        [HttpGet("{username}/folder/{folderName}")]
+        // [Authorize]
+        [ProducesResponseType(typeof(IEnumerable<Directory>), 200)]
+        [ProducesResponseType(404)]
+        public async Task<IActionResult> FolderContents([FromRoute, Required] string username, [FromRoute, Required] string folderName)
+        {
+            try
+            {
+                var result = await Client.GetDirectoryContentsAsync(username, folderName);
+                return Ok(result);
+            }
+            catch (UserOfflineException ex)
+            {
+                return NotFound(ex.Message);
+            }
+            catch (System.Exception ex)
+            {
+                System.Console.WriteLine(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
         ///     Retrieves the status of the current browse operation for the specified <paramref name="username"/>, if any.
         /// </summary>
         /// <param name="username">The username of the user.</param>
@@ -94,7 +122,7 @@
         [Authorize]
         [ProducesResponseType(typeof(decimal), 200)]
         [ProducesResponseType(404)]
-        public IActionResult BrowseStatus([FromRoute, Required]string username)
+        public IActionResult BrowseStatus([FromRoute, Required] string username)
         {
             if (BrowseTracker.TryGet(username, out var progress))
             {
@@ -113,7 +141,7 @@
         [Authorize]
         [ProducesResponseType(typeof(UserInfo), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Info([FromRoute, Required]string username)
+        public async Task<IActionResult> Info([FromRoute, Required] string username)
         {
             try
             {
@@ -135,7 +163,7 @@
         [Authorize]
         [ProducesResponseType(typeof(UserStatus), 200)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Status([FromRoute, Required]string username)
+        public async Task<IActionResult> Status([FromRoute, Required] string username)
         {
             try
             {

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -483,15 +483,22 @@ namespace WebAPI
         /// <returns>A Task resolving an instance of Soulseek.Directory containing the contents of the requested directory.</returns>
         private Task<IEnumerable<Soulseek.Directory>> DirectoryContentsResponseResolver(string username, IPEndPoint endpoint, int token, string directory)
         {
-            IEnumerable<Soulseek.Directory> list = new List<Soulseek.Directory>()
+            static Soulseek.Directory MakeDirectory(string dir) => new Soulseek.Directory(
+                name: dir.Replace("/", @"\"),
+                fileList: System.IO.Directory.GetFiles(dir)
+                    .Select(f => new Soulseek.File(1, Path.GetFileName(f), new FileInfo(f).Length, Path.GetExtension(f))));
+
+            var list = new List<Soulseek.Directory>()
             {
-                new Soulseek.Directory(
-                    directory.Replace("/", @"\"),
-                    System.IO.Directory.GetFiles(directory)
-                        .Select(f => new Soulseek.File(1, Path.GetFileName(f), new FileInfo(f).Length, Path.GetExtension(f))))
+                MakeDirectory(directory)
             };
 
-            return Task.FromResult(list);
+            foreach (var subDirectory in System.IO.Directory.GetDirectories(directory))
+            {
+                list.Add(MakeDirectory(subDirectory));
+            }
+
+            return Task.FromResult(list.AsEnumerable());
         }
 
         private string UploadQueueMode = "FIFO";

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -481,14 +481,17 @@ namespace WebAPI
         /// <param name="token">The unique token for the request, supplied by the requesting user.</param>
         /// <param name="directory">The requested directory.</param>
         /// <returns>A Task resolving an instance of Soulseek.Directory containing the contents of the requested directory.</returns>
-        private Task<Soulseek.Directory> DirectoryContentsResponseResolver(string username, IPEndPoint endpoint, int token, string directory)
+        private Task<IEnumerable<Soulseek.Directory>> DirectoryContentsResponseResolver(string username, IPEndPoint endpoint, int token, string directory)
         {
-            var result = new Soulseek.Directory(
-                directory.Replace("/", @"\"),
-                System.IO.Directory.GetFiles(directory)
-                    .Select(f => new Soulseek.File(1, Path.GetFileName(f), new FileInfo(f).Length, Path.GetExtension(f))));
+            IEnumerable<Soulseek.Directory> list = new List<Soulseek.Directory>()
+            {
+                new Soulseek.Directory(
+                    directory.Replace("/", @"\"),
+                    System.IO.Directory.GetFiles(directory)
+                        .Select(f => new Soulseek.File(1, Path.GetFileName(f), new FileInfo(f).Length, Path.GetExtension(f))))
+            };
 
-            return Task.FromResult(result);
+            return Task.FromResult(list);
         }
 
         private string UploadQueueMode = "FIFO";

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -851,7 +851,7 @@ namespace Soulseek
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
         /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        Task<Directory> GetDirectoryContentsAsync(string username, string directoryName, int? token = null, CancellationToken? cancellationToken = null);
+        Task<IReadOnlyCollection<Directory>> GetDirectoryContentsAsync(string username, string directoryName, int? token = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Asynchronously fetches the current place of the specified <paramref name="filename"/> in the queue of the

--- a/src/Messaging/Handlers/PeerMessageHandler.cs
+++ b/src/Messaging/Handlers/PeerMessageHandler.cs
@@ -18,6 +18,7 @@
 namespace Soulseek.Messaging.Handlers
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -210,7 +211,7 @@ namespace Soulseek.Messaging.Handlers
 
                     case MessageCode.Peer.FolderContentsRequest:
                         var folderContentsRequest = FolderContentsRequest.FromByteArray(message);
-                        Directory outgoingFolderContents = null;
+                        IEnumerable<Directory> outgoingFolderContents = null;
 
                         try
                         {
@@ -227,7 +228,7 @@ namespace Soulseek.Messaging.Handlers
 
                         if (outgoingFolderContents != null)
                         {
-                            var folderContentsResponseMessage = new FolderContentsResponse(folderContentsRequest.Token, outgoingFolderContents);
+                            var folderContentsResponseMessage = new FolderContentsResponse(folderContentsRequest.Token, folderContentsRequest.DirectoryName, outgoingFolderContents);
 
                             await connection.WriteAsync(folderContentsResponseMessage).ConfigureAwait(false);
                             Diagnostic.Info($"Folder contents for {folderContentsRequest.DirectoryName} sent to {connection.Username}");
@@ -237,7 +238,7 @@ namespace Soulseek.Messaging.Handlers
 
                     case MessageCode.Peer.FolderContentsResponse:
                         var folderContentsResponse = FolderContentsResponse.FromByteArray(message);
-                        SoulseekClient.Waiter.Complete(new WaitKey(MessageCode.Peer.FolderContentsResponse, connection.Username, folderContentsResponse.Token), folderContentsResponse.Directory);
+                        SoulseekClient.Waiter.Complete(new WaitKey(MessageCode.Peer.FolderContentsResponse, connection.Username, folderContentsResponse.Token), folderContentsResponse.Directories);
                         break;
 
                     case MessageCode.Peer.InfoResponse:

--- a/src/Messaging/Messages/Peer/FolderContentsResponse.cs
+++ b/src/Messaging/Messages/Peer/FolderContentsResponse.cs
@@ -17,6 +17,9 @@
 
 namespace Soulseek.Messaging.Messages
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     /// <summary>
     ///     The response to a peer folder contents request.
     /// </summary>
@@ -26,17 +29,32 @@ namespace Soulseek.Messaging.Messages
         ///     Initializes a new instance of the <see cref="FolderContentsResponse"/> class.
         /// </summary>
         /// <param name="token">The unique token for the request.</param>
-        /// <param name="directory">The directory contents.</param>
-        public FolderContentsResponse(int token, Directory directory)
+        /// <param name="directoryName">The name of the requested (root) directory.</param>
+        /// <param name="directories">The directory contents.</param>
+        public FolderContentsResponse(int token, string directoryName, IEnumerable<Directory> directories)
         {
             Token = token;
-            Directory = directory;
+
+            DirectoryName = directoryName;
+
+            Directories = directories.ToList().AsReadOnly();
+            DirectoryCount = Directories.Count;
         }
 
         /// <summary>
         ///     Gets the directory contents.
         /// </summary>
-        public Directory Directory { get; }
+        public IReadOnlyCollection<Directory> Directories { get; }
+
+        /// <summary>
+        ///     Gets the number of directories.
+        /// </summary>
+        public int DirectoryCount { get; }
+
+        /// <summary>
+        ///     Gets the name of the requested (root) directory.
+        /// </summary>
+        public string DirectoryName { get; }
 
         /// <summary>
         ///     Gets the token for the response.
@@ -61,12 +79,16 @@ namespace Soulseek.Messaging.Messages
             reader.Decompress();
 
             var token = reader.ReadInteger();
-            reader.ReadString(); // directory name, should always match that of the first directory
-            reader.ReadInteger(); // directory count, should always be 1
+            var rootDirectory = reader.ReadString(); // directory name, should always match that of the first directory
+            var directoryCount = reader.ReadInteger(); // directory count, should always be 1
+            var directoryList = new List<Directory>();
 
-            var directory = reader.ReadDirectory();
+            for (int i = 0; i < directoryCount; i++)
+            {
+                directoryList.Add(reader.ReadDirectory());
+            }
 
-            return new FolderContentsResponse(token, directory);
+            return new FolderContentsResponse(token, rootDirectory, directoryList);
         }
 
         /// <summary>
@@ -78,14 +100,12 @@ namespace Soulseek.Messaging.Messages
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.FolderContentsResponse)
                 .WriteInteger(Token)
-                .WriteString(Directory.Name)
-                .WriteInteger(1) // always one directory
-                .WriteString(Directory.Name)
-                .WriteInteger(Directory.FileCount);
+                .WriteString(DirectoryName)
+                .WriteInteger(DirectoryCount);
 
-            foreach (var file in Directory.Files)
+            foreach (var directory in Directories)
             {
-                builder.WriteFile(file);
+                builder.WriteDirectory(directory);
             }
 
             builder.Compress();

--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -18,6 +18,7 @@
 namespace Soulseek
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -86,7 +87,7 @@ namespace Soulseek
         ///     The delegate used to resolve the <see cref="BrowseResponse"/> for an incoming <see cref="BrowseRequest"/>.
         /// </param>
         /// <param name="directoryContentsResolver">
-        ///     The delegate used to resolve the <see cref="Directory"/> for an incoming <see cref="FolderContentsRequest"/>.
+        ///     The delegate used to resolve the list of <see cref="Directory"/> for an incoming <see cref="FolderContentsRequest"/>.
         /// </param>
         /// <param name="userInfoResolver">The delegate used to resolve the <see cref="UserInfo"/> for an incoming <see cref="UserInfoRequest"/>.</param>
         /// <param name="enqueueDownload">The delegate invoked upon an receipt of an incoming <see cref="QueueDownloadRequest"/>.</param>
@@ -127,7 +128,7 @@ namespace Soulseek
             Func<string, int, SearchQuery, Task<SearchResponse>> searchResponseResolver = null,
             ISearchResponseCache searchResponseCache = null,
             Func<string, IPEndPoint, Task<BrowseResponse>> browseResponseResolver = null,
-            Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResolver = null,
+            Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>> directoryContentsResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownload = null,
             Func<string, IPEndPoint, string, Task<int?>> placeInQueueResolver = null)
@@ -240,7 +241,7 @@ namespace Soulseek
         ///     Gets the delegate used to resolve the response for an incoming directory contents request. (Default = a response
         ///     with an empty directory).
         /// </summary>
-        public Func<string, IPEndPoint, int, string, Task<Directory>> DirectoryContentsResolver { get; }
+        public Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>> DirectoryContentsResolver { get; }
 
         /// <summary>
         ///     Gets the number of allowed distributed children. (Default = 100).
@@ -453,7 +454,7 @@ namespace Soulseek
         ///     The delegate used to resolve the <see cref="BrowseResponse"/> for an incoming <see cref="BrowseRequest"/>.
         /// </param>
         /// <param name="directoryContentsResolver">
-        ///     The delegate used to resolve the <see cref="Directory"/> for an incoming <see cref="FolderContentsRequest"/>.
+        ///     The delegate used to resolve the list of <see cref="Directory"/> for an incoming <see cref="FolderContentsRequest"/>.
         /// </param>
         /// <param name="userInfoResolver">The delegate used to resolve the <see cref="UserInfo"/> for an incoming <see cref="UserInfoRequest"/>.</param>
         /// <param name="enqueueDownload">The delegate invoked upon an receipt of an incoming <see cref="QueueDownloadRequest"/>.</param>
@@ -483,7 +484,7 @@ namespace Soulseek
             Func<string, int, SearchQuery, Task<SearchResponse>> searchResponseResolver = null,
             ISearchResponseCache searchResponseCache = null,
             Func<string, IPEndPoint, Task<BrowseResponse>> browseResponseResolver = null,
-            Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResolver = null,
+            Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>> directoryContentsResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownload = null,
             Func<string, IPEndPoint, string, Task<int?>> placeInQueueResolver = null)

--- a/src/Options/SoulseekClientOptionsPatch.cs
+++ b/src/Options/SoulseekClientOptionsPatch.cs
@@ -18,6 +18,7 @@
 namespace Soulseek
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Threading.Tasks;
     using Soulseek.Messaging.Messages;
@@ -64,7 +65,7 @@ namespace Soulseek
         ///     The delegate used to resolve the <see cref="BrowseResponse"/> for an incoming <see cref="BrowseRequest"/>.
         /// </param>
         /// <param name="directoryContentsResolver">
-        ///     The delegate used to resolve the <see cref="Directory"/> for an incoming <see cref="FolderContentsRequest"/>.
+        ///     The delegate used to resolve the list of <see cref="Directory"/> for an incoming <see cref="FolderContentsRequest"/>.
         /// </param>
         /// <param name="userInfoResolver">The delegate used to resolve the <see cref="UserInfo"/> for an incoming <see cref="UserInfoRequest"/>.</param>
         /// <param name="enqueueDownload">The delegate invoked upon an receipt of an incoming <see cref="QueueDownloadRequest"/>.</param>
@@ -99,7 +100,7 @@ namespace Soulseek
             Func<string, int, SearchQuery, Task<SearchResponse>> searchResponseResolver = null,
             ISearchResponseCache searchResponseCache = null,
             Func<string, IPEndPoint, Task<BrowseResponse>> browseResponseResolver = null,
-            Func<string, IPEndPoint, int, string, Task<Directory>> directoryContentsResolver = null,
+            Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>> directoryContentsResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownload = null,
             Func<string, IPEndPoint, string, Task<int?>> placeInQueueResolver = null)
@@ -184,7 +185,7 @@ namespace Soulseek
         /// <summary>
         ///     Gets the delegate used to resolve the response for an incoming directory contents request.
         /// </summary>
-        public Func<string, IPEndPoint, int, string, Task<Directory>> DirectoryContentsResolver { get; }
+        public Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>> DirectoryContentsResolver { get; }
 
         /// <summary>
         ///     Gets the number of allowed distributed children.

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SoulseekClient.cs" company="JP Dillingham">
+// <copyright file="SoulseekClient.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -3399,7 +3399,7 @@ namespace Soulseek
                         finally
                         {
 #if NETSTANDARD2_0
-                        outputStream?.Dispose();
+                            outputStream?.Dispose();
 #else
                             await outputStream.DisposeAsync().ConfigureAwait(false);
 #endif
@@ -4426,7 +4426,7 @@ namespace Soulseek
                     if (options.DisposeInputStreamOnCompletion && inputStream != null)
                     {
 #if NETSTANDARD2_0
-                    inputStream.Dispose();
+                        inputStream.Dispose();
 #else
                         await inputStream.DisposeAsync().ConfigureAwait(false);
 #endif

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -1509,7 +1509,7 @@ namespace Soulseek
         /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
         /// <exception cref="UserOfflineException">Thrown when the specified user is offline.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        public Task<Directory> GetDirectoryContentsAsync(string username, string directoryName, int? token = null, CancellationToken? cancellationToken = null)
+        public Task<IReadOnlyCollection<Directory>> GetDirectoryContentsAsync(string username, string directoryName, int? token = null, CancellationToken? cancellationToken = null)
         {
             if (string.IsNullOrWhiteSpace(username))
             {
@@ -3454,12 +3454,12 @@ namespace Soulseek
             }
         }
 
-        private async Task<Directory> GetDirectoryContentsInternalAsync(string username, string directoryName, int token, CancellationToken cancellationToken)
+        private async Task<IReadOnlyCollection<Directory>> GetDirectoryContentsInternalAsync(string username, string directoryName, int token, CancellationToken cancellationToken)
         {
             try
             {
                 var waitKey = new WaitKey(MessageCode.Peer.FolderContentsResponse, username, token);
-                var contentsWait = Waiter.Wait<Directory>(waitKey, cancellationToken: cancellationToken);
+                var contentsWait = Waiter.Wait<IReadOnlyCollection<Directory>>(waitKey, cancellationToken: cancellationToken);
 
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
 

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -1,4 +1,4 @@
-// <copyright file="SoulseekClient.cs" company="JP Dillingham">
+﻿// <copyright file="SoulseekClient.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -3459,7 +3459,7 @@ namespace Soulseek
             try
             {
                 var waitKey = new WaitKey(MessageCode.Peer.FolderContentsResponse, username, token);
-                var contentsWait = Waiter.Wait<IReadOnlyCollection<Directory>>(waitKey, cancellationToken: cancellationToken);
+                var contentsWait = Waiter.Wait<IEnumerable<Directory>>(waitKey, cancellationToken: cancellationToken);
 
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
 
@@ -3468,7 +3468,7 @@ namespace Soulseek
 
                 var response = await contentsWait.ConfigureAwait(false);
 
-                return response;
+                return response.ToList().AsReadOnly();
             }
             catch (Exception ex) when (!(ex is UserOfflineException) && !(ex is OperationCanceledException) && !(ex is TimeoutException))
             {

--- a/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
@@ -18,6 +18,8 @@
 namespace Soulseek.Tests.Unit.Client
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -114,8 +116,8 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                Directory dir = null;
-                var ex = await Record.ExceptionAsync(async () => dir = await s.GetDirectoryContentsAsync(username, directory));
+                IEnumerable<Directory> dirs = null;
+                var ex = await Record.ExceptionAsync(async () => dirs = await s.GetDirectoryContentsAsync(username, directory));
 
                 Assert.NotNull(ex);
                 Assert.IsType<TimeoutException>(ex);
@@ -150,8 +152,8 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                Directory dir = null;
-                var ex = await Record.ExceptionAsync(async () => dir = await s.GetDirectoryContentsAsync(username, directory));
+                IEnumerable<Directory> dirs = null;
+                var ex = await Record.ExceptionAsync(async () => dirs = await s.GetDirectoryContentsAsync(username, directory));
 
                 Assert.NotNull(ex);
                 Assert.IsType<OperationCanceledException>(ex);
@@ -173,8 +175,8 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                Directory dir = null;
-                var ex = await Record.ExceptionAsync(async () => dir = await s.GetDirectoryContentsAsync(username, directory));
+                IEnumerable<Directory> dirs = null;
+                var ex = await Record.ExceptionAsync(async () => dirs = await s.GetDirectoryContentsAsync(username, directory));
 
                 Assert.NotNull(ex);
                 Assert.IsType<UserOfflineException>(ex);
@@ -209,8 +211,8 @@ namespace Soulseek.Tests.Unit.Client
             {
                 s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
 
-                Directory dir = null;
-                var ex = await Record.ExceptionAsync(async () => dir = await s.GetDirectoryContentsAsync(username, directory));
+                IEnumerable<Directory> dirs = null;
+                var ex = await Record.ExceptionAsync(async () => dirs = await s.GetDirectoryContentsAsync(username, directory));
 
                 Assert.NotNull(ex);
                 Assert.IsType<SoulseekClientException>(ex);
@@ -222,10 +224,10 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "GetDirectoryContentsAsync returns expected Directory"), AutoData]
         public async Task GetDirectoryContentsAsync_Returns_Expected_Directory(string username, string directory)
         {
-            var result = new Directory(directory);
+            var result = new List<Directory>() { new Directory(directory) }.AsEnumerable();
 
             var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<Directory>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+            waiter.Setup(m => m.Wait<IEnumerable<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(result));
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
@@ -254,10 +256,10 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "GetDirectoryContentsAsync uses given token"), AutoData]
         public async Task GetDirectoryContentsAsync_Uses_Given_Token(string username, string directory, int token)
         {
-            var result = new Directory(directory);
+            var result = new List<Directory>() { new Directory(directory) }.AsEnumerable();
 
             var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<Directory>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+            waiter.Setup(m => m.Wait<IEnumerable<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(result));
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
@@ -293,10 +295,10 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "GetDirectoryContentsAsync uses given CancellationToken"), AutoData]
         public async Task GetDirectoryContentsAsync_Uses_Given_CancellationToken(string username, string directory, CancellationToken cancellationToken)
         {
-            var result = new Directory(directory);
+            var result = new List<Directory>() { new Directory(directory) }.AsEnumerable();
 
             var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<Directory>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+            waiter.Setup(m => m.Wait<IEnumerable<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(result));
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -18,6 +18,8 @@
 namespace Soulseek.Tests.Unit.Client
 {
     using System;
+    using System.Collections.Generic;
+
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -504,7 +506,7 @@ namespace Soulseek.Tests.Unit.Client
 
             var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
             var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
-            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>>((s, i, ii, ss) => Task.FromResult<IEnumerable<Directory>>(null));
             var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
             var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
             var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -302,11 +302,11 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         {
             var (handler, mocks) = GetFixture(username, endpoint);
 
-            var msg = new FolderContentsResponse(token, new Directory(dirname)).ToByteArray();
+            var msg = new FolderContentsResponse(token, dirname, new List<Directory>() { new Directory(dirname) }).ToByteArray();
 
             handler.HandleMessageRead(mocks.PeerConnection.Object, msg);
 
-            mocks.Waiter.Verify(m => m.Complete(new WaitKey(MessageCode.Peer.FolderContentsResponse, username, token), It.IsAny<Directory>()), Times.Once);
+            mocks.Waiter.Verify(m => m.Complete(new WaitKey(MessageCode.Peer.FolderContentsResponse, username, token), It.IsAny<IEnumerable<Directory>>()), Times.Once);
         }
 
         [Trait("Category", "Message")]
@@ -675,8 +675,8 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             var dir = new Directory(dirname, files);
 
-            var response = new FolderContentsResponse(token, dir);
-            var options = new SoulseekClientOptions(directoryContentsResolver: (u, i, t, d) => Task.FromResult(dir));
+            var response = new FolderContentsResponse(token, dirname, new List<Directory>() { dir });
+            var options = new SoulseekClientOptions(directoryContentsResolver: (u, i, t, d) => Task.FromResult(new List<Directory>() { dir }.AsEnumerable()));
 
             var (handler, mocks) = GetFixture(options: options);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
@@ -35,10 +35,12 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         [Theory(DisplayName = "Instantiates with given data"), AutoData]
         public void Instantiates_With_Given_Data(int token, Directory dir)
         {
-            var a = new FolderContentsResponse(token, dir);
+            var dirList = new List<Directory>() { dir };
+            var a = new FolderContentsResponse(token, directoryName: dir.Name, directories: dirList);
 
             Assert.Equal(token, a.Token);
-            Assert.Equal(dir, a.Directory);
+            Assert.Equal(dir.Name, a.DirectoryName);
+            Assert.Equal(dirList, a.Directories);
         }
 
         [Trait("Category", "Parse")]
@@ -94,8 +96,8 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             Assert.Null(ex);
             Assert.Equal(token, r.Token);
-            Assert.Equal(dirname, r.Directory.Name);
-            Assert.Equal(0, r.Directory.FileCount);
+            Assert.Equal(dirname, r.Directories.First().Name);
+            Assert.Equal(0, r.Directories.First().FileCount);
         }
 
         [Trait("Category", "Parse")]
@@ -145,11 +147,11 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             Assert.Null(ex);
 
-            Assert.Equal(dirname, r.Directory.Name);
-            Assert.Equal(1, r.Directory.FileCount);
-            Assert.Single(r.Directory.Files);
+            Assert.Equal(dirname, r.Directories.First().Name);
+            Assert.Equal(1, r.Directories.First().FileCount);
+            Assert.Single(r.Directories.First().Files);
 
-            var f = r.Directory.Files.ToList();
+            var f = r.Directories.First().Files.ToList();
 
             Assert.Equal(0x0, f[0].Code);
             Assert.Equal("foo", f[0].Filename);
@@ -184,7 +186,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             Assert.Null(ex);
 
-            var d = r.Directory;
+            var d = r.Directories.First();
 
             Assert.Equal(dir.Name, d.Name);
             Assert.Equal(dir.FileCount, d.FileCount);
@@ -223,7 +225,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             var dir = new Directory(dirname, list);
 
-            var r = new FolderContentsResponse(token, dir);
+            var r = new FolderContentsResponse(token, dirname, new List<Directory>() { dir });
 
             var bytes = r.ToByteArray();
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
@@ -166,15 +166,17 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         [Theory(DisplayName = "Parse handles a complete response"), AutoData]
         public void Parse_Handles_A_Complete_Response(int token)
         {
-            var dir = GetRandomDirectory(2);
+            var dir1 = GetRandomDirectory(2);
+            var dir2 = GetRandomDirectory(1);
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.FolderContentsResponse)
                 .WriteInteger(token)
-                .WriteString(dir.Name)
-                .WriteInteger(1);
+                .WriteString(dir1.Name) // name of first directory must go first
+                .WriteInteger(2); // 2 directories
 
-            BuildDirectory(builder, dir);
+            BuildDirectory(builder, dir1);
+            BuildDirectory(builder, dir2);
 
             var msg = builder
                 .Compress()
@@ -186,26 +188,52 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             Assert.Null(ex);
 
-            var d = r.Directories.First();
+            var d1 = r.Directories.First();
 
-            Assert.Equal(dir.Name, d.Name);
-            Assert.Equal(dir.FileCount, d.FileCount);
+            Assert.Equal(dir1.Name, d1.Name);
+            Assert.Equal(dir1.FileCount, d1.FileCount);
 
-            var files = d.Files.ToList();
-            var msgFiles = d.Files.ToList();
+            var files1 = d1.Files.ToList();
+            var msgFiles1 = d1.Files.ToList();
 
-            for (int j = 0; j < d.FileCount; j++)
+            for (int j = 0; j < d1.FileCount; j++)
             {
-                Assert.Equal(files[j].Code, msgFiles[j].Code);
-                Assert.Equal(files[j].Filename, msgFiles[j].Filename);
-                Assert.Equal(files[j].Size, msgFiles[j].Size);
-                Assert.Equal(files[j].Extension, msgFiles[j].Extension);
-                Assert.Equal(files[j].AttributeCount, msgFiles[j].AttributeCount);
+                Assert.Equal(files1[j].Code, msgFiles1[j].Code);
+                Assert.Equal(files1[j].Filename, msgFiles1[j].Filename);
+                Assert.Equal(files1[j].Size, msgFiles1[j].Size);
+                Assert.Equal(files1[j].Extension, msgFiles1[j].Extension);
+                Assert.Equal(files1[j].AttributeCount, msgFiles1[j].AttributeCount);
 
-                var attr = files[j].Attributes.ToList();
-                var msgAttr = files[j].Attributes.ToList();
+                var attr = files1[j].Attributes.ToList();
+                var msgAttr = files1[j].Attributes.ToList();
 
-                for (int k = 0; k < msgFiles[j].AttributeCount; k++)
+                for (int k = 0; k < msgFiles1[j].AttributeCount; k++)
+                {
+                    Assert.Equal(attr[k].Type, msgAttr[k].Type);
+                    Assert.Equal(attr[k].Value, msgAttr[k].Value);
+                }
+            }
+
+            var d2 = r.Directories.Last();
+
+            Assert.Equal(dir2.Name, d2.Name);
+            Assert.Equal(dir2.FileCount, d2.FileCount);
+
+            var files2 = d2.Files.ToList();
+            var msgFiles2 = d2.Files.ToList();
+
+            for (int j = 0; j < d2.FileCount; j++)
+            {
+                Assert.Equal(files2[j].Code, msgFiles2[j].Code);
+                Assert.Equal(files2[j].Filename, msgFiles2[j].Filename);
+                Assert.Equal(files2[j].Size, msgFiles2[j].Size);
+                Assert.Equal(files2[j].Extension, msgFiles2[j].Extension);
+                Assert.Equal(files2[j].AttributeCount, msgFiles2[j].AttributeCount);
+
+                var attr = files2[j].Attributes.ToList();
+                var msgAttr = files2[j].Attributes.ToList();
+
+                for (int k = 0; k < msgFiles2[j].AttributeCount; k++)
                 {
                     Assert.Equal(attr[k].Type, msgAttr[k].Type);
                     Assert.Equal(attr[k].Value, msgAttr[k].Value);
@@ -215,17 +243,24 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
         [Trait("Category", "ToByteArray")]
         [Theory(DisplayName = "ToByteArray returns the expected data"), AutoData]
-        public void ToByteArray_Returns_Expected_Data(int token, string dirname)
+        public void ToByteArray_Returns_Expected_Data(int token, string dirname1, string dirname2)
         {
-            var list = new List<File>()
+            var list1 = new List<File>()
             {
                 new File(1, "1", 1, ".1", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 1) }),
                 new File(2, "2", 2, ".2", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 2) }),
             };
 
-            var dir = new Directory(dirname, list);
+            var list2 = new List<File>()
+            {
+                new File(3, "3", 3, ".3", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitDepth, 3) }),
+                new File(4, "4", 4, ".4", new List<FileAttribute>() { new FileAttribute(FileAttributeType.BitRate, 4) }),
+            };
 
-            var r = new FolderContentsResponse(token, dirname, new List<Directory>() { dir });
+            var dir1 = new Directory(dirname1, list1); // "root" directory
+            var dir2 = new Directory(dirname1 + "/" + dirname2, list2); // subdirectory
+
+            var r = new FolderContentsResponse(token, dirname1, new List<Directory>() { dir1, dir2 });
 
             var bytes = r.ToByteArray();
 
@@ -235,10 +270,10 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(MessageCode.Peer.FolderContentsResponse, m.ReadCode());
             Assert.Equal(token, m.ReadInteger());
 
-            Assert.Equal(dirname, m.ReadString());
-            Assert.Equal(1, m.ReadInteger());
-            Assert.Equal(dirname, m.ReadString());
-            Assert.Equal(dir.FileCount, m.ReadInteger());
+            Assert.Equal(dirname1, m.ReadString()); // "root" directory
+            Assert.Equal(2, m.ReadInteger()); // count of directories
+            Assert.Equal(dirname1, m.ReadString()); // name of first directory, which is the "root"
+            Assert.Equal(dir1.FileCount, m.ReadInteger());
 
             // file 1
             Assert.Equal(1, m.ReadByte()); // code
@@ -249,6 +284,39 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
             Assert.Equal(FileAttributeType.BitDepth, (FileAttributeType)m.ReadInteger());
             Assert.Equal(1, m.ReadInteger());
+
+            // file 2
+            Assert.Equal(2, m.ReadByte()); // code
+            Assert.Equal("2", m.ReadString()); // name
+            Assert.Equal(2, m.ReadLong()); // length
+            Assert.Equal(".2", m.ReadString()); // ext
+            Assert.Equal(1, m.ReadInteger()); // attribute count
+
+            Assert.Equal(FileAttributeType.BitRate, (FileAttributeType)m.ReadInteger());
+            Assert.Equal(2, m.ReadInteger());
+
+            Assert.Equal(dirname1 + "/" + dirname2, m.ReadString()); // name of second directory, which is subdirectory
+            Assert.Equal(dir2.FileCount, m.ReadInteger());
+
+            // file 3
+            Assert.Equal(3, m.ReadByte()); // code
+            Assert.Equal("3", m.ReadString()); // name
+            Assert.Equal(3, m.ReadLong()); // length
+            Assert.Equal(".3", m.ReadString()); // ext
+            Assert.Equal(1, m.ReadInteger()); // attribute count
+
+            Assert.Equal(FileAttributeType.BitDepth, (FileAttributeType)m.ReadInteger());
+            Assert.Equal(3, m.ReadInteger());
+
+            // file 4
+            Assert.Equal(4, m.ReadByte()); // code
+            Assert.Equal("4", m.ReadString()); // name
+            Assert.Equal(4, m.ReadLong()); // length
+            Assert.Equal(".4", m.ReadString()); // ext
+            Assert.Equal(1, m.ReadInteger()); // attribute count
+
+            Assert.Equal(FileAttributeType.BitRate, (FileAttributeType)m.ReadInteger());
+            Assert.Equal(4, m.ReadInteger());
         }
 
         private MessageBuilder BuildDirectory(MessageBuilder builder, Directory dir)

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
@@ -18,6 +18,7 @@
 namespace Soulseek.Tests.Unit.Options
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
@@ -51,7 +52,7 @@ namespace Soulseek.Tests.Unit.Options
 
             var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
             var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
-            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>>((s, i, ii, ss) => Task.FromResult<IEnumerable<Directory>>(null));
             var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
             var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
             var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
@@ -18,6 +18,8 @@
 namespace Soulseek.Tests.Unit.Options
 {
     using System;
+    using System.Collections.Generic;
+
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -60,7 +62,7 @@ namespace Soulseek.Tests.Unit.Options
 
             var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
             var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
-            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>>((s, i, ii, ss) => Task.FromResult<IEnumerable<Directory>>(null));
             var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
             var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
             var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
@@ -358,7 +360,7 @@ namespace Soulseek.Tests.Unit.Options
 
             var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
             var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
-            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>>((s, i, ii, ss) => Task.FromResult<IEnumerable<Directory>>(null));
             var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
             var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
             var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));
@@ -467,7 +469,7 @@ namespace Soulseek.Tests.Unit.Options
 
             var searchResponseResolver = new Func<string, int, SearchQuery, Task<SearchResponse>>((s, i, q) => Task.FromResult<SearchResponse>(null));
             var browseResponseResolver = new Func<string, IPEndPoint, Task<BrowseResponse>>((s, i) => Task.FromResult<BrowseResponse>(null));
-            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<Directory>>((s, i, ii, ss) => Task.FromResult<Directory>(null));
+            var directoryContentsResponseResolver = new Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>>((s, i, ii, ss) => Task.FromResult<IEnumerable<Directory>>(null));
             var userInfoResponseResolver = new Func<string, IPEndPoint, Task<UserInfo>>((s, i) => Task.FromResult<UserInfo>(null));
             var enqueueDownloadAction = new Func<string, IPEndPoint, string, Task>((s, i, ss) => Task.CompletedTask);
             var placeInQueueResponseResolver = new Func<string, IPEndPoint, string, Task<int?>>((s, i, ss) => Task.FromResult<int?>(0));


### PR DESCRIPTION
This is a breaking change, specifically:

* `GetDirectoryContentsAsync()` now returns `IReadOnlyCollection<Directory>` instead of a singular `Directory`
* `DirectoryContentsResolver` in `SoulseekClientOptions` (and the patch counterpart) now expects a return type of `IEnumerable<Directory>` instead of a singular `Directory`

## Testing

* Soulseek NS, when choosing to download the directory, correctly downloads everything in the requested directory and everything in each subdirectory
* Soulseek Qt ignores subdirectories
* Nicotine+ ignores subdirectories
* slskd depends on this lib, so testing is somewhat irrelevant

Closes #822 