### PR TITLE
Remove ~150+ warnings

### DIFF
--- a/examples/Web/api/Extensions.cs
+++ b/examples/Web/api/Extensions.cs
@@ -40,7 +40,11 @@
         /// <returns></returns>
         public static string Sha1(this string str)
         {
+#pragma warning disable SYSLIB0021 // Type or member is obsolete
+
             using var sha1 = new SHA1Managed();
+#pragma warning restore SYSLIB0021 // Type or member is obsolete
+
             return BitConverter.ToString(sha1.ComputeHash(Encoding.UTF8.GetBytes(str))).Replace("-", "");
         }
 

--- a/examples/Web/api/Security/PassthroughAuthentication.cs
+++ b/examples/Web/api/Security/PassthroughAuthentication.cs
@@ -14,16 +14,20 @@
 
     public class PassthroughAuthenticationHandler : AuthenticationHandler<PassthroughAuthenticationOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public PassthroughAuthenticationHandler(IOptionsMonitor<PassthroughAuthenticationOptions> optionsMonitor, ILoggerFactory logger, UrlEncoder urlEncoder, ISystemClock systemClock)
+
             : base(optionsMonitor, logger, urlEncoder, systemClock)
-        {            
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        {
         }
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
             var identity = new GenericIdentity(Options.Username);
             var principal = new GenericPrincipal(identity, new[] { "User" });
-            var ticket = new AuthenticationTicket(principal , new AuthenticationProperties(), PassthroughAuthentication.AuthenticationScheme);
+            var ticket = new AuthenticationTicket(principal, new AuthenticationProperties(), PassthroughAuthentication.AuthenticationScheme);
 
             return Task.FromResult(AuthenticateResult.Success(ticket));
         }

--- a/examples/Web/api/Startup.cs
+++ b/examples/Web/api/Startup.cs
@@ -123,6 +123,11 @@ namespace WebAPI
                     });
             }
 
+#pragma warning disable ASP5001 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable SYSLIB0020 // Type or member is obsolete
+
+            // the compiler really fucking hates this
             services.AddMvc(options =>
             {
                 options.EnableEndpointRouting = false;
@@ -132,8 +137,13 @@ namespace WebAPI
                 {
                     options.JsonSerializerOptions.Converters.Add(new IPAddressConverter());
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+
                     options.JsonSerializerOptions.IgnoreNullValues = true;
+
                 });
+#pragma warning restore SYSLIB0020 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore ASP5001 // Type or member is obsolete
 
             services.AddRouting(options => options.LowercaseUrls = true);
 
@@ -201,7 +211,7 @@ namespace WebAPI
                 await next();
             });
 
-            WebRoot ??= Path.Combine(Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().GetName().CodeBase).AbsolutePath), "wwwroot");
+            WebRoot ??= Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "wwwroot");
             Console.WriteLine($"Serving static content from {WebRoot}");
 
             var fileServerOptions = new FileServerOptions

--- a/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
@@ -329,7 +329,7 @@ namespace Soulseek.Tests.Unit.Client
         [Fact(DisplayName = "Sets state to Connected | LoggedIn on success")]
         public async Task Sets_State_To_Connected_LoggedIn_On_Success()
         {
-            var (client, mocks) = GetFixture();
+            var (client, _) = GetFixture();
 
             using (client)
             {
@@ -449,7 +449,7 @@ namespace Soulseek.Tests.Unit.Client
         public async Task Starts_Listener_On_Success(string user, string password)
         {
             var port = Mocks.Port;
-            var (client, mocks) = GetFixture(new SoulseekClientOptions(listenPort: port));
+            var (client, _) = GetFixture(new SoulseekClientOptions(listenPort: port));
 
             using (client)
             {
@@ -588,7 +588,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        private (SoulseekClient client, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
+        private static (SoulseekClient client, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
         {
             var mocks = new Mocks();
             var client = new SoulseekClient(

--- a/tests/Soulseek.Tests.Unit/Client/ConnectToUserAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ConnectToUserAsyncTests.cs
@@ -230,7 +230,7 @@ namespace Soulseek.Tests.Unit.Client
             mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.AtLeastOnce);
         }
 
-        private (SoulseekClient client, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)
+        private static (SoulseekClient client, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)
         {
             var mocks = new Mocks();
             var client = new SoulseekClient(

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -3441,11 +3441,6 @@ namespace Soulseek.Tests.Unit.Client
 
             public override long Position { get; set; }
 
-            public new void Dispose()
-            {
-                throw new ObjectDisposedException("failed disposal");
-            }
-
             public override ValueTask DisposeAsync()
             {
                 throw new ObjectDisposedException("failed disposal");

--- a/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/DownloadAsyncTests.cs
@@ -836,8 +836,6 @@ namespace Soulseek.Tests.Unit.Client
             var response = new TransferResponse(token, "Queued");
             var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
 
-            var request = new TransferRequest(TransferDirection.Download, token, filename, size);
-
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), CancellationToken.None))
                 .Returns(Task.CompletedTask);
@@ -979,8 +977,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1028,8 +1024,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1203,8 +1197,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1266,8 +1258,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1325,8 +1315,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1362,7 +1350,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 _ = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, localFilename, (long?)size, 0, token, new TransferOptions(), null));
 
-                Assert.Equal(TransferStates.Completed | TransferStates.Aborted, events.Last().Transfer.State);
+                Assert.Equal(TransferStates.Completed | TransferStates.Aborted, events[events.Count - 1].Transfer.State);
             }
         }
 
@@ -1378,8 +1366,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1427,8 +1413,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1484,8 +1468,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1516,9 +1498,11 @@ namespace Soulseek.Tests.Unit.Client
                 var txoptions = new TransferOptions(disposeOutputStreamOnCompletion: true);
                 await s.InvokeMethod<Task>("DownloadToStreamAsync", username, filename, new Func<Task<Stream>>(() => Task.FromResult((Stream)stream)), (long?)size, 0, token, txoptions, null);
 
+                long p;
+
                 var ex = Record.Exception(() =>
                 {
-                    var p = stream.Position;
+                    p = stream.Position;
                 });
 
                 Assert.NotNull(ex);
@@ -1540,8 +1524,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1604,8 +1586,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1667,9 +1647,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -1724,8 +1701,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1783,8 +1758,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1853,9 +1826,6 @@ namespace Soulseek.Tests.Unit.Client
                 {
                     reporter(attempted, granted, actual);
                 });
-
-            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -1926,9 +1896,6 @@ namespace Soulseek.Tests.Unit.Client
                 {
                     reporter(attempted, granted, actual);
                 });
