### PR TITLE
Start search timeout timer on transition to InProgress

### DIFF
--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -413,6 +413,11 @@ namespace WebAPI
                 // Console.WriteLine($"[SEARCH REQUEST] {args.Username} requesting '{args.Query}'");
             };
 
+            Client.SearchStateChanged += (e, args) =>
+            {
+                Console.WriteLine($"[SEARCH STATE CHANGED] {args.Search.SearchText} {args.PreviousState} => {args.Search.State}");
+            };
+
             Client.SearchResponseDelivered += (e, args) =>
             {
                 Console.WriteLine($"[SEARCH RESPONSE DELIVERY] {args.SearchResponse.FileCount + args.SearchResponse.LockedFileCount} files to {args.Username} for query '{args.Query}'");

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -87,9 +87,9 @@ namespace Soulseek
         public string SearchText { get; }
 
         /// <summary>
-        ///     Gets or sets the state of the search.
+        ///     Gets the state of the search.
         /// </summary>
-        public SearchStates State { get; set; } = SearchStates.None;
+        public SearchStates State { get; private set; } = SearchStates.None;
 
         /// <summary>
         ///     Gets the unique identifier for the search.
@@ -142,6 +142,22 @@ namespace Soulseek
                 }
 
                 Disposed = true;
+            }
+        }
+
+        /// <summary>
+        ///     Sets the Search <see cref="State"/>.
+        /// </summary>
+        /// <param name="state">The state to which the Search is to be set.</param>
+        public void SetState(SearchStates state)
+        {
+            var previousState = State;
+            State = state;
+
+            // ensure the timeout timer is reset only one time, immediately after the search request is sent to the server.
+            if (previousState != SearchStates.InProgress && State == SearchStates.InProgress)
+            {
+                SearchTimeoutTimer.Reset();
             }
         }
 

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -53,7 +53,6 @@ namespace Soulseek
             };
 
             SearchTimeoutTimer.Elapsed += (sender, e) => { Complete(SearchStates.TimedOut); };
-            SearchTimeoutTimer.Reset();
         }
 
         /// <summary>

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3894,7 +3894,7 @@ namespace Soulseek
 
             void UpdateState(SearchStates state)
             {
-                search.State = state;
+                search.SetState(state);
                 var e = new SearchStateChangedEventArgs(previousState: lastState, search: new Search(search));
                 lastState = state;
                 options.StateChanged?.Invoke((e.PreviousState, e.Search));

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3903,6 +3903,9 @@ namespace Soulseek
 
             try
             {
+                Searches.TryAdd(search.Token, search);
+                UpdateState(SearchStates.Requested);
+
                 Diagnostic.Debug($"Attempting to acquire search semaphore for search '{query.SearchText}' ({SearchSemaphore.CurrentCount} left)");
                 UpdateState(SearchStates.Queued);
 
@@ -3929,9 +3932,6 @@ namespace Soulseek
                         options.ResponseReceived?.Invoke((e.Search, e.Response));
                         SearchResponseReceived?.Invoke(this, e);
                     };
-
-                    Searches.TryAdd(search.Token, search);
-                    UpdateState(SearchStates.Requested);
 
                     await ServerConnection.WriteAsync(message, cancellationToken).ConfigureAwait(false);
                     UpdateState(SearchStates.InProgress);

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3906,7 +3906,7 @@ namespace Soulseek
                 Searches.TryAdd(search.Token, search);
                 UpdateState(SearchStates.Requested);
 
-                Diagnostic.Debug($"Attempting to acquire search semaphore for search '{query.SearchText}' ({SearchSemaphore.CurrentCount} left)");
+                Diagnostic.Debug($"Attempting to acquire search semaphore for search '{query.SearchText}' ({SearchSemaphore.CurrentCount} available)");
                 UpdateState(SearchStates.Queued);
 
                 // obtain a semaphore, or wait until one becomes available. this is done as a protective measure
@@ -3946,7 +3946,7 @@ namespace Soulseek
                 finally
                 {
                     SearchSemaphore.Release(releaseCount: 1);
-                    Diagnostic.Debug($"Released search semaphore for search '{query.SearchText}'");
+                    Diagnostic.Debug($"Released search semaphore for search '{query.SearchText}' ({SearchSemaphore.CurrentCount} available)");
                 }
             }
             catch (OperationCanceledException)

