### PR TITLE
Don't respond to your own search requests, unless the request is the result of an intentional user search containing your own username

### DIFF
--- a/src/Messaging/Handlers/DistributedMessageHandler.cs
+++ b/src/Messaging/Handlers/DistributedMessageHandler.cs
@@ -168,6 +168,11 @@ namespace Soulseek.Messaging.Handlers
 
                                 _ = SoulseekClient.DistributedConnectionManager.BroadcastMessageAsync(embeddedMessage.DistributedMessage).ConfigureAwait(false);
 
+                                if (embeddedSearchRequest.Username == SoulseekClient.Username)
+                                {
+                                    break; // don't respond to our own searches
+                                }
+
                                 await SoulseekClient.SearchResponder.TryRespondAsync(embeddedSearchRequest.Username, embeddedSearchRequest.Token, embeddedSearchRequest.Query).ConfigureAwait(false);
 
                                 break;
@@ -183,6 +188,11 @@ namespace Soulseek.Messaging.Handlers
                         var searchRequest = DistributedSearchRequest.FromByteArray(message);
 
                         _ = SoulseekClient.DistributedConnectionManager.BroadcastMessageAsync(message).ConfigureAwait(false);
+
+                        if (searchRequest.Username == SoulseekClient.Username)
+                        {
+                            break; // don't respond to our own searches
+                        }
 
                         await SoulseekClient.SearchResponder.TryRespondAsync(searchRequest.Username, searchRequest.Token, searchRequest.Query).ConfigureAwait(false);
 

--- a/src/Search.cs
+++ b/src/Search.cs
@@ -25,15 +25,17 @@ namespace Soulseek
         /// <summary>
         ///     Initializes a new instance of the <see cref="Search"/> class.
         /// </summary>
-        /// <param name="searchText">The text for which to search.</param>
+        /// <param name="query">The search query.</param>
+        /// <param name="scope">The scope of the search.</param>
         /// <param name="token">The unique search token.</param>
         /// <param name="state">The state of the search.</param>
         /// <param name="responseCount">The current number of responses received.</param>
         /// <param name="fileCount">The total number of files contained within received responses.</param>
         /// <param name="lockedFileCount">The total number of locked files contained within received responses.</param>