-
-            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -2004,9 +1971,6 @@ namespace Soulseek.Tests.Unit.Client
                     reporter(attempted, granted, actual);
                 });
 
-            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2069,9 +2033,6 @@ namespace Soulseek.Tests.Unit.Client
                     await governor(size, CancellationToken.None);
                 });
 
-            var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2120,7 +2081,7 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "DownloadToStreamAsync")]
         [Theory(DisplayName = "DownloadToStreamAsync throws DuplicateTransferException when failing to insert UniqueKeyDictionary"), AutoData]
-        public async Task DownloadToStreamAsync_Throws_DuplicateTransferException_When_Failing_To_Insert_UniqueKeyDictionary(string username, IPEndPoint endpoint, string filename, int token, int size)
+        public async Task DownloadToStreamAsync_Throws_DuplicateTransferException_When_Failing_To_Insert_UniqueKeyDictionary(string username, string filename, int token, int size)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
             var waiter = new Mock<IWaiter>();
@@ -2451,8 +2412,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2514,8 +2473,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2573,8 +2530,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2610,7 +2565,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 _ = await Record.ExceptionAsync(() => s.InvokeMethod<Task<Transfer>>("DownloadToFileAsync", username, filename, localFilename, (long?)size, 0, token, new TransferOptions(), null));
 
-                Assert.Equal(TransferStates.Completed | TransferStates.Aborted, events.Last().Transfer.State);
+                Assert.Equal(TransferStates.Completed | TransferStates.Aborted, events[events.Count - 1].Transfer.State);
             }
         }
 
@@ -2628,8 +2583,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -2692,8 +2645,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2746,8 +2697,6 @@ namespace Soulseek.Tests.Unit.Client
             var transferConn = new Mock<IConnection>();
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -2802,8 +2751,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<Action<int, int, int>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new byte[size]))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -2867,8 +2814,6 @@ namespace Soulseek.Tests.Unit.Client
                 .Returns(Task.FromResult(BitConverter.GetBytes(token)))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -2922,8 +2867,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<Action<int, int, int>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(BitConverter.GetBytes(token)))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -2983,8 +2926,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.ReadAsync(It.IsAny<long>(), It.IsAny<Stream>(), It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<Action<int, int, int>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(BitConverter.GetBytes(token)))
                 .Raises(m => m.DataRead += null, this, new ConnectionDataEventArgs(1, 1));
-
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
 
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
@@ -3354,8 +3295,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -3406,8 +3345,6 @@ namespace Soulseek.Tests.Unit.Client
             transferConn.Setup(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var data = new byte[] { 0x0, 0x1, 0x2, 0x3 };
-
             var waiter = new Mock<IWaiter>();
             waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(response));
@@ -3440,43 +3377,6 @@ namespace Soulseek.Tests.Unit.Client
                 Assert.IsType<SoulseekClientException>(ex);
                 Assert.IsType<Exception>(ex.InnerException);
                 Assert.Equal(expected, ex.InnerException);
