### PR TITLE
Synchronize search transitions and handling of responses

### DIFF
--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -218,13 +218,8 @@ namespace Soulseek
                     return;
                 }
 
-                if (Options.FilterResponses)
-                {
-                    // apply custom filter, if one was provided
-                    if (!(Options.ResponseFilter?.Invoke(response) ?? true))
-                    {
-                        return;
-                    }
+            try
+            {
 
                     // apply individual file filter, if one was provided
                     var filteredFiles = response.Files.Where(f => Options.FileFilter?.Invoke(f) ?? true);
@@ -254,6 +249,10 @@ namespace Soulseek
                 {
                     Complete(SearchStates.FileLimitReached);
                 }
+            }
+            catch (ObjectDisposedException)
+            {
+                // noop; response arrived too late and we don't care
             }
         }
 

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -118,8 +118,18 @@ namespace Soulseek
         /// </summary>
         public void Cancel()
         {
+            ReaderWriterLock.EnterWriteLock();
+
+            try
+            {
                 SearchTimeoutTimer.Stop();
                 State = SearchStates.Completed | SearchStates.Cancelled;
+                TaskCompletionSource.TrySetException(new OperationCanceledException());
+            }
+            finally
+            {
+                ReaderWriterLock.ExitWriteLock();
+            }
         }
 
         /// <summary>
@@ -128,9 +138,18 @@ namespace Soulseek
         /// <param name="state">The terminal state of the search.</param>
         public void Complete(SearchStates state)
         {
-            SearchTimeoutTimer.Stop();
-            State = SearchStates.Completed | state;
-            TaskCompletionSource.TrySetResult(0);
+            ReaderWriterLock.EnterWriteLock();
+
+            try
+            {
+                SearchTimeoutTimer.Stop();
+                State = SearchStates.Completed | state;
+                TaskCompletionSource.TrySetResult(0);
+            }
+            finally
+            {
+                ReaderWriterLock.ExitWriteLock();
+            }
         }
 
         /// <summary>