-        public Search(string searchText, int token, SearchStates state, int responseCount, int fileCount, int lockedFileCount)
+        public Search(SearchQuery query, SearchScope scope, int token, SearchStates state, int responseCount, int fileCount, int lockedFileCount)
         {
-            SearchText = searchText;
+            Query = query;
+            Scope = scope;
             Token = token;
             State = state;
             ResponseCount = responseCount;
@@ -47,7 +49,8 @@ namespace Soulseek
         /// <param name="searchInternal">The internal instance from which to copy data.</param>
         internal Search(SearchInternal searchInternal)
             : this(
-                searchInternal.SearchText,
+                searchInternal.Query,
+                searchInternal.Scope,
                 searchInternal.Token,
                 searchInternal.State,
                 searchInternal.ResponseCount,
@@ -67,14 +70,19 @@ namespace Soulseek
         public int LockedFileCount { get; }
 
         /// <summary>
+        ///     Gets the search query.
+        /// </summary>
+        public SearchQuery Query { get; }
+
+        /// <summary>
         ///     Gets the current number of responses received.
         /// </summary>
         public int ResponseCount { get; }
 
         /// <summary>
-        ///     Gets the text for which to search.
+        ///     Gets the scope of the saerch.
         /// </summary>
-        public string SearchText { get; }
+        public SearchScope Scope { get; }
 
         /// <summary>
         ///     Gets the state of the search.

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -35,12 +35,14 @@ namespace Soulseek
         /// <summary>
         ///     Initializes a new instance of the <see cref="SearchInternal"/> class.
         /// </summary>
-        /// <param name="searchText">The text for which to search.</param>
+        /// <param name="query">The search query.</param>
+        /// <param name="scope">The search scope.</param>
         /// <param name="token">The unique search token.</param>
         /// <param name="options">The options for the search.</param>
-        public SearchInternal(string searchText, int token, SearchOptions options = null)
+        public SearchInternal(SearchQuery query, SearchScope scope, int token, SearchOptions options = null)
         {
-            SearchText = searchText;
+            Query = query;
+            Scope = scope;
             Token = token;
 
             Options = options ?? new SearchOptions();
@@ -71,6 +73,11 @@ namespace Soulseek
         public SearchOptions Options { get; }
 
         /// <summary>
+        ///     Gets the search query.
+        /// </summary>
+        public SearchQuery Query { get; }
+
+        /// <summary>
         ///     Gets the current number of responses received.
         /// </summary>
         public int ResponseCount => responseCount;
@@ -81,9 +88,9 @@ namespace Soulseek
         public Action<SearchResponse> ResponseReceived { get; set; }
 
         /// <summary>
-        ///     Gets the text for which to search.
+        ///     Gets the scope of the search.
         /// </summary>
-        public string SearchText { get; }
+        public SearchScope Scope { get; }
 
         /// <summary>
         ///     Gets the state of the search.

--- a/src/SearchScope.cs
+++ b/src/SearchScope.cs
@@ -39,7 +39,7 @@ namespace Soulseek
 
             if ((Type == SearchScopeType.Network || Type == SearchScopeType.Wishlist) && subjects.Length > 0)
             {
-                throw new ArgumentException($"The {Type} search scope accepts no subjects", nameof(subjects));
+                throw new ArgumentException($"The {Type} search scope can not be used with subjects", nameof(subjects));
             }
 
             if (Type == SearchScopeType.Room && (subjects.Length != 1 || string.IsNullOrEmpty(subjects[0])))

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3952,7 +3952,7 @@ namespace Soulseek
 
         private async Task<Search> SearchToCallbackAsync(SearchQuery query, Action<SearchResponse> responseHandler, SearchScope scope, int token, SearchOptions options, CancellationToken cancellationToken)
         {
-            var search = new SearchInternal(query.SearchText, token, options);
+            var search = new SearchInternal(query, scope, token, options);
             var lastState = SearchStates.None;
 
             void UpdateState(SearchStates state)
@@ -3981,10 +3981,10 @@ namespace Soulseek
                 {
                     var message = scope.Type switch
                     {
-                        SearchScopeType.Room => new RoomSearchRequest(scope.Subjects.First(), search.SearchText, search.Token).ToByteArray(),
-                        SearchScopeType.User => scope.Subjects.SelectMany(u => new UserSearchRequest(u, search.SearchText, search.Token).ToByteArray()).ToArray(),
-                        SearchScopeType.Wishlist => new WishlistSearchRequest(search.SearchText, search.Token).ToByteArray(),
-                        _ => new SearchRequest(search.SearchText, search.Token).ToByteArray()
+                        SearchScopeType.Room => new RoomSearchRequest(scope.Subjects.First(), search.Query.SearchText, search.Token).ToByteArray(),
+                        SearchScopeType.User => scope.Subjects.SelectMany(u => new UserSearchRequest(u, search.Query.SearchText, search.Token).ToByteArray()).ToArray(),
+                        SearchScopeType.Wishlist => new WishlistSearchRequest(search.Query.SearchText, search.Token).ToByteArray(),
+                        _ => new SearchRequest(search.Query.SearchText, search.Token).ToByteArray()
                     };
 
                     search.ResponseReceived = (response) =>

--- a/tests/Soulseek.Tests.Unit/EventArgs/SearchEventArgsTests.cs
+++ b/tests/Soulseek.Tests.Unit/EventArgs/SearchEventArgsTests.cs
@@ -32,7 +32,7 @@ namespace Soulseek.Tests.Unit
             var searchText = Guid.NewGuid().ToString();
             var token = new Random().Next();
 
-            using (var search = new SearchInternal(searchText, token, new SearchOptions()))
+            using (var search = new SearchInternal(new SearchQuery(searchText), SearchScope.Network, token, new SearchOptions()))
             {
                 var response = new SearchResponse("foo", 1, true, 1, 1, new List<File>());
 
@@ -52,7 +52,7 @@ namespace Soulseek.Tests.Unit
             var searchText = Guid.NewGuid().ToString();
             var token = new Random().Next();
 
-            using (var search = new SearchInternal(searchText, token, new SearchOptions()))
+            using (var search = new SearchInternal(new SearchQuery(searchText), SearchScope.Network, token, new SearchOptions()))
             {
                 search.SetProperty("State", SearchStates.Completed);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -437,7 +437,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             var responses = new List<SearchResponse>();
 
-            using (var search = new SearchInternal("foo", token)
+            using (var search = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, token)
             {
                 ResponseReceived = (r) => responses.Add(r),
             })

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -2117,6 +2117,10 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Client.Setup(m => m.Username)
                 .Returns(username);
 
+            // no active searches in dictionary, so this should NOT be treated as intentional
+            var searches = new ConcurrentDictionary<int, SearchInternal>();
+            mocks.Client.Setup(m => m.Searches).Returns(searches);
+
             var message = GetServerSearchRequest(username, token, query);
             var endpoint = new IPEndPoint(IPAddress.None, 0);
 
@@ -2124,6 +2128,10 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             mocks.Client.Verify(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()), Times.Never);
             mocks.PeerConnectionManager.Verify(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()), Times.Never);
+
+            // verify that SearchResponder is NOT called since this is not an intentional self-search
+            mocks.SearchResponder.Verify(m => m.TryRespondAsync(username, token, query), Times.Never);
+        }
         }
 
         [Trait("Category", "Message")]

--- a/tests/Soulseek.Tests.Unit/SearchScopeTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchScopeTests.cs
@@ -48,7 +48,7 @@ namespace Soulseek.Tests.Unit
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);
-            Assert.True(ex.Message.ContainsInsensitive("accepts no subjects"));
+            Assert.True(ex.Message.ContainsInsensitive("subjects"));
         }
 
         [Trait("Category", "Instantiation")]
@@ -61,7 +61,7 @@ namespace Soulseek.Tests.Unit
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);
-            Assert.True(ex.Message.ContainsInsensitive("accepts no subjects"));
+            Assert.True(ex.Message.ContainsInsensitive("subjects"));
         }
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/SearchTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchTests.cs
@@ -17,6 +17,8 @@
 
 namespace Soulseek.Tests.Unit
 {
+    using System.Collections.Generic;
+
     using AutoFixture.Xunit2;
     using Xunit;
 
@@ -26,9 +28,10 @@ namespace Soulseek.Tests.Unit
         [Theory(DisplayName = "Instantiates with expected data"), AutoData]
         public void Instantiates_With_Expected_Data(string searchText, int token, SearchStates state, int responseCount, int fileCount, int lockedFileCount)
         {
-            var s = new Search(searchText, token, state, responseCount, fileCount, lockedFileCount);
+            var s = new Search(new SearchQuery(searchText), SearchScope.Network, token, state, responseCount, fileCount, lockedFileCount);
 
-            Assert.Equal(searchText, s.SearchText);
+            Assert.Equal(searchText, s.Query.SearchText);
+            Assert.Equal(SearchScope.Network.Type, s.Scope.Type);
             Assert.Equal(token, s.Token);
             Assert.Equal(state, s.State);
             Assert.Equal(responseCount, s.ResponseCount);
@@ -38,11 +41,18 @@ namespace Soulseek.Tests.Unit
 
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates with expected data given SearchInternal"), AutoData]
-        internal void Instantiates_With_Expected_Data_Given_SearchInternal(SearchInternal i)
+        internal void Instantiates_With_Expected_Data_Given_SearchInternal(string searchText, int token)
         {
+            var i = new SearchInternal(SearchQuery.FromText(searchText), SearchScope.Network, token);
+            i.SetState(SearchStates.Completed);
+            i.TryAddResponse(new SearchResponse("foo", 42, false, 420, 24, new List<File>()
+            {
+                new File(1, "foo.bar", 2323, "bar", null),
+            }));
+
             var s = new Search(i);
 
-            Assert.Equal(i.SearchText, s.SearchText);
+            Assert.Equal(i.Query.SearchText, s.Query.SearchText);
             Assert.Equal(i.Token, s.Token);
             Assert.Equal(i.State, s.State);
             Assert.Equal(i.ResponseCount, s.ResponseCount);

--- a/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
+++ b/tests/Soulseek.Tests.Unit/SoulseekClientTests.cs
@@ -354,8 +354,8 @@ namespace Soulseek.Tests.Unit
             {
                 s.SetProperty("State", SoulseekClientStates.Connected);
 
-                using (var search1 = new SearchInternal(string.Empty, 0, new SearchOptions()))
-                using (var search2 = new SearchInternal(string.Empty, 1, new SearchOptions()))
+                using (var search1 = new SearchInternal(new SearchQuery(string.Empty), SearchScope.Network, 0, new SearchOptions()))
+                using (var search2 = new SearchInternal(new SearchQuery(string.Empty), SearchScope.Network, 1, new SearchOptions()))
                 {
                     var searches = new ConcurrentDictionary<int, SearchInternal>();
                     searches.TryAdd(0, search1);
@@ -425,7 +425,7 @@ namespace Soulseek.Tests.Unit
 
             var p = new Mock<IPeerConnectionManager>();
 
-            using (var search = new SearchInternal("foo", 1))
+            using (var search = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 1))
             {
                 var searches = new ConcurrentDictionary<int, SearchInternal>();
                 searches.TryAdd(1, search);


### PR DESCRIPTION
A user in Discord gave me a heads up that the middleware they were using to connect slskd to Lidarr was attempting to download their own files, meaning they were responding to their own search requests.

After investigation I found that there's logic to prevent that when the server sends a `FileSearch` request, but no logic to prevent it when we receive a search request via the distributed network.

Nicotine+ responds to these requests if there's evidence that the user did it intentionally, and I think that's useful if a user wants to see how their shares look to other users.

This PR implements this behavior, specifically:

* Discarding any distributed search request originating from the current user (`SoulseekClient.Username`)
* Discarding any _embedded_ distributed search request originating from the current user
* Adjusting the existing logic that discards such search requests when they come via a `FileSearch` request to inspect the list of ongoing local searches to see if any match the token, were sent with the `User` scope, and with a `subject` that includes the current username (this specifically signals that the user made the search request intentionally) and in that case, responding to the request

To pull this off I had to adjust the `Search` and `SearchInternal` classes so that they capture the `SearchScope`, and further made the improvement to capture the full `SearchQuery` object instead of just `searchText`.  This captures the full search request, the way it was sent from the calling application.

This broke a ton of tests, and is a breaking change to the public API (removes `SearchText` from `Search`, specifically)