-            }
-        }
-
-        private class UnReadableWriteableStream : Stream
-        {
-            public override bool CanRead => false;
-            public override bool CanWrite => false;
-
-            public override bool CanSeek => throw new NotImplementedException();
-
-            public override long Length => throw new NotImplementedException();
-
-            public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-            public override void Flush()
-            {
-                throw new NotImplementedException();
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void SetLength(long value)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                throw new NotImplementedException();
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -52,7 +52,7 @@ namespace Soulseek.Tests.Unit.Client
         [Fact(DisplayName = "Throws ListenException given listen port which can not be bound")]
         public async Task Throws_ListenException_Given_Listen_Port_Which_Can_Not_Be_Bound()
         {
-            var (client, mocks) = GetFixture();
+            var (client, _) = GetFixture();
 
             var port = Mocks.Port;
             var patch = new SoulseekClientOptionsPatch(listenPort: port);
@@ -485,7 +485,7 @@ namespace Soulseek.Tests.Unit.Client
         [Fact(DisplayName = "Updates options")]
         public async Task Updates_Options()
         {
-            var (client, mocks) = GetFixture(new SoulseekClientOptions(
+            var (client, _) = GetFixture(new SoulseekClientOptions(
                 enableListener: false,
                 listenPort: Mocks.Port,
                 enableDistributedNetwork: false,
@@ -637,7 +637,7 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
-        private (SoulseekClient client, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
+        private static (SoulseekClient client, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
         {
             var mocks = new Mocks();
             var client = new SoulseekClient(
@@ -673,7 +673,6 @@ namespace Soulseek.Tests.Unit.Client
             }
 
             private static readonly Random Rng = new Random();
-            public static IPAddress Address => IPAddress.Parse(string.Join(".", Rng.Next(0, 254).ToString(), Rng.Next(0, 254).ToString(), Rng.Next(0, 254).ToString(), Rng.Next(0, 254).ToString()));
             public static int Port => Rng.Next(1024, IPEndPoint.MaxPort);
 
             public Mock<IMessageConnection> ServerConnection { get; } = new Mock<IMessageConnection>();

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -1184,7 +1184,7 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "UploadFromStreamAsync")]
         [Theory(DisplayName = "UploadFromStreamAsync throws DuplicateTransferException when failing to insert UniqueKeyDictionary"), AutoData]
-        public async Task UploadFromStreamAsync_Throws_DuplicateTransferException_If_Unique_Key_Add_Fails(string username, IPEndPoint endpoint, string filename, int token, int size)
+        public async Task UploadFromStreamAsync_Throws_DuplicateTransferException_If_Unique_Key_Add_Fails(string username, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
             var waiter = new Mock<IWaiter>();
@@ -1210,7 +1210,7 @@ namespace Soulseek.Tests.Unit.Client
 
         [Trait("Category", "UploadFromStreamAsync")]
         [Theory(DisplayName = "UploadFromStreamAsync throws DuplicateTransferException when failing to insert UploadDictionary"), AutoData]
-        public async Task UploadFromStreamAsync_Throws_DuplicateTransferException_If_UploadDictionary_Add_Fails(string username, string filename, int token, int size)
+        public async Task UploadFromStreamAsync_Throws_DuplicateTransferException_If_UploadDictionary_Add_Fails(string username, string filename, int token)
         {
             var options = new SoulseekClientOptions(messageTimeout: 5);
             var waiter = new Mock<IWaiter>();
@@ -1282,9 +1282,11 @@ namespace Soulseek.Tests.Unit.Client
 
                 Assert.Null(ex);
 
+                long p;
+
                 var ex2 = Record.Exception(() =>
                 {
-                    var p = stream.Position;
+                    p = stream.Position;
                 });
 
                 Assert.NotNull(ex2);
@@ -3227,11 +3229,6 @@ namespace Soulseek.Tests.Unit.Client
             public override long Length => 0;
 
             public override long Position { get; set; }
-
-            public new void Dispose()
-            {
-                throw new ObjectDisposedException("failed disposal");
-            }
 
             public override ValueTask DisposeAsync()
             {

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/DistributedMessageHandlerTests.cs
@@ -643,7 +643,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Diagnostic.Verify(m => m.Debug(It.Is<string>(s => s.ContainsInsensitive($"Distributed message sent: BranchLevel"))), Times.Once);
         }
 
-        private (DistributedMessageHandler Handler, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
+        private static (DistributedMessageHandler Handler, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
         {
             var mocks = new Mocks(clientOptions);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/PeerMessageHandlerTests.cs
@@ -90,7 +90,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises DownloadDenied on UploadDenied"), AutoData]
         public void Raises_DownloadDenied_On_UploadDenied(string username, string filename, string message)
         {
-            var (handler, mocks) = GetFixture(username);
+            var (_, mocks) = GetFixture(username);
 
             using (var client = new SoulseekClient(options: null))
             {
@@ -112,7 +112,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises DownloadFailed on UploadFailed"), AutoData]
         public void Raises_DownloadFailed_On_UploadFailed(string username, string filename)
         {
-            var (handler, mocks) = GetFixture(username);
+            var (_, mocks) = GetFixture(username);
 
             using (var client = new SoulseekClient(options: null))
             {
@@ -459,7 +459,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             var options = new SoulseekClientOptions(userInfoResolver: (u, i) => { throw new Exception(); });
 
             var defaultResponse = await new SoulseekClientOptions()
-                .UserInfoResolver(null, null).ConfigureAwait(false);
+                .UserInfoResolver(null, null);
 
             var (handler, mocks) = GetFixture(options: options);
 
@@ -1054,7 +1054,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             mocks.Diagnostic.Verify(m => m.Warning(It.Is<string>(s => s.ContainsInsensitive("Error handling peer message")), It.IsAny<Exception>()), Times.Once);
         }
 
-        private (PeerMessageHandler Handler, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
+        private static (PeerMessageHandler Handler, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
         {
             var mocks = new Mocks(options);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Handlers/ServerMessageHandlerTests.cs
@@ -150,9 +150,9 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         public void Raises_PrivateMessageRecieved_Event_On_ServerPrivateMessage(int id, int timeOffset, string username, string message, bool replayed)
         {
             var options = new SoulseekClientOptions(autoAcknowledgePrivateMessages: false);
-            var (handler, mocks) = GetFixture(options);
+            var (handler, _) = GetFixture(options);
 
-            var epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            var epoch = DateTime.UnixEpoch;
             var timestamp = epoch.AddSeconds(timeOffset);
 
             var msg = new MessageBuilder()
@@ -181,7 +181,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises UserCannotConnect event on CannotConnect if username"), AutoData]
         public void Raises_UserCannotConnect_Event_On_CannotConnect_If_Username(int token, string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Server.CannotConnect)
@@ -203,7 +203,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises UserCannotConnect event on CannotConnect if no username"), AutoData]
         public void Does_Not_Raise_UserCannotConnect_Event_On_CannotConnect_If_No_Username(int token)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Server.CannotConnect)
@@ -238,7 +238,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on CannotConnect if UserCannotConnect event is unbound"), AutoData]
         public void Does_Not_Throw_On_CannotConnect_If_UserCannotConnect_Event_Is_Unbound(int token, string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var msg = new MessageBuilder()
                 .WriteCode(MessageCode.Server.CannotConnect)
@@ -280,7 +280,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             int value = new Random().Next();
             ServerInfo result = null;
 
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             handler.ServerInfoReceived += (_, arg) => result = arg;
 
@@ -301,7 +301,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             int value = new Random().Next();
             ServerInfo result = null;
 
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             handler.ServerInfoReceived += (_, arg) => result = arg;
 
@@ -322,7 +322,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             int value = new Random().Next();
             ServerInfo result = null;
 
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             handler.ServerInfoReceived += (_, arg) => result = arg;
 
@@ -366,7 +366,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [InlineData(MessageCode.Server.WishlistInterval)]
         internal void Does_Not_Throw_On_ServerInfo_When_ServerInfoReceived_Is_Unbound(MessageCode.Server code)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var msg = new MessageBuilder()
                 .WriteCode(code)
@@ -444,22 +444,22 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(null, builder.Build());
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.Public, r => r.Name == name);
             }
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.Private, r => r.Name == name);
             }
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.Owned, r => r.Name == name);
             }
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.ModeratedRoomNames, r => r == name);
             }
@@ -503,22 +503,22 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
 
             handler.HandleMessageRead(null, builder.Build());
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.Public, r => r.Name == name);
             }
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.Private, r => r.Name == name);
             }
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.Owned, r => r.Name == name);
             }
 
-            foreach (var (name, userCount) in rooms)
+            foreach (var (name, _) in rooms)
             {
                 Assert.Contains(result.ModeratedRoomNames, r => r == name);
             }
@@ -529,7 +529,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         public void Raises_PrivilegedUserListReceived(string[] names)
         {
             IReadOnlyCollection<string> eventResult = null;
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivilegedUsers)
@@ -556,7 +556,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivilegedUserListReceived when unbound"), AutoData]
         public void Does_Not_Throw_On_PrivilegedUserListReceived_When_Unbound(string[] names)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivilegedUsers)
@@ -579,7 +579,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         public void Raises_ExcludedSearchPhrasesReceived(string[] names)
         {
             IReadOnlyCollection<string> eventResult = null;
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.ExcludedSearchPhrases)
@@ -1069,7 +1069,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises UserStatusChanged on ServerGetStatus"), AutoData]
         public void Raises_UserStatusChanged_On_ServerGetStatus(string username, UserPresence status, bool privileged)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.GetStatus)
@@ -1093,7 +1093,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises UserStatsChanged on GetUserStats"), AutoData]
         public void Raises_UserStatsChanged_On_GetUserStats(string username, int averageSpeed, long uploadCount, int fileCount, int directoryCount)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.GetUserStats)
@@ -1191,7 +1191,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Handles SayInChatRoom"), AutoData]
         public void Handles_SayInChatRoom(string roomName, string username, string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.SayInChatRoom)
@@ -1214,7 +1214,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on SayInChatRoom when RoomMessageReceived is unbound"), AutoData]
         public void Does_Not_Throw_On_SayInChatRoom_When_RoomMessageReceived_Is_Unbound(string roomName, string username, string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.SayInChatRoom)
@@ -1233,7 +1233,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Handles PublicChat"), AutoData]
         public void Handles_PublicChatMessage(string roomName, string username, string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PublicChat)
@@ -1256,7 +1256,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PublicChat if PublicChatMessageReceived is not bound"), AutoData]
         public void Does_Not_Throw_On_PublicChat_If_PublicChatMessageReceived_Is_Not_Bound(string roomName, string username, string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PublicChat)
@@ -1275,7 +1275,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Handles UserJoinedRoom"), AutoData]
         public void Handles_UserJoinedRoom(string roomName, string username, UserData data)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.UserJoinedRoom)
@@ -1309,7 +1309,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on UserJoinedRoom when RoomJoined is unbound"), AutoData]
         public void Does_Not_Throw_On_UserJoinedRoom_When_RoomJoined_Is_Unbound(string roomName, string username, UserData data)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.UserJoinedRoom)
@@ -1334,7 +1334,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Handles UserLeftRoom"), AutoData]
         public void Handles_UserLeftRoom(string roomName, string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.UserLeftRoom)
@@ -1355,7 +1355,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on UserLeftRoom when RoomLeft is unbound"), AutoData]
         public void Does_Not_Throw_On_UserLeftRoom_When_RoomLeft_Is_Unbound(string roomName, string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.UserLeftRoom)
@@ -1373,7 +1373,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Fact(DisplayName = "Raises KickedFromServer on KickedFromServer")]
         public void Raises_KickedFromServer_On_KickedFromServer()
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.KickedFromServer)
@@ -1392,7 +1392,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Fact(DisplayName = "Does not throw on KickedFromServer when KickedFromServer is unbound")]
         public void Does_Not_Throw_On_KickedFromServer_When_KickedFromServer_Is_Unbound()
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.KickedFromServer)
@@ -1407,7 +1407,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivilegeNotificationReceived on AddPrivilegedUser"), AutoData]
         public void Raises_PrivilegeNotificationReceived_On_AddPrivilegedUser(string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.AddPrivilegedUser)
