### PR TITLE
Adjust upload/download stream handling logic to make it harder to "leak" streams

### DIFF
--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3388,14 +3388,13 @@ namespace Soulseek
 
                 // attempt to get the actual final position of the stream for accurate record keeping. if something goes wrong,
                 // which can happen depending on the stream type (e.g. FileStream.Position can throw if the file is closed),
-                // just assume the final size is the requested size of the file and move on
+                // set it to zero and let the consumer figure it out
                 try
                 {
-                    finalStreamPosition = outputStream?.Position ?? size ?? 0;
+                    finalStreamPosition = outputStream?.Position ?? 0;
                 }
                 catch (Exception)
                 {
-                    finalStreamPosition = size ?? 0;
                 }
 
                 if (options.DisposeOutputStreamOnCompletion && outputStream != null)
@@ -4431,14 +4430,13 @@ namespace Soulseek
 
                 // attempt to get the actual final position of the stream for accurate record keeping. if something goes wrong,
                 // which can happen depending on the stream type (e.g. FileStream.Position can throw if the file is closed),
-                // just assume the final size is the requested size of the file and move on
+                // set it to zero and let the consumer figure it out
                 try
                 {
-                    finalStreamPosition = inputStream?.Position ?? size;
+                    finalStreamPosition = inputStream?.Position ?? 0;
                 }
                 catch (Exception)
                 {
-                    finalStreamPosition = size;
                 }
 
                 if (options.DisposeInputStreamOnCompletion && inputStream != null)

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3386,9 +3386,17 @@ namespace Soulseek
 
                 long finalStreamPosition = 0;
 
