### PR TITLE
Add Trace diagnostic level, log string encoding fallbacks as Trace instead of Debug

### DIFF
--- a/src/Diagnostics/DiagnosticFactory.cs
+++ b/src/Diagnostics/DiagnosticFactory.cs
@@ -39,6 +39,25 @@ namespace Soulseek.Diagnostics
         private DiagnosticLevel MinimumLevel { get; }
 
         /// <summary>
+        ///     Creates a <see cref="DiagnosticLevel.Trace"/> diagnostic message.
+        /// </summary>
+        /// <param name="message">The desired message.</param>
+        public void Trace(string message)
+        {
+            RaiseEvent(DiagnosticLevel.Trace, message);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DiagnosticLevel.Trace"/> diagnostic message.
+        /// </summary>
+        /// <param name="message">The desired message.</param>
+        /// <param name="exception">An optional Exception.</param>
+        public void Trace(string message, Exception exception)
+        {
+            RaiseEvent(DiagnosticLevel.Trace, message, exception);
+        }
+
+        /// <summary>
         ///     Creates a <see cref="DiagnosticLevel.Debug"/> diagnostic message.
         /// </summary>
         /// <param name="message">The desired message.</param>

--- a/src/Diagnostics/DiagnosticLevel.cs
+++ b/src/Diagnostics/DiagnosticLevel.cs
@@ -41,5 +41,10 @@ namespace Soulseek.Diagnostics
         ///     Debug.
         /// </summary>
         Debug = 3,
+
+        /// <summary>
+        ///     Trace.
+        /// </summary>
+        Trace = 4,
     }
 }

--- a/src/Diagnostics/GlobalDiagnostic.cs
+++ b/src/Diagnostics/GlobalDiagnostic.cs
@@ -37,6 +37,19 @@ namespace Soulseek.Diagnostics
         public static void Init(IDiagnosticFactory factory) => Factory = factory;
 
         /// <summary>
+        ///     Creates a <see cref="DiagnosticLevel.Trace"/> diagnostic message.
+        /// </summary>
+        /// <param name="message">The desired message.</param>
+        public static void Trace(string message) => Factory?.Trace(message);
+
+        /// <summary>
+        ///     Creates a <see cref="DiagnosticLevel.Trace"/> diagnostic message.
+        /// </summary>
+        /// <param name="message">The desired message.</param>
+        /// <param name="exception">An optional Exception.</param>
+        public static void Trace(string message, Exception exception) => Factory?.Trace(message, exception);
+
+        /// <summary>
         ///     Creates a <see cref="DiagnosticLevel.Debug"/> diagnostic message.
         /// </summary>
         /// <param name="message">The desired message.</param>

--- a/src/Diagnostics/IDiagnosticFactory.cs
+++ b/src/Diagnostics/IDiagnosticFactory.cs
@@ -25,6 +25,19 @@ namespace Soulseek.Diagnostics
     internal interface IDiagnosticFactory
     {
         /// <summary>
+        ///     Creates a <see cref="DiagnosticLevel.Trace"/> diagnostic message.
+        /// </summary>
+        /// <param name="message">The desired message.</param>
+        void Trace(string message);
+
+        /// <summary>
+        ///     Creates a <see cref="DiagnosticLevel.Trace"/> diagnostic message.
+        /// </summary>
+        /// <param name="message">The desired message.</param>
+        /// <param name="exception">An optional Exception.</param>
+        void Trace(string message, Exception exception);
+
+        /// <summary>
         ///     Creates a <see cref="DiagnosticLevel.Debug"/> diagnostic message.
         /// </summary>
         /// <param name="message">The desired message.</param>

--- a/src/Messaging/MessageBuilder.cs
+++ b/src/Messaging/MessageBuilder.cs
@@ -214,7 +214,7 @@ namespace Soulseek.Messaging
                 // in this case we'll fail 'up' to UTF-8, instead of encoding to ISO-8859-1 while allowing replacements,
                 // which is almost certainly wrong.
                 bytes = Encoding.GetEncoding(CharacterEncoding.UTF8).GetBytes(value);
-                GlobalDiagnostic.Debug($"Failed to encode {encoding} for string {value}; resorted to fallback encoding {CharacterEncoding.UTF8} (base64: {Convert.ToBase64String(bytes)})", ex);
+                GlobalDiagnostic.Trace($"Failed to encode {encoding} for string {value}; resorted to fallback encoding {CharacterEncoding.UTF8} (base64: {Convert.ToBase64String(bytes)})", ex);
             }
 
             return WriteBytes(BitConverter.GetBytes(bytes.Length))