--- a/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/SearchAsyncTests.cs
@@ -491,11 +491,10 @@ namespace Soulseek.Tests.Unit.Client
         {
             var options = new SearchOptions(searchTimeout: 1000, fileLimit: 1);
 
-            using (var search = new SearchInternal(searchText, token, options)
+            using (var search = new SearchInternal(searchText, token, options))
             {
-                State = SearchStates.InProgress,
-            })
-            {
+                search.SetState(SearchStates.InProgress);
+
                 var conn = new Mock<IMessageConnection>();
                 conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                     .Returns(Task.CompletedTask);
@@ -643,11 +642,10 @@ namespace Soulseek.Tests.Unit.Client
             var fired = false;
             var options = new SearchOptions(searchTimeout: 1000, fileLimit: 1, stateChanged: (e) => fired = true);
 
-            using (var search = new SearchInternal(searchText, token, options)
+            using (var search = new SearchInternal(searchText, token, options))
             {
-                State = SearchStates.InProgress,
-            })
-            {
+                search.SetState(SearchStates.InProgress);
+
                 var conn = new Mock<IMessageConnection>();
                 conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                     .Returns(Task.CompletedTask);
@@ -672,11 +670,10 @@ namespace Soulseek.Tests.Unit.Client
             var fired = false;
             var options = new SearchOptions(searchTimeout: 1000, fileLimit: 1);
 
-            using (var search = new SearchInternal(searchText, token, options)
+            using (var search = new SearchInternal(searchText, token, options))
             {
-                State = SearchStates.InProgress,
-            })
-            {
+                search.SetState(SearchStates.InProgress);
+
                 var conn = new Mock<IMessageConnection>();
                 conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), null))
                     .Returns(Task.CompletedTask);

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -439,10 +439,10 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             using (var search = new SearchInternal("foo", token)
             {
-                State = SearchStates.InProgress,
                 ResponseReceived = (r) => responses.Add(r),
             })
             {
+                search.SetState(SearchStates.InProgress);
                 mocks.Searches.TryAdd(token, search);
 
                 handler.HandleMessageRead(mocks.PeerConnection.Object, msg);

--- a/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
@@ -550,7 +550,43 @@ namespace Soulseek.Tests.Unit
             }
         }
 
-        private List<File> DuplicateFile(File file, int count)
+        [Trait("Category", "Timer")]
+        [Fact(DisplayName = "Timer is disabled initially")]
+        public void Timer_Disabled_Initially()
+        {
+            using (var s = new SearchInternal("foo", 1))
+            {
+                var timer = s.GetProperty<System.Timers.Timer>("SearchTimeoutTimer");
+
+                Assert.False(timer.Enabled);
+            }
+        }
+
+        [Trait("Category", "Timer")]
+        [Fact(DisplayName = "Timer starts on transition to InProgress")]
+        public void Timer_Starts_On_InProgress_Transition()
+        {
+            using (var s = new SearchInternal("foo", 1))
+            {
+                var timer = s.GetProperty<System.Timers.Timer>("SearchTimeoutTimer");
+
+                Assert.False(timer.Enabled);
+
+                s.SetState(SearchStates.Requested);
+
+                Assert.False(timer.Enabled);
+
+                s.SetState(SearchStates.Queued);
+
+                Assert.False(timer.Enabled);
+
+                s.SetState(SearchStates.InProgress);
+
+                Assert.True(timer.Enabled);
+            }
+        }
+
+        private static List<File> DuplicateFile(File file, int count)
         {
             var list = new List<File>();
 

--- a/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
@@ -153,10 +153,8 @@ namespace Soulseek.Tests.Unit
         [Fact(DisplayName = "TryAddResponse ignores response when search is not in progress")]
         public void TryAddResponse_Ignores_Response_When_Search_Is_Not_In_Progress()
         {
-            var s = new SearchInternal("foo", 42)
-            {
-                State = SearchStates.Completed,
-            };
+            var s = new SearchInternal("foo", 42);
+            s.SetState(SearchStates.Completed);
 
             s.TryAddResponse(new SearchResponse("bar", 42, true, 1, 1, null));
 
@@ -172,10 +170,8 @@ namespace Soulseek.Tests.Unit
         [Fact(DisplayName = "TryAddResponse ignores response when token does not match")]
         public void TryAddResponse_Ignores_Response_When_Token_Does_Not_Match()
         {
-            var s = new SearchInternal("foo", 42)
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", 42);
+            s.SetState(SearchStates.InProgress);
 
             s.TryAddResponse(new SearchResponse("bar", 24, true, 1, 1, null));
 
@@ -191,10 +187,8 @@ namespace Soulseek.Tests.Unit
         [Fact(DisplayName = "TryAddResponse ignores response when response criteria not met")]
         public void TryAddResponse_Ignores_Response_When_Response_Criteria_Not_Met()
         {
-            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1));
+            s.SetState(SearchStates.InProgress);
 
             s.TryAddResponse(new SearchResponse("bar", 42, true, 1, 1, null));
 
@@ -212,10 +206,8 @@ namespace Soulseek.Tests.Unit
         {
             bool Filter(SearchResponse response) => false;
 
-            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 0, responseFilter: Filter))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 0, responseFilter: Filter));
+            s.SetState(SearchStates.InProgress);
 
             s.TryAddResponse(new SearchResponse("bar", 42, true, 1, 1, null));
 
