### PR TITLE
Fix RuntimeBinderException when calling GetDirectoryContentsAsync()

### DIFF
--- a/src/Common/Waiter.cs
+++ b/src/Common/Waiter.cs
@@ -22,6 +22,7 @@ namespace Soulseek
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CSharp.RuntimeBinder;
 
     /// <summary>
     ///     Enables await-able server messages.
@@ -231,51 +232,58 @@ namespace Soulseek
 
         private void Disposition(WaitKey key, Action<PendingWait> action)
         {
-            if (Waits.TryGetValue(key, out var queue) && queue.TryDequeue(out var wait))
+            try
             {
-                action(wait);
-                wait.Dispose();
-
-                if (Locks.TryGetValue(key, out var recordLock))
+                if (Waits.TryGetValue(key, out var queue) && queue.TryDequeue(out var wait))
                 {
-                    // enter a read lock first; TryPeek and TryDequeue are atomic so there's no risky operation until later.
-                    recordLock.EnterUpgradeableReadLock();
+                    action(wait);
+                    wait.Dispose();
 
-                    try
+                    if (Locks.TryGetValue(key, out var recordLock))
                     {
-                        // clean up entries in the Waits and Locks dictionaries if the corresponding ConcurrentQueue is empty.
-                        // this is tricky, because we don't want to remove a record if another thread is in the process of
-                        // enqueueing a new wait.
-                        if (queue.IsEmpty)
-                        {
-                            // enter the write lock to prevent Wait() (which obtains a read lock) from enqueing any more waits
-                            // before we can delete the dictionary record. it's ok and expected that Wait() might add this record
-                            // back to the dictionary as soon as this unblocks; we're preventing new waits from being discarded if
-                            // they are added by another thread just prior to the TryRemove() operation below.
-                            recordLock.EnterWriteLock();
+                        // enter a read lock first; TryPeek and TryDequeue are atomic so there's no risky operation until later.
+                        recordLock.EnterUpgradeableReadLock();
 
-                            try
+                        try
+                        {
+                            // clean up entries in the Waits and Locks dictionaries if the corresponding ConcurrentQueue is empty.
+                            // this is tricky, because we don't want to remove a record if another thread is in the process of
+                            // enqueueing a new wait.
+                            if (queue.IsEmpty)
                             {
-                                // check the queue again to ensure Wait() didn't enqueue anything between the last check and when
-                                // we entered the write lock. this is guarateed to be safe since we now have exclusive access to
-                                // the record and it should be impossible to remove a record containing a non-empty queue
-                                if (queue.IsEmpty)
+                                // enter the write lock to prevent Wait() (which obtains a read lock) from enqueing any more waits
+                                // before we can delete the dictionary record. it's ok and expected that Wait() might add this record
+                                // back to the dictionary as soon as this unblocks; we're preventing new waits from being discarded if
+                                // they are added by another thread just prior to the TryRemove() operation below.
+                                recordLock.EnterWriteLock();
+
+                                try
                                 {
-                                    Waits.TryRemove(key, out _);
-                                    Locks.TryRemove(key, out _);
+                                    // check the queue again to ensure Wait() didn't enqueue anything between the last check and when
+                                    // we entered the write lock. this is guarateed to be safe since we now have exclusive access to
+                                    // the record and it should be impossible to remove a record containing a non-empty queue
+                                    if (queue.IsEmpty)
+                                    {
+                                        Waits.TryRemove(key, out _);
+                                        Locks.TryRemove(key, out _);
+                                    }
+                                }
+                                finally
+                                {
+                                    recordLock.ExitWriteLock();
                                 }
                             }
-                            finally
-                            {
-                                recordLock.ExitWriteLock();
-                            }
+                        }
+                        finally
+                        {
+                            recordLock.ExitUpgradeableReadLock();
                         }
                     }
-                    finally
-                    {
-                        recordLock.ExitUpgradeableReadLock();
-                    }
                 }
+            }
+            catch (RuntimeBinderException ex)
+            {
+                throw new SoulseekClientException($"Failed to bind Wait Types for key {key}; this is likely a mismatch in the Types specified in the Wait() and the Complete(), which needs investigation. Please file a GitHub issue https://github.com/jpdillingham/Soulseek.NET. Exception message: {ex.Message}", ex);
             }
         }
 

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>7.0.2</Version>
+    <Version>7.0.3</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3459,7 +3459,7 @@ namespace Soulseek
             try
             {
                 var waitKey = new WaitKey(MessageCode.Peer.FolderContentsResponse, username, token);
-                var contentsWait = Waiter.Wait<IEnumerable<Directory>>(waitKey, cancellationToken: cancellationToken);
+                var contentsWait = Waiter.Wait<IReadOnlyCollection<Directory>>(waitKey, cancellationToken: cancellationToken);
 
                 var endpoint = await GetUserEndPointAsync(username, cancellationToken).ConfigureAwait(false);
 

--- a/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/GetDirectoryContentsAsyncTests.cs
@@ -19,7 +19,6 @@ namespace Soulseek.Tests.Unit.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -224,10 +223,10 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "GetDirectoryContentsAsync returns expected Directory"), AutoData]
         public async Task GetDirectoryContentsAsync_Returns_Expected_Directory(string username, string directory)
         {
-            var result = new List<Directory>() { new Directory(directory) }.AsEnumerable();
+            IReadOnlyCollection<Directory> result = new List<Directory>() { new Directory(directory) }.AsReadOnly();
 
             var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<IEnumerable<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+            waiter.Setup(m => m.Wait<IReadOnlyCollection<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(result));
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
@@ -256,10 +255,10 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "GetDirectoryContentsAsync uses given token"), AutoData]
         public async Task GetDirectoryContentsAsync_Uses_Given_Token(string username, string directory, int token)
         {
-            var result = new List<Directory>() { new Directory(directory) }.AsEnumerable();
+            IReadOnlyCollection<Directory> result = new List<Directory>() { new Directory(directory) }.AsReadOnly();
 
             var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<IEnumerable<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+            waiter.Setup(m => m.Wait<IReadOnlyCollection<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(result));
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));
@@ -295,10 +294,10 @@ namespace Soulseek.Tests.Unit.Client
         [Theory(DisplayName = "GetDirectoryContentsAsync uses given CancellationToken"), AutoData]
         public async Task GetDirectoryContentsAsync_Uses_Given_CancellationToken(string username, string directory, CancellationToken cancellationToken)
         {
-            var result = new List<Directory>() { new Directory(directory) }.AsEnumerable();
+            IReadOnlyCollection<Directory> result = new List<Directory>() { new Directory(directory) }.AsReadOnly();
 
             var waiter = new Mock<IWaiter>();
-            waiter.Setup(m => m.Wait<IEnumerable<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
+            waiter.Setup(m => m.Wait<IReadOnlyCollection<Directory>>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(result));
             waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new UserAddressResponse(username, IPAddress.Parse("127.0.0.1"), 1)));