@@ -1430,7 +1430,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on AddPrivilegedUser when PrivilegeNotificationReceived is unbound"), AutoData]
         public void Does_Not_Throw_On_AddPrivilegedUser_When_PrivilegeNotificationReceived_Is_Unbound(string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.AddPrivilegedUser)
@@ -1446,7 +1446,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivilegeNotificationReceived on NotifyPrivileges"), AutoData]
         public void Raises_PrivilegeNotificationReceived_On_NotifyPrivileges(string username, int id)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.NotifyPrivileges)
@@ -1470,7 +1470,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Fact(DisplayName = "Raises DistributedNetworkReset on DistributedReset")]
         public void Raises_DistributedNetworkReset_On_DistributedReset()
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.DistributedReset)
@@ -1581,7 +1581,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Handles GlobalAdminMessage"), AutoData]
         public void Handles_GlobalAdminMessage(string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.GlobalAdminMessage)
@@ -1600,7 +1600,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on GlobalAdminMessage when GlobalAdminMessage is unbound"), AutoData]
         public void Does_Not_Throw_On_GlobalAdminMessage_When_GlobalAdminMessage_Is_Unbound(string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.GlobalAdminMessage)
@@ -1647,7 +1647,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivateRoomMembershipAdded on PrivateRoomAdded"), AutoData]
         public void Raises_PrivateRoomMembershipAdded_On_PrivateRoomAdded(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomAdded)
@@ -1667,7 +1667,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivateRoomAdded when PrivateRoomMembershipAdded is unbound"), AutoData]
         public void Does_Not_Throw_On_PrivateRoomAdded_When_PrivateRoomMembershipAdded_Is_Unbound(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomAdded)
@@ -1683,7 +1683,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivateRoomModeratorAdded on PrivateRoomOperatorAdded"), AutoData]
         public void Raises_PrivateRoomModerationAdded_On_PrivateRoomOperatorAdded(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOperatorAdded)
@@ -1703,7 +1703,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivateRoomOperatorAdded when PrivateRoomModerationAdded is unbound"), AutoData]
         public void Does_Not_Throw_On_PrivateRoomOperatorAdded_When_PrivateRoomModerationAdded_Is_Unbound(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOperatorAdded)
@@ -1719,7 +1719,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivateRoomMembershipRemoved on PrivateRoomRemoved"), AutoData]
         public void Raises_PrivateRoomMembershipRemoved_On_PrivateRoomRemoved(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomRemoved)
@@ -1739,7 +1739,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivateRoomRemoved when PrivateRoomMembershipRemoved is unbound"), AutoData]
         public void Does_Not_Throw_On_PrivateRoomRemoved_When_PrivateRoomMembershipRemoved_Is_Unbound(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomRemoved)
@@ -1787,7 +1787,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivateRoomModerationRemoved on PrivateRoomOperatorRemoved"), AutoData]
         public void Raises_PrivateRoomModerationRemoved_On_PrivateRoomOperatorRemoved(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOperatorRemoved)