--- a/tests/Soulseek.Tests.Unit/Diagnostics/DiagnosticFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Diagnostics/DiagnosticFactoryTests.cs
@@ -34,6 +34,45 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(handler, d.GetProperty<Action<DiagnosticEventArgs>>("EventHandler"));
         }
 
+        [Trait("Category", "Trace")]
+        [Theory(DisplayName = "Raises event on trace"), AutoData]
+        public void Raises_Event_On_Trace(string message)
+        {
+            DiagnosticEventArgs e = null;
+
+            var d = new DiagnosticFactory(DiagnosticLevel.Trace, (args) =>
+            {
+                e = args;
+            });
+
+            d.Trace(message);
+
+            Assert.Equal(message, e.Message);
+            Assert.Equal(DiagnosticLevel.Trace, e.Level);
+            Assert.False(e.IncludesException);
+            Assert.Null(e.Exception);
+        }
+
+        [Trait("Category", "Trace")]
+        [Theory(DisplayName = "Raises event on trace with Exception"), AutoData]
+        public void Raises_Event_On_Trace_With_Exception(string message, Exception ex)
+        {
+            DiagnosticEventArgs e = null;
+
+            var d = new DiagnosticFactory(DiagnosticLevel.Trace, (args) =>
+            {
+                e = args;
+            });
+
+            d.Trace(message, ex);
+
+            Assert.Equal(message, e.Message);
+            Assert.Equal(ex, e.Exception);
+            Assert.Equal(DiagnosticLevel.Trace, e.Level);
+            Assert.True(e.IncludesException);
+            Assert.NotNull(e.Exception);
+        }
+
         [Trait("Category", "Debug")]
         [Theory(DisplayName = "Raises event on debug"), AutoData]
         public void Raises_Event_On_Debug(string message)

--- a/tests/Soulseek.Tests.Unit/Diagnostics/GlobalDiagnosticTests.cs
+++ b/tests/Soulseek.Tests.Unit/Diagnostics/GlobalDiagnosticTests.cs
@@ -36,6 +36,8 @@ namespace Soulseek.Tests.Unit
 
             var ex = Record.Exception(() =>
             {
+                GlobalDiagnostic.Trace("asdf");
+                GlobalDiagnostic.Trace("asdf", new Exception("xyz"));
                 GlobalDiagnostic.Debug("foo");
                 GlobalDiagnostic.Debug("foo", new Exception("bar"));
                 GlobalDiagnostic.Info("asdfasdfa");
@@ -50,12 +52,16 @@ namespace Soulseek.Tests.Unit
 
             GlobalDiagnostic.Init(f.Object);
 
+            GlobalDiagnostic.Trace("asdf");
+            GlobalDiagnostic.Trace("asdf", ex);
             GlobalDiagnostic.Debug("foo");
             GlobalDiagnostic.Debug("foo", ex);
             GlobalDiagnostic.Info("asdfasdfa");
             GlobalDiagnostic.Warning("warn");
             GlobalDiagnostic.Warning("asdf", ex);
 
+            f.Verify(m => m.Trace("asdf"), Times.Exactly(1));
+            f.Verify(m => m.Trace("asdf", ex), Times.Exactly(1));
             f.Verify(m => m.Debug("foo"), Times.Exactly(1));
             f.Verify(m => m.Debug("foo", ex), Times.Exactly(1));
             f.Verify(m => m.Info("asdfasdfa"), Times.Exactly(1));


### PR DESCRIPTION
This should clean up Debug logs quite a bit.

Bumps version to 7.0.4