@@ -166,13 +185,22 @@ namespace Soulseek
         /// <param name="state">The state to which the Search is to be set.</param>
         public void SetState(SearchStates state)
         {
-            var previousState = State;
-            State = state;
+            ReaderWriterLock.EnterWriteLock();
 
-            // ensure the timeout timer is reset only one time, immediately after the search request is sent to the server.
-            if (previousState != SearchStates.InProgress && State == SearchStates.InProgress)
+            try
             {
-                SearchTimeoutTimer.Reset();
+                var previousState = State;
+                State = state;
+
+                // ensure the timeout timer is reset only one time, immediately after the search request is sent to the server.
+                if (previousState != SearchStates.InProgress && State == SearchStates.InProgress)
+                {
+                    SearchTimeoutTimer.Reset();
+                }
+            }
+            finally
+            {
+                ReaderWriterLock.ExitWriteLock();
             }
         }
 

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -118,7 +118,8 @@ namespace Soulseek
         /// </summary>
         public void Cancel()
         {
-            TaskCompletionSource.TrySetException(new OperationCanceledException());
+                SearchTimeoutTimer.Stop();
+                State = SearchStates.Completed | SearchStates.Cancelled;
         }
 
         /// <summary>

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -220,6 +220,10 @@ namespace Soulseek
 
             try
             {
+                ReaderWriterLock.EnterReadLock();
+
+                try
+                {
 
                     // apply individual file filter, if one was provided
                     var filteredFiles = response.Files.Where(f => Options.FileFilter?.Invoke(f) ?? true);
@@ -238,8 +242,11 @@ namespace Soulseek
                 Interlocked.Add(ref fileCount, response.FileCount);
                 Interlocked.Add(ref lockedFileCount, response.LockedFileCount);
 
-                ResponseReceived?.Invoke(response);
-                SearchTimeoutTimer.Reset();
+                }
+                finally
+                {
+                    ReaderWriterLock.ExitReadLock();
+                }
 
                 if (responseCount >= Options.ResponseLimit)
                 {

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -211,12 +211,15 @@ namespace Soulseek
         /// <param name="response">The response to add.</param>
         public void TryAddResponse(SearchResponse response)
         {
-            if (!Disposed && State.HasFlag(SearchStates.InProgress) && response.Token == Token)
+            if (response.Token != Token)
             {
-                if (!ResponseMeetsOptionCriteria(response))
-                {
-                    return;
-                }
+                throw new DataMisalignedException($"Search for '{Query}' with token {Token} received response with search token {response.Token}");
+            }
+
+            if (Disposed)
+            {
+                return;
+            }
 
             try
             {
@@ -224,24 +227,43 @@ namespace Soulseek
 
                 try
                 {
-
-                    // apply individual file filter, if one was provided
-                    var filteredFiles = response.Files.Where(f => Options.FileFilter?.Invoke(f) ?? true);
-                    var filteredLockedFiles = response.LockedFiles.Where(f => Options.FileFilter?.Invoke(f) ?? true);
-
-                    response = new SearchResponse(response, filteredFiles, filteredLockedFiles);
-
-                    // ensure the filtered file count still meets the response criteria
-                    if (response.FileCount + response.LockedFileCount < Options.MinimumResponseFileCount)
+                    if (!State.HasFlag(SearchStates.InProgress))
                     {
                         return;
                     }
-                }
 
-                Interlocked.Increment(ref responseCount);
-                Interlocked.Add(ref fileCount, response.FileCount);
-                Interlocked.Add(ref lockedFileCount, response.LockedFileCount);
+                    if (!ResponseMeetsOptionCriteria(response))
+                    {
+                        return;
+                    }
 
+                    if (Options.FilterResponses)
+                    {
+                        // apply custom filter, if one was provided
+                        if (!(Options.ResponseFilter?.Invoke(response) ?? true))
+                        {
+                            return;
+                        }
+
+                        // apply individual file filter, if one was provided
+                        var filteredFiles = response.Files.Where(f => Options.FileFilter?.Invoke(f) ?? true);
+                        var filteredLockedFiles = response.LockedFiles.Where(f => Options.FileFilter?.Invoke(f) ?? true);
+
+                        response = new SearchResponse(response, filteredFiles, filteredLockedFiles);
+
+                        // ensure the filtered file count still meets the response criteria
+                        if (response.FileCount + response.LockedFileCount < Options.MinimumResponseFileCount)
+                        {
+                            return;
+                        }
+                    }
+
+                    Interlocked.Increment(ref responseCount);
+                    Interlocked.Add(ref fileCount, response.FileCount);
+                    Interlocked.Add(ref lockedFileCount, response.LockedFileCount);
+
+                    ResponseReceived?.Invoke(response);
+                    SearchTimeoutTimer.Reset();
                 }
                 finally
                 {

--- a/src/SearchInternal.cs
+++ b/src/SearchInternal.cs
@@ -111,6 +111,7 @@ namespace Soulseek
         private bool Disposed { get; set; } = false;
         private SystemTimer SearchTimeoutTimer { get; set; }
         private TaskCompletionSource<int> TaskCompletionSource { get; } = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private ReaderWriterLockSlim ReaderWriterLock { get; } = new ReaderWriterLockSlim();
 
         /// <summary>
         ///     Cancels the search.
@@ -151,6 +152,7 @@ namespace Soulseek
                 if (disposing)
                 {
                     SearchTimeoutTimer.Dispose();
+                    ReaderWriterLock.Dispose();
                 }
 
                 Disposed = true;

--- a/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchInternalTests.cs
@@ -62,6 +62,18 @@ namespace Soulseek.Tests.Unit
             s.Dispose();
         }
 
+        [Trait("Category", "Dispose")]
+        [Fact(DisplayName = "Dispose is idempotent")]
+        public void Dispose_Is_Idempotent()
+        {
+            var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 42);
+            s.Dispose();
+
+            var ex = Record.Exception(() => s.Dispose());
+
+            Assert.Null(ex);
+        }
+
         [Trait("Category", "Complete")]
         [Fact(DisplayName = "Complete sets state")]
         public void Complete_Sets_State()
@@ -168,17 +180,20 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "TryAddResponse")]
-        [Fact(DisplayName = "TryAddResponse ignores response when token does not match")]
+        [Fact(DisplayName = "TryAddResponse throws DataMisalignedException when token does not match")]
         public void TryAddResponse_Ignores_Response_When_Token_Does_Not_Match()
         {
             var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 42);
             s.SetState(SearchStates.InProgress);
 
-            s.TryAddResponse(new SearchResponse("bar", 24, true, 1, 1, null));
+            var ex = Record.Exception(() => s.TryAddResponse(new SearchResponse("bar", 24, true, 1, 1, null)));
 
             var invoked = false;
             s.ResponseReceived = (r) => invoked = true;
 
+            Assert.NotNull(ex);
+            Assert.IsType<DataMisalignedException>(ex);
+            Assert.Contains($"with token {42} received response with search token {24}", ex.Message);
             Assert.False(invoked);
 
             s.Dispose();
@@ -294,6 +309,40 @@ namespace Soulseek.Tests.Unit
             Assert.Equal(username, response.Username);
             Assert.Equal(file.Filename, files[0].Filename);
             Assert.Equal(file.Size, files[0].Size);