@@ -1807,7 +1807,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivateRoomOperatorRemoved when PrivateRoomModerationRemoved is unbound"), AutoData]
         public void Does_Not_Throw_On_PrivateRoomOperatorRemoved_When_PrivateRoomModerationRemoved_Is_Unbound(string roomName)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOperatorRemoved)
@@ -1839,7 +1839,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivateRoomUserListReceived on PrivateRoomUsers"), AutoData]
         public void Raises_PrivateRoomUserListReceived_On_PrivateRoomUsers(string roomName, List<string> users)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomUsers)
@@ -1870,7 +1870,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivateRoomUsers when PrivateRoomUserListReceived is unbound"), AutoData]
         public void Does_Not_Throw_On_PrivateRoomUsers_When_PrivateRoomUserListReceived(string roomName, List<string> users)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomUsers)
@@ -1890,7 +1890,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises PrivateRoomModeratorListReceived on PrivateRoomOwned"), AutoData]
         public void Raises_PrivateRoomModeratedUserListReceived_On_PrivateRoomOwned(string roomName, List<string> users)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOwned)
@@ -1921,7 +1921,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on PrivateRoomOwned when PrivateRoomModeratedUserListReceived is unbound"), AutoData]
         public void Does_Not_Throw_On_PrivateRoomOwned_When_PrivateRoomModeratedUserListRecieved_Is_Unbound(string roomName, List<string> users)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.PrivateRoomOwned)
@@ -2234,7 +2234,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         public void Does_Not_Throw_When_Handling_SearchRequest_If_SearchResponseResolver_Is_Null(string username, int token, string query)
         {
             var options = new SoulseekClientOptions(searchResponseResolver: null);
-            var (handler, mocks) = GetFixture(options);
+            var (handler, _) = GetFixture(options);
 
             var conn = new Mock<IMessageConnection>();
 
@@ -2262,7 +2262,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises RoomTickerListReceived on RoomTickers"), AutoData]
         public void Raises_RoomTickerListRecieved_On_RoomTickers(string roomName, List<RoomTicker> tickers)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.RoomTickers)
@@ -2297,7 +2297,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on RoomTickers when RoomTickerListReceived is unbound"), AutoData]
         public void Does_Not_Throw_On_RoomTickers_When_RoomTickerListReceived_Is_Unbound(string roomName, List<RoomTicker> tickers)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var builder = new MessageBuilder()
                 .WriteCode(MessageCode.Server.RoomTickers)
@@ -2322,7 +2322,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises RoomTickerAdded on RoomTickerAdd"), AutoData]
         public void Raises_RoomTickerAdded_On_RoomTickerAdd(string roomName, string username, string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.RoomTickerAdd)
@@ -2346,7 +2346,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on RoomTickerAdd when RoomTickerAdded is unbound"), AutoData]
         public void Does_Not_Throw_On_RoomTickerAdd_When_RoomTickerAdded_Is_Unbound(string roomName, string username, string msg)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.RoomTickerAdd)
@@ -2364,7 +2364,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Raises RoomTickerRemoved on RoomTickerRemove"), AutoData]
         public void Raises_RoomTickerRemoved_On_RoomTickerRemove(string roomName, string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.RoomTickerRemove)
@@ -2386,7 +2386,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
         [Theory(DisplayName = "Does not throw on RoomTickerRemove when RoomTickerRemoved is unbound"), AutoData]
         public void Does_Not_Throw_On_RoomTickerRemove_When_RoomTickerRemoved_Is_Unbound(string roomName, string username)
         {
-            var (handler, mocks) = GetFixture();
+            var (handler, _) = GetFixture();
 
             var message = new MessageBuilder()
                 .WriteCode(MessageCode.Server.RoomTickerRemove)
@@ -2399,7 +2399,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
             Assert.Null(ex);
         }
 
-        private byte[] GetServerSearchRequest(string username, int token, string query)
+        private static byte[] GetServerSearchRequest(string username, int token, string query)
         {
             return new MessageBuilder()
                 .WriteCode(MessageCode.Server.FileSearch)
@@ -2409,7 +2409,7 @@ namespace Soulseek.Tests.Unit.Messaging.Handlers
                 .Build();
         }
 
-        private (ServerMessageHandler Handler, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
+        private static (ServerMessageHandler Handler, Mocks Mocks) GetFixture(SoulseekClientOptions clientOptions = null)
         {
             var mocks = new Mocks(clientOptions);
 

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/BrowseResponseFactoryTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/BrowseResponseFactoryTests.cs
@@ -483,7 +483,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(2, m.ReadInteger());
         }
 
-        private MessageBuilder BuildDirectory(MessageBuilder builder, Directory dir)
+        private static MessageBuilder BuildDirectory(MessageBuilder builder, Directory dir)
         {
             builder
                 .WriteString(dir.Name)

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Peer/FolderContentsResponseTests.cs
@@ -319,7 +319,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(4, m.ReadInteger());
         }
 
-        private MessageBuilder BuildDirectory(MessageBuilder builder, Directory dir)
+        private static MessageBuilder BuildDirectory(MessageBuilder builder, Directory dir)
         {
             builder
                 .WriteString(dir.Name)

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/LoginResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/LoginResponseTests.cs
@@ -25,7 +25,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
 
     public class LoginResponseTests
     {
-        private string RandomGuid => Guid.NewGuid().ToString();
+        private static string RandomGuid { get; } = Guid.NewGuid().ToString();
         private Random Random { get; } = new Random();
 
         [Trait("Category", "Instantiation")]

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/PrivateMessageNotificationTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/PrivateMessageNotificationTests.cs
@@ -74,7 +74,7 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         [Theory(DisplayName = "Parse returns expected data"), AutoData]
         public void Parse_Returns_Expected_Data(int id, int timeOffset, string username, string message)
         {
-            var epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            var epoch = DateTime.UnixEpoch;
             var timestamp = epoch.AddSeconds(timeOffset);
 
             var msg = new MessageBuilder()

--- a/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/DistributedConnectionManagerTests.cs
@@ -522,7 +522,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "BroadcastMessageAsync broadcasts message"), AutoData]
         public async Task BroadcastMessageAsync_Broadcasts_Message(byte[] bytes)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var c1 = new Mock<IMessageConnection>();
             c1.Setup(m => m.State)
@@ -549,7 +549,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "BroadcastMessageAsync sets AverageBroadcastLatency"), AutoData]
         public async Task BroadcastMessageAsync_Sets_AverageBroadcastLatency(byte[] bytes)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var c1 = new Mock<IMessageConnection>();
             c1.Setup(m => m.State)