--- a/tests/Soulseek.Tests.Unit/Common/WaiterTests.cs
+++ b/tests/Soulseek.Tests.Unit/Common/WaiterTests.cs
@@ -585,5 +585,25 @@ namespace Soulseek.Tests.Unit
 
             Assert.Null(ex);
         }
+
+        [Trait("Category", "Exception")]
+        [Fact(DisplayName = "Thorws SoulseekClientException given type mismatch")]
+        public void Throws_SoulseekClientException_Given_Type_Mismatch()
+        {
+            using (var waiter = new Waiter())
+            {
+                var key = new WaitKey(MessageCode.Server.Login);
+
+                // wait for a Guid
+                _ = waiter.Wait<Guid>(key);
+
+                // complete with an int
+                var ex = Record.Exception(() => waiter.Complete<int>(key, 42));
+
+                Assert.NotNull(ex);
+                Assert.IsType<SoulseekClientException>(ex);
+                Assert.Contains("mismatch", ex.Message);
+            }
+        }
     }
 }


### PR DESCRIPTION
The return type of GetDirectoryContentsAsync() was changed from `Directory` to `IReadOnlyCollection<Directory>` in #841, but the corresponding `Wait` type was incorrectly set to `IEnumerable<Directory>` which didn't agree with either the return type of this method, or the type of the `Directories` property on the `FolderContentsResponse` type.

This ultimately led to the `Wait` being set up to expect an `IEnumerable`, but being completed with an `IReadOnlyCollection`, producing the following Exception at runtime:

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Cannot convert type 'System.Threading.Tasks.TaskCompletionSource<System.Collections.Generic.IEnumerable<Soulseek.Directory>>' to 'System.Threading.Tasks.TaskCompletionSource<System.Collections.Generic.IReadOnlyCollection<Soulseek.Directory>>'
   at CallSite.Target(Closure, CallSite, Object)
   at Soulseek.Waiter.<>c__DisplayClass19_0`1.<Complete>b__0(PendingWait wait)
   at Soulseek.Waiter.Disposition(WaitKey key, Action`1 action)
   at Soulseek.Waiter.Complete[T](WaitKey key, T result)
   at Soulseek.Messaging.Handlers.PeerMessageHandler.HandleMessageRead(Object sender, Byte[] message)
```

This is unfortunately hard to guard against because classes are tested in isolation.  This would be a good reason to figure out some integration or e2e tests, or simply try and involve more than one class in unit tests.