@@ -233,10 +225,8 @@ namespace Soulseek.Tests.Unit
         {
             bool Filter(File file) => false;
 
-            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1, fileFilter: Filter))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1, fileFilter: Filter));
+            s.SetState(SearchStates.InProgress);
 
             s.TryAddResponse(new SearchResponse("bar", 42, true, 1, 1, new List<File>() { new File(1, "a", 1, "b") }));
 
@@ -254,10 +244,8 @@ namespace Soulseek.Tests.Unit
         {
             bool Filter(File file) => false;
 
-            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1, fileFilter: Filter))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", 42, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1, fileFilter: Filter));
+            s.SetState(SearchStates.InProgress);
 
             s.TryAddResponse(new SearchResponse("bar", 42, true, 1, 1, null, lockedFileList: new List<File>() { new File(1, "a", 1, "b") }));
 
@@ -273,10 +261,8 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "TryAddResponse adds response"), AutoData]
         public void TryAddResponse_Adds_Response(string username, int token, File file)
         {
-            var s = new SearchInternal("foo", token, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1));
+            s.SetState(SearchStates.InProgress);
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -315,10 +301,8 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "TryAddResponse swallows exceptions"), AutoData]
         public void TryAddResponse_Swallows_Exceptions(string username, int token, File file)
         {
-            var s = new SearchInternal("foo", token, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1));
+            s.SetState(SearchStates.InProgress);
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -355,10 +339,8 @@ namespace Soulseek.Tests.Unit
                     minimumResponseFileCount: 1,
                     fileFilter: (f) => false);
 
-            var s = new SearchInternal("foo", token, options)
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, options);
+            s.SetState(SearchStates.InProgress);
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -400,10 +382,8 @@ namespace Soulseek.Tests.Unit
                     minimumResponseFileCount: 1,
                     responseFilter: (r) => false);
 
-            var s = new SearchInternal("foo", token, options)
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, options);
+            s.SetState(SearchStates.InProgress);
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -445,10 +425,8 @@ namespace Soulseek.Tests.Unit
                     minimumResponseFileCount: 1,
                     fileLimit: 1);
 
-            var s = new SearchInternal("foo", token, options)
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, options);
+            s.SetState(SearchStates.InProgress);
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -487,10 +465,8 @@ namespace Soulseek.Tests.Unit
                     responseLimit: 1,
                     fileLimit: 10000000);
 
-            var s = new SearchInternal("foo", token, options)
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, options);
+            s.SetState(SearchStates.InProgress);
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Peer.SearchResponse)
@@ -531,10 +507,8 @@ namespace Soulseek.Tests.Unit
         {
             SearchResponse addResponse = null;
 
-            var s = new SearchInternal("foo", token, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1))
-            {
-                State = SearchStates.InProgress,
-            };
+            var s = new SearchInternal("foo", token, new SearchOptions(filterResponses: true, minimumResponseFileCount: 1));
+            s.SetState(SearchStates.InProgress);
 
             s.ResponseReceived += (response) => addResponse = response;
 


### PR DESCRIPTION
While testing the new semaphore behavior I discovered that enqueued searches were timing out immediately after becoming unblocked.  This is because the timer used to determine when a search had timed out was starting when `SearchInternal` was instantiated.  Previously a search would transition into `InProgress` almost immediately after being created, and that's no longer the case consistently.

This PR leaves this timer disabled on instantiation and only starts it when the state transitions into `InProgress`.

To accomplish this I made the `State` setter private and added a `SetState` method to capture the new behavior.  I also moved the `Requested` state transition up so that it is set prior to `Queued`, an oversight from the initial implementation.