### PR TITLE
Add experimental flag to raise events asynchronously

### DIFF
--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -639,8 +639,19 @@ namespace Soulseek.Network.Tcp
 
                     reporter?.Invoke(bytesToRead, bytesGranted, bytesRead);
 
-                    Interlocked.CompareExchange(ref DataRead, null, null)?
-                        .Invoke(this, new ConnectionDataEventArgs(totalBytesRead, length));
+                    if (SoulseekClient.RaiseEventsAsynchronously)
+                    {
+                        Task.Run(() =>
+                        {
+                            Interlocked.CompareExchange(ref DataRead, null, null)?
+                                .Invoke(this, new ConnectionDataEventArgs(totalBytesRead, length));
+                        }, cancellationToken).Forget();
+                    }
+                    else
+                    {
+                        Interlocked.CompareExchange(ref DataRead, null, null)?
+                            .Invoke(this, new ConnectionDataEventArgs(totalBytesRead, length));
+                    }
 
                     ResetInactivityTime();
                 }
@@ -740,8 +751,19 @@ namespace Soulseek.Network.Tcp
 
                     reporter?.Invoke(bytesToRead, bytesGranted, bytesRead);
 
-                    Interlocked.CompareExchange(ref DataWritten, null, null)?
-                        .Invoke(this, new ConnectionDataEventArgs(totalBytesWritten, length));
+                    if (SoulseekClient.RaiseEventsAsynchronously)
+                    {
+                        Task.Run(() =>
+                        {
+                            Interlocked.CompareExchange(ref DataWritten, null, null)?
+                                .Invoke(this, new ConnectionDataEventArgs(totalBytesWritten, length));
+                        }, cancellationToken).Forget();
+                    }
+                    else
+                    {
+                        Interlocked.CompareExchange(ref DataWritten, null, null)?
+                            .Invoke(this, new ConnectionDataEventArgs(totalBytesWritten, length));
+                    }
 
                     ResetInactivityTime();
                 }

--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -94,6 +94,7 @@ namespace Soulseek
         /// <param name="placeInQueueResolver">
         ///     The delegate used to resolve the <see cref="int"/> response for an incoming request.
         /// </param>
+        /// <param name="raiseEventsAsynchronously">(Experimental!) Raise events asynchronously to improve parallelism.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when the value supplied for <paramref name="listenPort"/> is not between 1024 and 65535.
         /// </exception>
@@ -131,7 +132,8 @@ namespace Soulseek
             Func<string, IPEndPoint, int, string, Task<IEnumerable<Directory>>> directoryContentsResolver = null,
             Func<string, IPEndPoint, Task<UserInfo>> userInfoResolver = null,
             Func<string, IPEndPoint, string, Task> enqueueDownload = null,
-            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResolver = null)
+            Func<string, IPEndPoint, string, Task<int?>> placeInQueueResolver = null,
+            bool raiseEventsAsynchronously = false)
         {
             EnableListener = enableListener;
             ListenIPAddress = listenIPAddress ?? IPAddress.Any;
@@ -203,6 +205,8 @@ namespace Soulseek
             UserInfoResolver = userInfoResolver ?? defaultUserInfoResolver;
             EnqueueDownload = enqueueDownload ?? defaultEnqueueDownload;
             PlaceInQueueResolver = placeInQueueResolver ?? defaultPlaceInQueueResolver;
+
+            RaiseEventsAsynchronously = raiseEventsAsynchronously;
         }
 
         /// <summary>
@@ -375,6 +379,11 @@ namespace Soulseek
         ///     Gets the delegate used to resolve the <see cref="UserInfo"/> for an incoming request. (Default = a blank/zeroed response).
         /// </summary>
         public Func<string, IPEndPoint, Task<UserInfo>> UserInfoResolver { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether to raise events asynchronously.
+        /// </summary>
+        public bool RaiseEventsAsynchronously { get; }
 
         /// <summary>
         ///     Creates a clone of this instance with the substitutions in the specified <paramref name="patch"/> applied.

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>8.1.2</Version>
+    <Version>8.2.0</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -102,6 +102,8 @@ namespace Soulseek
 #pragma warning restore S3427 // Method overloads with default parameter values should not overlap
             Options = options ?? new SoulseekClientOptions();
 
+            RaiseEventsAsynchronously = Options.RaiseEventsAsynchronously;
+
             SearchSemaphore = new SemaphoreSlim(initialCount: Options.MaximumConcurrentSearches, maxCount: Options.MaximumConcurrentSearches);
 
             GlobalDownloadSemaphore = new SemaphoreSlim(initialCount: Options.MaximumConcurrentDownloads, maxCount: Options.MaximumConcurrentDownloads);
@@ -442,6 +444,11 @@ namespace Soulseek
         /// </summary>
         /// <remarks>Add a user to the server watch list with <see cref="WatchUserAsync(string, CancellationToken?)"/>.</remarks>
         public event EventHandler<UserStatus> UserStatusChanged;
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to raise events asynchronously.
+        /// </summary>
+        public static bool RaiseEventsAsynchronously { get; set; }
 
         /// <summary>
         ///     Gets the unresolved server address.


### PR DESCRIPTION
I'm troubleshooting performance issues in slskd and in doing so have realized that when a single peer enqueues a ton of files (I'm testing with >700), they enqueue very slowly, to the extent that the last several hundred time out because the enqueue request has not been answered after 30(!!!) seconds.

This is happening because the `MessageRead` event is raised inside of the loop that reads messages from the peer connection and fires them off to be handled, meaning precisely 1 file is enqueued at a time, synchronously.

This is obviously terrible, and I'm very surprised it took me 6+ years to see it.

This PR adds a new flag to options, `RaiseEventsAsynchronously` which, when set, wraps the events associated with TCP connections in `Task.Run`, allowing them to run in parallel(ish, depending on the thread pool yadda yadda).

Assuming all works fine (I tested with the example app in this repo and it works great) I will follow up and remove this flag and make this new behavior default.