### PR TITLE
Adjust some IDisposable usage

### DIFF
--- a/src/Common/ITokenBucket.cs
+++ b/src/Common/ITokenBucket.cs
@@ -17,13 +17,15 @@
 
 namespace Soulseek
 {
+    using System;
+
     using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
     ///     Implements the 'token bucket' or 'leaky bucket' rate limiting algorithm.
     /// </summary>
-    internal interface ITokenBucket
+    internal interface ITokenBucket : IDisposable
     {
         /// <summary>
         ///     Gets the bucket capacity.

--- a/src/Common/ITokenBucket.cs
+++ b/src/Common/ITokenBucket.cs
@@ -18,7 +18,6 @@
 namespace Soulseek
 {
     using System;
-
     using System.Threading;
     using System.Threading.Tasks;
 

--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -825,6 +825,8 @@ namespace Soulseek.Network
                 {
                     WatchdogTimer.Dispose();
                     StatusDebounceTimer.Dispose();
+                    StatusSyncRoot.Dispose();
+                    ParentSyncRoot.Dispose();
                     RemoveAndDisposeAll();
                 }
 

--- a/src/Network/DistributedConnectionManager.cs
+++ b/src/Network/DistributedConnectionManager.cs
@@ -825,8 +825,10 @@ namespace Soulseek.Network
                 {
                     WatchdogTimer.Dispose();
                     StatusDebounceTimer.Dispose();
+
                     StatusSyncRoot.Dispose();
                     ParentSyncRoot.Dispose();
+
                     RemoveAndDisposeAll();
                 }
 

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -574,6 +574,9 @@ namespace Soulseek.Network.Tcp
                     WatchdogTimer.Dispose();
                     Stream?.Dispose();
                     TcpClient?.Dispose();
+
+                    WriteSemaphore?.Dispose();
+                    WriteQueueSemaphore?.Dispose();
                 }
 
                 Disposed = true;

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -52,10 +52,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -52,6 +52,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2727,10 +2727,20 @@ namespace Soulseek
                     Listener?.Stop();
 
                     PeerConnectionManager.Dispose();
-
                     DistributedConnectionManager.Dispose();
 
                     Waiter.Dispose();
+
+                    UploadTokenBucket.Dispose();
+                    DownloadTokenBucket.Dispose();
+
+                    StateSyncRoot.Dispose();
+                    UploadSemaphoreSyncRoot.Dispose();
+                    UserEndPointSemaphoreSyncRoot.Dispose();
+
+                    SearchSemaphore.Dispose();
+                    GlobalUploadSemaphore.Dispose();
+                    GlobalDownloadSemaphore.Dispose();
 
                     ServerConnection?.Dispose();
 


### PR DESCRIPTION
I recently found the package  `IDisposableAnalyzers`, which helps catch problems with `IDisposable` objects, which might contribute to memory or resource leakage.

This PR solves the issues that were found, other than some potentially problematic handling of input/output streams for transfers.