### PR TITLE
Optimize the assignment of file attributes when instantiating

### DIFF
--- a/src/File.cs
+++ b/src/File.cs
@@ -43,14 +43,29 @@ namespace Soulseek
             Attributes = (attributeList?.ToList() ?? new List<FileAttribute>()).AsReadOnly();
             AttributeCount = Attributes.Count;
 
-            BitDepth = GetAttributeValue(FileAttributeType.BitDepth);
-            BitRate = GetAttributeValue(FileAttributeType.BitRate);
-
-            var vbr = GetAttributeValue(FileAttributeType.VariableBitRate);
-            IsVariableBitRate = vbr == null ? (bool?)null : vbr != 0;
-
-            Length = GetAttributeValue(FileAttributeType.Length);
-            SampleRate = GetAttributeValue(FileAttributeType.SampleRate);
+            foreach (var attribute in Attributes)
+            {
+                switch (attribute.Type)
+                {
+                    case FileAttributeType.BitDepth:
+                        BitDepth = attribute.Value;
+                        break;
+                    case FileAttributeType.BitRate:
+                        BitRate = attribute.Value;
+                        break;
+                    case FileAttributeType.VariableBitRate:
+                        IsVariableBitRate = attribute.Value != 0;
+                        break;
+                    case FileAttributeType.Length:
+                        Length = attribute.Value;
+                        break;
+                    case FileAttributeType.SampleRate:
+                        SampleRate = attribute.Value;
+                        break;
+                    default:
+                        break;
+                }
+            }
         }
 
         /// <summary>
@@ -108,15 +123,5 @@ namespace Soulseek
         ///     Gets the file size in bytes.
         /// </summary>
         public long Size { get; }
-
-        /// <summary>
-        ///     Returns the value of the specified attribute <paramref name="type"/>.
-        /// </summary>
-        /// <param name="type">The attribute to return.</param>
-        /// <returns>The value of the specified attribute.</returns>
-        public int? GetAttributeValue(FileAttributeType type)
-        {
-            return Attributes.FirstOrDefault(a => a.Type == type)?.Value;
-        }
     }
 }

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>7.1.1</Version>
+    <Version>7.1.2</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/tests/Soulseek.Tests.Unit/FileTests.cs
+++ b/tests/Soulseek.Tests.Unit/FileTests.cs
@@ -25,7 +25,7 @@ namespace Soulseek.Tests.Unit
     public class FileTests
     {
         [Trait("Category", "Instantiation")]
-        [Theory(DisplayName ="Instantiates with the given data"), AutoData]
+        [Theory(DisplayName = "Instantiates with the given data"), AutoData]
         public void Instantiates_With_The_Given_Data(int code, string filename, long size, string extension, List<FileAttribute> attributeList)
         {
             var f = default(File);
@@ -142,28 +142,6 @@ namespace Soulseek.Tests.Unit
 
             Assert.Empty(f.Attributes);
             Assert.Null(f.Length);
-        }
-
-        [Trait("Category", "GetAttributeValue")]
-        [Theory(DisplayName = "GetAttributeValue returns null when no value"), AutoData]
-        public void GetAttributeValue_Returns_Null_When_No_Value(int code, string filename, long size, string extension)
-        {
-            var list = new List<FileAttribute>() { };
-
-            var f = new File(code, filename, size, extension, list);
-
-            Assert.Null(f.GetAttributeValue(FileAttributeType.BitDepth));
-        }
-
-        [Trait("Category", "GetAttributeValue")]
-        [Theory(DisplayName = "GetAttributeValue returns value when value"), AutoData]
-        public void GetAttributeValue_Returns_Value_When_Value(int code, string filename, long size, string extension, FileAttributeType type, int value)
-        {
-            var list = new List<FileAttribute>() { new FileAttribute(type, value) };
-
-            var f = new File(code, filename, size, extension, list);
-
-            Assert.Equal(value, f.GetAttributeValue(type));
         }
 
         [Trait("Category", "IsVariableBitRate")]


### PR DESCRIPTION
The existing implementation iterates over the attribute list multiple times, when it really only needs to be done once.  This shouldn't have a _huge_ impact on performance, but this is a really hot path when searching and browsing.