### PR TITLE
Remove guard preventing uploads of 0 byte files

### DIFF
--- a/src/Network/MessageConnection.cs
+++ b/src/Network/MessageConnection.cs
@@ -183,13 +183,6 @@ namespace Soulseek.Network
 
         private async Task ReadContinuouslyAsync()
         {
-            if (SoulseekClient.RaiseEventsAsynchronously)
-            {
-                Console.WriteLine("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-                Console.WriteLine("Raising events asynchronously! This is experimental! YMMV!");
-                Console.WriteLine("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-            }
-
             if (ReadingContinuously)
             {
                 return;

--- a/src/Network/MessageConnection.cs
+++ b/src/Network/MessageConnection.cs
@@ -266,8 +266,19 @@ namespace Soulseek.Network
         {
             await WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
 
-            Interlocked.CompareExchange(ref MessageWritten, null, null)?
-                .Invoke(this, new MessageEventArgs(bytes));
+            if (SoulseekClient.RaiseEventsAsynchronously)
+            {
+                Task.Run(() =>
+                {
+                    Interlocked.CompareExchange(ref MessageWritten, null, null)?
+                        .Invoke(this, new MessageEventArgs(bytes));
+                }, cancellationToken).Forget();
+            }
+            else
+            {
+                Interlocked.CompareExchange(ref MessageWritten, null, null)?
+                    .Invoke(this, new MessageEventArgs(bytes));
+            }
         }
     }
 }

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -32,7 +32,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>8.2.0</Version>
+    <Version>8.2.1</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2650,6 +2650,11 @@ namespace Soulseek
                 throw new ArgumentException("The remote filename must not be a null or empty string, or one consisting only of whitespace", nameof(remoteFilename));
             }
 
+            if (size < 0)
+            {
+                throw new ArgumentException("The requested size must be greater than or equal to zero", nameof(size));
+            }
+
             if (inputStreamFactory == null)
             {
                 throw new ArgumentNullException(nameof(inputStreamFactory), "The specified input stream factory is null");

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2650,11 +2650,6 @@ namespace Soulseek
                 throw new ArgumentException("The remote filename must not be a null or empty string, or one consisting only of whitespace", nameof(remoteFilename));
             }
 
-            if (size <= 0)
-            {
-                throw new ArgumentException("The requested size must be greater than or equal to zero", nameof(size));
-            }
-
             if (inputStreamFactory == null)
             {
                 throw new ArgumentNullException(nameof(inputStreamFactory), "The specified input stream factory is null");

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -140,8 +140,25 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "UploadAsync")]
+        [Fact(DisplayName = "UploadAsync stream does not throw given zero size")]
+        public async Task UploadAsync_Stream_Does_Not_Throw_Given_Zero_Size()
+        {
+            using (var stream = new MemoryStream())
+            using (var s = new SoulseekClient())
+            {
+                var zeroSizeArgument = 0;
+                var ex = await Record.ExceptionAsync(() => s.UploadAsync("username", "filename", zeroSizeArgument, (_) => Task.FromResult((Stream)stream)));
+
+                // this only works because the check for connection state comes after the size guard clause
+                // if that moves this test will break and/or not test the size guard
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+                Assert.Contains("Connected", ex.Message, StringComparison.InvariantCultureIgnoreCase);
+            }
+        }
+
+        [Trait("Category", "UploadAsync")]
         [Theory(DisplayName = "UploadAsync stream throws ArgumentException bad size")]
-        [InlineData(0)]
         [InlineData(-1)]
         [InlineData(-12413)]
         public async Task UploadAsync_Stream_Throws_ArgumentException_Given_Bad_Size(long size)


### PR DESCRIPTION
In #872 I added a check for file size and if it is zero, bypass the write, here: https://github.com/jpdillingham/Soulseek.NET/pull/872/files#diff-246696b5b1ce06f8977980e6acb1bfc649c4c9b18f56679fa53476613c77f432R4317

With this in place, I no longer need to guard against zero byte uploads.

This is actually a subtle bug, now that I look at it closer.  The exception states the size must be greater than or equal to zero, but the check was `size <= 0`. 

Also removes a chatty log message related to `RaiseEventsAsynchronously`, and applies the logic related to that flag to the `MessageWritten` event