+                // attempt to get the actual final position of the stream for accurate record keeping. if something goes wrong,
+                // which can happen depending on the stream type (e.g. FileStream.Position can throw if the file is closed),
+                // just assume the final size is the requested size of the file and move on
                 try
                 {
-                    finalStreamPosition = outputStream?.Position ?? 0;
+                    finalStreamPosition = outputStream?.Position ?? size ?? 0;
+                }
+                catch (Exception)
+                {
+                    finalStreamPosition = size ?? 0;
+                }
 
                     if (options.DisposeOutputStreamOnCompletion && outputStream != null)
                     {
@@ -4419,9 +4427,17 @@ namespace Soulseek
 
                 long finalStreamPosition = 0;
 
+                // attempt to get the actual final position of the stream for accurate record keeping. if something goes wrong,
+                // which can happen depending on the stream type (e.g. FileStream.Position can throw if the file is closed),
+                // just assume the final size is the requested size of the file and move on
                 try
                 {
-                    finalStreamPosition = inputStream?.Position ?? 0;
+                    finalStreamPosition = inputStream?.Position ?? size;
+                }
+                catch (Exception)
+                {
+                    finalStreamPosition = size;
+                }
 
                     if (options.DisposeInputStreamOnCompletion && inputStream != null)
                     {

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3393,8 +3393,9 @@ namespace Soulseek
                 {
                     finalStreamPosition = outputStream?.Position ?? 0;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Diagnostic.Warning($"Failed to determine final position of output stream for file {Path.GetFileName(download.Filename)} from {username}: {ex.Message}", ex);
                 }
 
                 if (options.DisposeOutputStreamOnCompletion && outputStream != null)
@@ -4435,8 +4436,9 @@ namespace Soulseek
                 {
                     finalStreamPosition = inputStream?.Position ?? 0;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Diagnostic.Warning($"Failed to determine final position of input stream for file {Path.GetFileName(upload.Filename)} to {username}: {ex.Message}", ex);
                 }
 
                 if (options.DisposeInputStreamOnCompletion && inputStream != null)

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3398,7 +3398,9 @@ namespace Soulseek
                     finalStreamPosition = size ?? 0;
                 }
 
-                    if (options.DisposeOutputStreamOnCompletion && outputStream != null)
+                if (options.DisposeOutputStreamOnCompletion && outputStream != null)
+                {
+                    try
                     {
                         try
                         {
@@ -3407,16 +3409,16 @@ namespace Soulseek
                         finally
                         {
 #if NETSTANDARD2_0
-                            outputStream?.Dispose();
+                            outputStream.Dispose();
 #else
                             await outputStream.DisposeAsync().ConfigureAwait(false);
 #endif
                         }
                     }
-                }
-                catch (Exception ex)
-                {
-                    Diagnostic.Debug($"Failed to finalize output stream for file {Path.GetFileName(download.Filename)} from {username}: {ex.Message}", ex);
+                    catch (Exception ex)
+                    {
+                        Diagnostic.Warning($"Failed to finalize output stream for file {Path.GetFileName(download.Filename)} from {username}: {ex.Message}", ex);
+                    }
                 }
 
                 if (!download.State.HasFlag(TransferStates.Completed))
@@ -4439,7 +4441,9 @@ namespace Soulseek
                     finalStreamPosition = size;
                 }
 
-                    if (options.DisposeInputStreamOnCompletion && inputStream != null)
+                if (options.DisposeInputStreamOnCompletion && inputStream != null)
+                {
+                    try
                     {
 #if NETSTANDARD2_0
                         inputStream.Dispose();
@@ -4447,10 +4451,10 @@ namespace Soulseek
                         await inputStream.DisposeAsync().ConfigureAwait(false);
 #endif
                     }
-                }
-                catch (Exception ex)
-                {
-                    Diagnostic.Debug($"Failed to finalize input stream for file {Path.GetFileName(upload.Filename)} to {username}: {ex.Message}", ex);
+                    catch (Exception ex)
+                    {
+                        Diagnostic.Warning($"Failed to finalize input stream for file {Path.GetFileName(upload.Filename)} to {username}: {ex.Message}", ex);
+                    }
                 }
 
                 if (!upload.State.HasFlag(TransferStates.Completed))

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -1184,6 +1184,61 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadFromStreamAsync")]
+        [Theory(DisplayName = "UploadFromStreamAsync does not throw and produces a warning diagnostic if stream disposal fails"), AutoData]
+        public async Task UploadFromStreamAsync_Does_Not_Throw_And_Produces_Warning_Diagnostic_If_Stream_Disposal_Fails(string username, IPEndPoint endpoint, string filename, int token, int size)
+        {
+            var options = new SoulseekClientOptions(messageTimeout: 5);
+
+            var response = new TransferResponse(token, size);
+            var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
+
+            var waiter = new Mock<IWaiter>();
+            waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+            waiter.Setup(m => m.WaitIndefinitely(It.IsAny<WaitKey>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            var transferConn = new Mock<IConnection>();
+            transferConn.Setup(m => m.ReadAsync(8, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+
+            var connManager = new Mock<IPeerConnectionManager>();
+            connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(conn.Object));
+            connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(transferConn.Object));
+
+            var diagnostic = new Mock<IDiagnosticFactory>();
+
+            try
+            {
+                using (var stream = new UnDisposableStream())
+                using (var s = new SoulseekClient(options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object, diagnosticFactory: diagnostic.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var txoptions = new TransferOptions(disposeInputStreamOnCompletion: true);
+
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromStreamAsync", username, filename, 1, new Func<long, Task<Stream>>((_) => Task.FromResult((Stream)stream)), token, txoptions, null));
+
+                    Assert.Null(ex);
+
+                    diagnostic.Verify(m => m.Warning(It.Is<string>(str => str.ContainsInsensitive("failed to finalize input stream")), It.IsAny<Exception>()), Times.Once);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // noop; this is expected because UnDisposableStream throws when dispose is called
+            }
+        }
+
+        [Trait("Category", "UploadFromStreamAsync")]
         [Theory(DisplayName = "UploadFromStreamAsync does not dispose stream given false dispose option flag"), AutoData]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1481:Unused local variables should be removed", Justification = "Discard")]
         public async Task UploadFromStreamAsync_Does_Not_Dispose_Stream_Given_False_Dispose_Option_Flag(string username, IPEndPoint endpoint, string filename, int token, int size)
@@ -2932,6 +2987,55 @@ namespace Soulseek.Tests.Unit.Client
                     return 0;
                 }
                 set => throw new NotImplementedException();
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return count;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return offset;
+            }
+
+            public override void SetLength(long value)
+            {
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+            }
+        }
+
+        private class UnDisposableStream : Stream
+        {
+            public override bool CanRead => false;
+            public override bool CanWrite => false;
+
+            public override bool CanSeek => false;
+
+            public override long Length => 0;
+
+            public override long Position { get; set; }
+
+            public new void Dispose()
+            {
+                throw new ObjectDisposedException("failed disposal");
+            }
+
+            public override ValueTask DisposeAsync()
+            {
+                throw new ObjectDisposedException("failed disposal");
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                throw new ObjectDisposedException("failed disposal");
             }
 
             public override void Flush()


### PR DESCRIPTION
Attempting to reference `.Position` of certain types of stream in certain states can throw, which would prevent the stream from being disposed and potentially cause resource leak.  This PR moves that logic into a try/catch to prevent this.

Also logs failures to finalize streams in this way as warnings instead of debug, as those sorts of warnings will never surface for an end user and this bug can cause a resource leak that they should be able to report.

Closes #851 