@@ -572,7 +572,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "BroadcastMessageAsync updates AverageBroadcastLatency"), AutoData]
         public async Task BroadcastMessageAsync_Updates_AverageBroadcastLatency(byte[] bytes)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var c1 = new Mock<IMessageConnection>();
             c1.Setup(m => m.State)
@@ -595,7 +595,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "BroadcastMessageAsync does not broadcast message to unconnected connections"), AutoData]
         public async Task BroadcastMessageAsync_Does_Not_Broadcast_Message_To_Unconnected_Connections(byte[] bytes)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var c1 = new Mock<IMessageConnection>();
             c1.Setup(m => m.State)
@@ -622,7 +622,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "BroadcastMessageAsync disconnects connection if write throws"), AutoData]
         public async Task BroadcastMessageAsync_Disconnects_Connection_If_Write_Throws(byte[] bytes)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var c1 = new Mock<IMessageConnection>();
             c1.Setup(m => m.State)
@@ -646,7 +646,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "BroadcastMessageAsync does not throw if connection is null"), AutoData]
         public async Task BroadcastMessageAsync_Does_Not_Throw_If_Connection_Is_Null(byte[] bytes)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var c1 = new Mock<IMessageConnection>();
 
@@ -3205,7 +3205,7 @@ namespace Soulseek.Tests.Unit.Network
             using (manager)
             {
                 var semaphore = manager.GetProperty<SemaphoreSlim>("ParentSyncRoot");
-                semaphore.Wait();
+                await semaphore.WaitAsync();
 
                 await manager.AddParentConnectionAsync(candidates);
             }
@@ -3791,7 +3791,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "WaitForParentCandidateConnection_MessageRead ignores all other messages"), AutoData]
         internal void WaitForParentCandidateConnection_MessageRead_Ignores_All_Other_Messages(string username, IPEndPoint endpoint)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
 
@@ -3809,7 +3809,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "WaitForParentCandidateConnection_MessageRead disconnects and disposes on exception"), AutoData]
         internal void WaitForParentCandidateConnection_MessageRead_Disconnects_And_Disposes_On_Exception(string username, IPEndPoint endpoint)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var conn = GetMessageConnectionMock(username, endpoint);
 
@@ -3986,7 +3986,7 @@ namespace Soulseek.Tests.Unit.Network
             mocks.ServerConnection.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
