### PR TITLE
Reserve Soulseek client minor version range for slskdN

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ I appreciate everyone's cooperation and commitment to ensuring the long term hea
 Applications using this library are required, as a condition of the [LICENSE](https://github.com/jpdillingham/Soulseek.NET/blob/master/LICENSE), to use a unique minor version number when logging in to the Soulseek network.  To aid in avoidance of versions used by other applications, a list of reserved version ranges and their associated applications are included below.
 
 * 760-7699999: [slskd](https://github.com/slskd/slskd)
+* 7700000-7709999: [slskdN](https://github.com/snapetech/slskdn)
 
 # See also
 


### PR DESCRIPTION
This reserves a Soulseek client minor-version range for slskdN, a fork of slskd.

slskdN is moving off the slskd client minor-version range to avoid colliding with upstream slskd and to comply with Soulseek.NET's documented client version allocation rules.

Requested allocation:

- Client: slskdN
- Repository: https://github.com/snapetech/slskdn
- Minor version range: `7700000-7709999`

Context:

slskd currently uses the reserved `760-7699999` range. slskdN previously inherited that value as a fork, but it now needs its own range so clients can be distinguished on the Soulseek network and so future slskdN releases do not present as upstream slskd.