### PR TITLE
Add KickedFromServer event and version number properties to ISoulseekClient interface

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -108,6 +108,12 @@ namespace Soulseek
         event EventHandler<string> GlobalMessageReceived;
 
         /// <summary>
+        ///     Occurs when the client is forcefully disconnected from the server, probably because another client logged in with
+        ///     the same credentials.
+        /// </summary>
+        public event EventHandler KickedFromServer;
+
+        /// <summary>
         ///     Occurs when the client is logged in.
         /// </summary>
         event EventHandler LoggedIn;
@@ -287,6 +293,16 @@ namespace Soulseek
         ///     Gets the resolved server endpoint.
         /// </summary>
         IPEndPoint IPEndPoint { get; }
+
+        /// <summary>
+        ///     Gets the major version of the library.
+        /// </summary>
+        int MajorVersion { get; }
+
+        /// <summary>
+        ///     Gets the configured minor version of the client.
+        /// </summary>
+        int MinorVersion { get; }
 
         /// <summary>
         ///     Gets the client options.

--- a/src/Soulseek.csproj
+++ b/src/Soulseek.csproj
@@ -34,7 +34,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>10.0.1</Version>
+    <Version>10.0.2</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Soulseek.NET</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Soulseek.NET</PackageProjectUrl>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -271,8 +271,8 @@ namespace Soulseek
             ServerMessageHandler.KickedFromServer += (sender, e) =>
             {
                 Diagnostic.Info($"Kicked from server.");
-                Disconnect("Kicked from server", new KickedFromServerException());
                 KickedFromServer?.Invoke(this, e);
+                Disconnect("Kicked from server", new KickedFromServerException());
             };
         }
 


### PR DESCRIPTION
These 3 members are defined in SoulseekClient but not the matching interface, meaning downstream clients can't access them.

Also swaps the order of the firing of the `KickedFromServer` event and the disconnect.