+
+            s.Dispose();
+        }
+
+        [Trait("Category", "TryAddResponse")]
+        [Fact(DisplayName = "TryAddResponse returns without invoking handler when disposed")]
+        public void TryAddResponse_Returns_When_Disposed()
+        {
+            var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 42);
+            s.SetState(SearchStates.InProgress);
+
+            var invoked = false;
+            s.ResponseReceived = (r) => invoked = true;
+
+            s.Dispose();
+
+            var ex = Record.Exception(() => s.TryAddResponse(new SearchResponse("bar", 42, true, 1, 1, null)));
+
+            Assert.Null(ex);
+            Assert.False(invoked);
+        }
+
+        [Trait("Category", "TryAddResponse")]
+        [Theory(DisplayName = "TryAddResponse swallows ObjectDisposedException thrown from body"), AutoData]
+        public void TryAddResponse_Swallows_ObjectDisposedException_Thrown_From_Body(string username, int token, File file)
+        {
+            var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, token);
+            s.SetState(SearchStates.InProgress);
+
+            s.ResponseReceived = (r) => throw new ObjectDisposedException("test");
+
+            var ex = Record.Exception(() => s.TryAddResponse(new SearchResponse(username, token, true, 1, 1, new List<File>() { file })));
+
+            Assert.Null(ex);
 
             s.Dispose();
         }
@@ -551,6 +600,43 @@ namespace Soulseek.Tests.Unit
             }
         }
 
+        [Trait("Category", "WaitForCompletion")]
+        [Fact(DisplayName = "WaitForCompletion returns when Complete is called")]
+        public async Task WaitForCompletion_Returns_When_Complete_Is_Called()
+        {
+            using (var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 42))
+            {
+                s.SetState(SearchStates.InProgress);
+
+                var task = s.WaitForCompletion(CancellationToken.None);
+                s.Complete(SearchStates.TimedOut);
+
+                var ex = await Record.ExceptionAsync(() => task);
+
+                Assert.Null(ex);
+                Assert.True(s.State.HasFlag(SearchStates.Completed));
+            }
+        }
+
+        [Trait("Category", "WaitForCompletion")]
+        [Fact(DisplayName = "WaitForCompletion throws when CancellationToken is cancelled")]
+        public async Task WaitForCompletion_Throws_When_CancellationToken_Is_Cancelled()
+        {
+            using (var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 42))
+            using (var cts = new CancellationTokenSource())
+            {
+                s.SetState(SearchStates.InProgress);
+
+                var task = s.WaitForCompletion(cts.Token);
+                await cts.CancelAsync();
+
+                var ex = await Record.ExceptionAsync(() => task);
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+
         [Trait("Category", "Timer")]
         [Fact(DisplayName = "Timer is disabled initially")]
         public void Timer_Disabled_Initially()
@@ -584,6 +670,35 @@ namespace Soulseek.Tests.Unit
                 s.SetState(SearchStates.InProgress);
 
                 Assert.True(timer.Enabled);
+            }
+        }
+
+        [Trait("Category", "Timer")]
+        [Fact(DisplayName = "Timer does not reset when already InProgress")]
+        public void Timer_Does_Not_Reset_When_Already_InProgress()
+        {
+            using (var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 1))
+            {
+                s.SetState(SearchStates.InProgress);
+
+                var ex = Record.Exception(() => s.SetState(SearchStates.InProgress));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "Timer")]
+        [Fact(DisplayName = "Timer elapsed completes search with TimedOut")]
+        public async Task Timer_Elapsed_Completes_Search_With_TimedOut()
+        {
+            using (var s = new SearchInternal(new SearchQuery("foo"), SearchScope.Network, 1, new SearchOptions(searchTimeout: 50)))
+            {
+                s.SetState(SearchStates.InProgress);
+
+                await s.WaitForCompletion(CancellationToken.None);
+
+                Assert.True(s.State.HasFlag(SearchStates.Completed));
+                Assert.True(s.State.HasFlag(SearchStates.TimedOut));
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/SearchTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchTests.cs
@@ -45,7 +45,7 @@ namespace Soulseek.Tests.Unit
         {
             var i = new SearchInternal(SearchQuery.FromText(searchText), SearchScope.Network, token);
             i.SetState(SearchStates.Completed);
-            i.TryAddResponse(new SearchResponse("foo", 42, false, 420, 24, new List<File>()
+            i.TryAddResponse(new SearchResponse("foo", token, false, 420, 24, new List<File>()
             {
                 new File(1, "foo.bar", 2323, "bar", null),
             }));


### PR DESCRIPTION
It's currently possible for search responses to arrive and be processed while a search has transitioned into a terminal state and the search has been disposed, causing (harmless) exception spam in logs.

This PR adds a `ReaderWriterLockSlim` to synchronize logic that mutates state and logic that processes responses.  How it works:

1. `TryAddResponse` calls `EnterReadLock`, any number of threads concurrently
2. The desired response/file count is reached and `Complete()` is called
3. `Complete()` calls `EnterWriteLock`
4. `EnterWriteLock` blocks until all other threads have released their read locks via `ExitReadLock`
5. `Complete()` successfully acquires exclusive access over `State` and updates the state
6. Concurrent calls to `TryAddResponse` block behind `EnterReadLock`, as long as exclusive access is held by `Complete()`
7. `Complete()` releases exclusive access via `ExitWriteLock`
8. All of the threads that were waiting behind `EnterReadLock` are unblocked and see that the state no longer contains `InProgress`, and return without error or having processed the response

