### PR TITLE
Add SetInterestsAsync to broadcast user likes and dislikes

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -1261,6 +1261,15 @@ namespace Soulseek
         Task SetStatusAsync(UserPresence status, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        ///     Asynchronously informs the server of the user's liked and disliked interests.
+        /// </summary>
+        /// <param name="likes">A collection of liked interests.</param>
+        /// <param name="dislikes">A collection of disliked interests.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetInterestsAsync(IEnumerable<string> likes, IEnumerable<string> dislikes, CancellationToken? cancellationToken = null);
+
+        /// <summary>
         ///     Asynchronously starts receiving public chat messages.
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="HatedInterestAddCommand.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Messaging.Messages.Server
+{
+    using Soulseek.Messaging;
+
+    /// <summary>
+    ///     Adds a disliked interest to the user's profile on the server.
+    /// </summary>
+    internal class HatedInterestAddCommand : IOutgoingMessage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="HatedInterestAddCommand"/> class.
+        /// </summary>
+        /// <param name="interest">The disliked interest to add.</param>
+        public HatedInterestAddCommand(string interest)
+        {
+            Interest = interest;
+        }
+
+        /// <summary>
+        ///     Gets the disliked interest to add.
+        /// </summary>
+        public string Interest { get; }
+
+        /// <summary>
+        ///     Constructs a <see cref="byte"/> array from this message.
+        /// </summary>
+        /// <returns>The constructed byte array.</returns>
+        public byte[] ToByteArray()
+        {
+            return new MessageBuilder()
+                .WriteCode((MessageCode.Server)117)
+                .WriteString(Interest)
+                .Build();
+        }
+    }
+}

--- a/src/Messaging/Messages/Server/InterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/InterestAddCommand.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="InterestAddCommand.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Messaging.Messages.Server
+{
+    using Soulseek.Messaging;
+
+    /// <summary>
+    ///     Adds a liked interest to the user's profile on the server.
+    /// </summary>
+    internal class InterestAddCommand : IOutgoingMessage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="InterestAddCommand"/> class.
+        /// </summary>
+        /// <param name="interest">The interest to add.</param>
+        public InterestAddCommand(string interest)
+        {
+            Interest = interest;
+        }
+
+        /// <summary>
+        ///     Gets the interest to add.
+        /// </summary>
+        public string Interest { get; }
+
+        /// <summary>
+        ///     Constructs a <see cref="byte"/> array from this message.
+        /// </summary>
+        /// <returns>The constructed byte array.</returns>
+        public byte[] ToByteArray()
+        {
+            return new MessageBuilder()
+                .WriteCode((MessageCode.Server)51)
+                .WriteString(Interest)
+                .Build();
+        }
+    }
+}

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -17,6 +17,13 @@
 
 namespace Soulseek
 {
+    using Soulseek.Diagnostics;
+    using Soulseek.Messaging;
+    using Soulseek.Messaging.Handlers;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Messaging.Messages.Server;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
@@ -27,12 +34,6 @@ namespace Soulseek
     using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
-    using Soulseek.Diagnostics;
-    using Soulseek.Messaging;
-    using Soulseek.Messaging.Handlers;
-    using Soulseek.Messaging.Messages;
-    using Soulseek.Network;
-    using Soulseek.Network.Tcp;
 
     /// <summary>
     ///     A client for the Soulseek file sharing network.
@@ -2478,6 +2479,58 @@ namespace Soulseek
                 throw new SoulseekClientException($"Failed to set shared counts to {directories} directories and {files} files: {ex.Message}", ex);
             }
         }
+
+
+
+        /// <summary>
+        ///     Asynchronously informs the server of the user's <paramref name="likes"/> and <paramref name="dislikes"/>.
+        /// </summary>
+        /// <param name="likes">A collection of liked interests.</param>
+        /// <param name="dislikes">A collection of disliked interests.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public async Task SetInterestsAsync(IEnumerable<string> likes, IEnumerable<string> dislikes, CancellationToken? cancellationToken = null)
+        {
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to set interests; currently {State}.");
+            }
+
+            var token = cancellationToken ?? CancellationToken.None;
+
+            try
+            {
+                if (likes != null)
+                {
+                    foreach (var like in likes)
+                    {
+                        if (string.IsNullOrWhiteSpace(like)) continue;
+
+                        await ServerConnection.WriteAsync(new InterestAddCommand(like), token).ConfigureAwait(false);
+                    }
+                }
+
+                if (dislikes != null)
+                {
+                    foreach (var dislike in dislikes)
+                    {
+                        if (string.IsNullOrWhiteSpace(dislike)) continue;
+
+                        await ServerConnection.WriteAsync(new HatedInterestAddCommand(dislike), token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
+            {
+                throw new SoulseekClientException($"Failed to set interests: {ex.Message}", ex);
+            }
+        }
+
+
 
         /// <summary>
         ///     Asynchronously informs the server of the current online <paramref name="status"/> of the client.


### PR DESCRIPTION
Resolves Issue #905.

This PR adds support for broadcasting user interests (Likes and Dislikes) to the Soulseek network, bringing the library closer to feature parity with other clients like Nicotine+.

I made the changes directly based on the master branch because there was no develop branch available.

**Changes**
- Added SetInterestsAsync to ISoulseekClient.cs and SoulseekClient.cs.
- Added network message commands for User Interests and Hated Interests.

This PR is being made alongside another Pull Request in slskd/slskd to also implement interest broadcasting. Slskd relies on Soulseek.NET, so I also had to make implementations here.

(The import changes in SoulseekClient.cs were accidental. I apologize for that.)


