### PR TITLE
Log MessageReader encoding fallbacks as Trace

### DIFF
--- a/src/Messaging/MessageReader.cs
+++ b/src/Messaging/MessageReader.cs
@@ -234,7 +234,7 @@ namespace Soulseek.Messaging
                 var requestedEncoding = encoding;
                 encoding = CharacterEncoding.ISO88591;
                 retVal = Encoding.GetEncoding(encoding).GetString(bytes);
-                GlobalDiagnostic.Debug($"Failed to decode {requestedEncoding} for string {retVal}; resorted to fallback encoding {CharacterEncoding.ISO88591} (base64: {Convert.ToBase64String(bytes)})", ex);
+                GlobalDiagnostic.Trace($"Failed to decode {requestedEncoding} for string {retVal}; resorted to fallback encoding {CharacterEncoding.ISO88591} (base64: {Convert.ToBase64String(bytes)})", ex);
             }
 
             Position += length;

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>


### PR DESCRIPTION
This is already being done in MessageWriter; I neglected to update the reader too.  