-        private (DistributedConnectionManager Manager, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
+        private static (DistributedConnectionManager Manager, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
         {
             var mocks = new Mocks(options);
 
@@ -4003,7 +4003,7 @@ namespace Soulseek.Tests.Unit.Network
             return (handler, mocks);
         }
 
-        private Mock<IMessageConnection> GetMessageConnectionMock(string username, IPEndPoint endpoint)
+        private static Mock<IMessageConnection> GetMessageConnectionMock(string username, IPEndPoint endpoint)
         {
             var mock = new Mock<IMessageConnection>();
             mock.Setup(m => m.Username).Returns(username);
@@ -4012,7 +4012,7 @@ namespace Soulseek.Tests.Unit.Network
             return mock;
         }
 
-        private Mock<IConnection> GetConnectionMock(IPEndPoint endpoint)
+        private static Mock<IConnection> GetConnectionMock(IPEndPoint endpoint)
         {
             var mock = new Mock<IConnection>();
             mock.Setup(m => m.IPEndPoint)

--- a/tests/Soulseek.Tests.Unit/Network/ListenerHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/ListenerHandlerTests.cs
@@ -430,7 +430,7 @@ namespace Soulseek.Tests.Unit.Network
             mocks.SearchResponder.Verify(m => m.TryRespondAsync(token), Times.Once);
         }
 
-        private (ListenerHandler Handler, Mocks Mocks) GetFixture(IPEndPoint endpoint, SoulseekClientOptions clientOptions = null)
+        private static (ListenerHandler Handler, Mocks Mocks) GetFixture(IPEndPoint endpoint, SoulseekClientOptions clientOptions = null)
         {
             var mocks = new Mocks(clientOptions);
 

--- a/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/PeerConnectionManagerTests.cs
@@ -1368,7 +1368,7 @@ namespace Soulseek.Tests.Unit.Network
         internal void MessageConnectionProvisional_Disconnected_Disposes_Connection(string message)
         {
             var conn = new Mock<IMessageConnection>();
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             using (manager)
             {
@@ -1391,7 +1391,7 @@ namespace Soulseek.Tests.Unit.Network
             var dict = new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
             dict.GetOrAdd(username, new Lazy<Task<IMessageConnection>>(() => Task.FromResult(conn.Object)));
 
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             manager.SetProperty("MessageConnectionDictionary", dict);
 
@@ -1449,7 +1449,7 @@ namespace Soulseek.Tests.Unit.Network
 
             var dict = new ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>();
 
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             manager.SetProperty("MessageConnectionDictionary", dict);
 
@@ -2121,7 +2121,7 @@ namespace Soulseek.Tests.Unit.Network
                 .Returns(conn.Object);
 
             using (manager)
-            using (var c = await manager.GetOrAddMessageConnectionAsync(ctpr).ConfigureAwait(false))
+            using (var c = await manager.GetOrAddMessageConnectionAsync(ctpr))
             {
                 var dict = manager.GetProperty<ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>>("MessageConnectionDictionary");
 
@@ -2130,7 +2130,7 @@ namespace Soulseek.Tests.Unit.Network
 
                 Assert.True(dict.TryGetValue(username, out var record));
 
-                using (var cached = await record.Value.ConfigureAwait(false))
+                using (var cached = await record.Value)
                 {
                     Assert.Equal(conn.Object, cached);
                 }
@@ -2152,7 +2152,7 @@ namespace Soulseek.Tests.Unit.Network
                 var dict = manager.GetProperty<ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>>("MessageConnectionDictionary");
                 dict.TryAdd(username, new Lazy<Task<IMessageConnection>>(() => Task.FromResult(conn.Object)));
 
-                var c = await manager.GetOrAddMessageConnectionAsync(ctpr).ConfigureAwait(false);
+                var c = await manager.GetOrAddMessageConnectionAsync(ctpr);
 
                 Assert.Equal(conn.Object, c);
 
@@ -2413,7 +2413,7 @@ namespace Soulseek.Tests.Unit.Network
             direct.Setup(m => m.Type)
                 .Returns(ConnectionTypes.Direct);
 
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             var dict = manager.GetProperty<ConcurrentDictionary<string, Lazy<Task<IMessageConnection>>>>("MessageConnectionDictionary");
             dict.TryAdd(username, new Lazy<Task<IMessageConnection>>(Task.FromResult(direct.Object)));
@@ -2889,7 +2889,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "TryInvalidateMessageConnectionCache removes corresponding entry from MessageConnectionDictionary"), AutoData]
         internal void TryInvalidateMessageConnectionCache_Removes_Corresponding_Entry_From_MessageConnectionDictionary(string username)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             using (manager)
             {
@@ -2908,7 +2908,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "TryInvalidateMessageConnectionCache returns true if cache is invalidated"), AutoData]
         internal void TryInvalidateMessageConnectionCache_Returns_True_If_Cache_Is_Invalidated(string username)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             using (manager)
             {
@@ -2927,7 +2927,7 @@ namespace Soulseek.Tests.Unit.Network
         [Theory(DisplayName = "TryInvalidateMessageConnectionCache returns false if cache is missed"), AutoData]
         internal void TryInvalidateMessageConnectionCache_Returns_False_If_Cache_Is_Missed(string username)
         {
-            var (manager, mocks) = GetFixture();
+            var (manager, _) = GetFixture();
 
             using (manager)
             {
@@ -2968,7 +2968,7 @@ namespace Soulseek.Tests.Unit.Network
             }
         }
 
-        private (PeerConnectionManager Manager, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
+        private static (PeerConnectionManager Manager, Mocks Mocks) GetFixture(string username = null, IPEndPoint endpoint = null, SoulseekClientOptions options = null)
         {
             var mocks = new Mocks(options);
 
@@ -2985,7 +2985,7 @@ namespace Soulseek.Tests.Unit.Network
             return (handler, mocks);
         }
 
-        private Mock<IMessageConnection> GetMessageConnectionMock(string username, IPEndPoint endpoint)
+        private static Mock<IMessageConnection> GetMessageConnectionMock(string username, IPEndPoint endpoint)
         {
             var mock = new Mock<IMessageConnection>();
             mock.Setup(m => m.Username).Returns(username);
@@ -2994,7 +2994,7 @@ namespace Soulseek.Tests.Unit.Network
             return mock;
         }
 
-        private Mock<IConnection> GetConnectionMock(IPEndPoint endpoint)
+        private static Mock<IConnection> GetConnectionMock(IPEndPoint endpoint)
         {
             var mock = new Mock<IConnection>();
             mock.Setup(m => m.IPEndPoint)

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ConnectionTests.cs
@@ -32,13 +32,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
     public class ConnectionTests
     {
-        private readonly Action<string> output;
-
-        public ConnectionTests(ITestOutputHelper outputHelper)
-        {
-            output = (s) => outputHelper.WriteLine(s);
-        }
-
         [Trait("Category", "Instantiation")]
         [Theory(DisplayName = "Instantiates properly"), AutoData]
         public void Instantiates_Properly(IPEndPoint endpoint)
@@ -311,8 +304,11 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             {
                 var t = new Mock<ITcpClient>();
                 t.Setup(m => m.Client).Returns(socket);
+#pragma warning disable S2925 // "Thread.Sleep" should not be used in tests
+
                 t.Setup(m => m.ConnectAsync(It.IsAny<IPAddress>(), It.IsAny<int>()))
                     .Returns(Task.Run(() => Thread.Sleep(10000)));
+#pragma warning restore S2925 // "Thread.Sleep" should not be used in tests
 
                 var o = new ConnectionOptions(connectTimeout: 0);
                 using (var c = new Connection(endpoint, options: o, tcpClient: t.Object))
@@ -337,8 +333,11 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             {
                 var t = new Mock<ITcpClient>();
                 t.Setup(m => m.Client).Returns(socket);
+#pragma warning disable S2925 // "Thread.Sleep" should not be used in tests
+
                 t.Setup(m => m.ConnectAsync(It.IsAny<IPAddress>(), It.IsAny<int>()))
                     .Returns(Task.Run(() => Thread.Sleep(10000)));
+#pragma warning restore S2925 // "Thread.Sleep" should not be used in tests
 
                 var o = new ConnectionOptions(connectTimeout: 10000);
 
@@ -348,7 +347,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                     using (var cts = new CancellationTokenSource())
                     {
-                        cts.Cancel();
+                        await cts.CancelAsync();
                         ex = await Record.ExceptionAsync(() => c.ConnectAsync(cts.Token));
                     }
 

--- a/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
@@ -25,7 +25,6 @@ namespace Soulseek.Tests.Unit
     using AutoFixture.Xunit2;
     using Moq;
     using Soulseek.Diagnostics;
-    using Soulseek.Messaging.Messages;
     using Soulseek.Network;
     using Xunit;
 
@@ -87,7 +86,7 @@ namespace Soulseek.Tests.Unit
         public void TryDiscard_Removes_Token_From_Cache(int responseToken, string username, int token, string query, SearchResponse searchResponse)
         {
             var cache = GetCacheMock();
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             (string Username, int Token, string Query, SearchResponse SearchResponse) record = (username, token, query, searchResponse);
 
@@ -106,7 +105,7 @@ namespace Soulseek.Tests.Unit
         public void TryDiscard_Raises_ResponseDeliveryFailed_When_Discarding(int responseToken, string username, int token, string query, SearchResponse searchResponse)
         {
             var cache = GetCacheMock();
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             (string Username, int Token, string Query, SearchResponse SearchResponse) record = (username, token, query, searchResponse);
 
@@ -131,7 +130,7 @@ namespace Soulseek.Tests.Unit
         public void TryDiscard_Does_Not_Throw_Raising_Unbound_ResponseDeliveryFailed_When_Discarding(int responseToken, string username, int token, string query, SearchResponse searchResponse)
         {
             var cache = GetCacheMock();
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             (string Username, int Token, string Query, SearchResponse SearchResponse) record = (username, token, query, searchResponse);
 
@@ -167,7 +166,7 @@ namespace Soulseek.Tests.Unit
         public void TryDiscard_Returns_False_If_Not_Cached(int responseToken)
         {
             var cache = GetCacheMock();
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             (string Username, int Token, string Query, SearchResponse SearchResponse) record = default;
 
@@ -186,7 +185,7 @@ namespace Soulseek.Tests.Unit
         public void TryDiscard_Returns_False_If_Cache_Throws(int responseToken)
         {
             var cache = GetCacheMock();
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             (string Username, int Token, string Query, SearchResponse SearchResponse) record = default;
 
@@ -523,7 +522,7 @@ namespace Soulseek.Tests.Unit
             cache.Setup(m => m.TryRemove(responseToken, out record))
                 .Returns(false);
 
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             var responded = await responder.TryRespondAsync(responseToken);
 
@@ -540,7 +539,7 @@ namespace Soulseek.Tests.Unit
             cache.Setup(m => m.TryRemove(responseToken, out record))
                 .Throws(new Exception());
 
-            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseCache: cache.Object));
 
             var responded = await responder.TryRespondAsync(responseToken);
 
@@ -786,7 +785,7 @@ namespace Soulseek.Tests.Unit
             Assert.Null(ex);
         }
 
-        private (SearchResponder SearchResponder, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)
+        private static (SearchResponder SearchResponder, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)
         {
             var mocks = new Mocks(options);
 
@@ -797,7 +796,7 @@ namespace Soulseek.Tests.Unit
             return (responder, mocks);
         }
 
-        private Mock<ISearchResponseCache> GetCacheMock() => new Mock<ISearchResponseCache>();
+        private static Mock<ISearchResponseCache> GetCacheMock() => new Mock<ISearchResponseCache>();
 
         private class Mocks
         {

--- a/tests/Soulseek.Tests.Unit/SearchScopeTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchScopeTests.cs
@@ -98,7 +98,10 @@ namespace Soulseek.Tests.Unit
         {
             SearchScope s = null;
 
+#pragma warning disable S3878 // Arrays should not be created for params parameters
+
             var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.Room, new string[] { null }));
+#pragma warning restore S3878 // Arrays should not be created for params parameters
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);
@@ -111,7 +114,7 @@ namespace Soulseek.Tests.Unit
         {
             SearchScope s = null;
 
-            var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.Room, new string[] { string.Empty }));
+            var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.Room, string.Empty));
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);
@@ -124,7 +127,7 @@ namespace Soulseek.Tests.Unit
         {
             SearchScope s = null;
 
-            var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.Room, new[] { "one", "two" }));
+            var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.Room, "one", "two"));
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);
@@ -165,7 +168,10 @@ namespace Soulseek.Tests.Unit
         {
             SearchScope s = null;
 
+#pragma warning disable S3878 // Arrays should not be created for params parameters
+
             var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.User, new string[] { "one", null }));
+#pragma warning restore S3878 // Arrays should not be created for params parameters
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);
@@ -178,7 +184,10 @@ namespace Soulseek.Tests.Unit
         {
             SearchScope s = null;
 
+#pragma warning disable S3878 // Arrays should not be created for params parameters
+
             var ex = Record.Exception(() => s = new SearchScope(SearchScopeType.User, new string[] { "one", string.Empty }));
+#pragma warning restore S3878 // Arrays should not be created for params parameters
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentException>(ex);

--- a/tests/Soulseek.Tests.Unit/Soulseek.Tests.Unit.csproj
+++ b/tests/Soulseek.Tests.Unit/Soulseek.Tests.Unit.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NoWarn>CS0618,SA1615,SA1611</NoWarn>
+    <NoWarn>CS0618,SA1615,SA1611,S3881</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Soulseek.Tests.Unit/TransferInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/TransferInternalTests.cs
@@ -137,7 +137,7 @@ namespace Soulseek.Tests.Unit
         {
             var d = new TransferInternal(TransferDirection.Download, string.Empty, string.Empty, 0);
 
-            var s = new DateTime(2019, 4, 25);
+            var s = new DateTime(2019, 4, 25, 0, 0, 0, DateTimeKind.Utc);
 
             d.SetProperty("StartTime", s);
 
@@ -150,8 +150,8 @@ namespace Soulseek.Tests.Unit
         {
             var d = new TransferInternal(TransferDirection.Download, string.Empty, string.Empty, 0);
 
-            var s = new DateTime(2019, 4, 25);
-            var e = new DateTime(2019, 4, 26);
+            var s = new DateTime(2019, 4, 25, 0, 0, 0, DateTimeKind.Utc);
+            var e = new DateTime(2019, 4, 26, 0, 0, 0, DateTimeKind.Utc);
 
             d.SetProperty("StartTime", s);
             d.SetProperty("EndTime", e);

--- a/tests/Soulseek.Tests.Unit/TransferTests.cs
+++ b/tests/Soulseek.Tests.Unit/TransferTests.cs
@@ -122,7 +122,7 @@ namespace Soulseek.Tests.Unit
         {
             var i = new TransferInternal(TransferDirection.Download, string.Empty, string.Empty, 0);
 
-            var s = new DateTime(2019, 4, 25);
+            var s = new DateTime(2019, 4, 25, 0, 0, 0, DateTimeKind.Utc);
 
             i.SetProperty("StartTime", s);
 
@@ -137,8 +137,8 @@ namespace Soulseek.Tests.Unit
         {
             var i = new TransferInternal(TransferDirection.Download, string.Empty, string.Empty, 0);
 
-            var s = new DateTime(2019, 4, 25);
-            var e = new DateTime(2019, 4, 26);
+            var s = new DateTime(2019, 4, 25, 0, 0, 0, DateTimeKind.Utc);
+            var e = new DateTime(2019, 4, 26, 0, 0, 0, DateTimeKind.Utc);
 
             i.SetProperty("StartTime", s);
             i.SetProperty("EndTime", e);


### PR DESCRIPTION
I can't recall when these all popped up.  They are making it really difficult to review test output, though.

I'm not expecting any functionality change or broken tests.