### PR TITLE
Add an overload for BrowseAsync that accepts a delegate for handling each directory

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -416,6 +416,8 @@ namespace Soulseek
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
         Task<BrowseResponse> BrowseAsync(string username, BrowseOptions options = null, CancellationToken? cancellationToken = null);
 
+        Task<BrowseResponse> BrowseAsync(string username, Action<Directory, bool> directoryHandler, BrowseOptions options = null, CancellationToken? cancellationToken = null);
+
         /// <summary>
         ///     Asynchronously changes the password for the currently logged in user.
         /// </summary>

--- a/src/Network/IMessageConnection.cs
+++ b/src/Network/IMessageConnection.cs
@@ -24,6 +24,7 @@
 namespace Soulseek.Network
 {
     using System;
+    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
     using Soulseek.Messaging.Messages;
@@ -83,6 +84,21 @@ namespace Soulseek.Network
         ///     Gets the username of the peer associated with the connection, if applicable.
         /// </summary>
         string Username { get; }
+
+        /// <summary>
+        ///     Registers an override for handling of the specified <paramref name="messageCode"/>, which will divert the
+        ///     received data packets to the specified <paramref name="stream"/> instead of the attached message handler,
+        ///     and will invoke the specified <paramref name="callback"/> when the message has been fully recieved.
+        /// </summary>
+        /// <remarks>
+        ///     Registrations are added to a FIFO queue internally, and messages will be streamed to handlers in the order
+        ///     they are registered and received. There is no way to guarantee that the remote client will respond in
+        ///     chronological order, so avoid using this for messages that are variable in this way (e.g. search responses).
+        /// </remarks>
+        /// <param name="messageCode">The message code of the message for which to override handling.</param>
+        /// <param name="stream">The stream to write the message data to.</param>
+        /// <param name="callback">The callback to invoke when the message has been fully received.</param>
+        void RegisterMessageHandlingOverride(int messageCode, Stream stream, Action callback);
 
         /// <summary>
         ///     Begins the internal continuous read loop, if it has not yet started.

--- a/src/Network/MessageConnection.cs
+++ b/src/Network/MessageConnection.cs
@@ -24,10 +24,13 @@
 namespace Soulseek.Network
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.IO;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using Soulseek.Messaging;
     using Soulseek.Messaging.Messages;
     using Soulseek.Network.Tcp;
 
@@ -263,23 +266,36 @@ namespace Soulseek.Network
 
                         DataRead += RaiseMessageDataRead;
 
-                        var payloadBytes = await ReadAsync(length - CodeLength, CancellationToken.None).ConfigureAwait(false);
-                        message.AddRange(payloadBytes);
-
-                        var messageBytes = message.ToArray();
-
-                        if (SoulseekClient.RaiseEventsAsynchronously)
+                        // if a message stream 'hook' has been installed via InstallMessageStreamHook, stream the remainder
+                        // of the message to the provided stream. the caller will be notified that the read is complete
+                        // via MessageRead -> PeerMessageHandler.HandleMessageRead -> regular message handling
+                        // the caller must avoid trying to use the browse response, since it would have been streamed instead of passed
+                        if (BitConverter.ToInt32(codeBytes) == (int)MessageCode.Peer.BrowseResponse
+                            && MessageHandlingOverrideRegistrations.TryGetValue((int)MessageCode.Peer.BrowseResponse, out var queue)
+                            && queue.TryDequeue(out var entry))
                         {
-                            Task.Run(() =>
-                            {
-                                Interlocked.CompareExchange(ref MessageRead, null, null)?
-                                    .Invoke(this, new MessageEventArgs(messageBytes));
-                            }, CancellationToken.None).Forget();
+                            await ReadAsync(length - CodeLength, entry.Stream, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                            entry.Callback();
                         }
                         else
                         {
-                            Interlocked.CompareExchange(ref MessageRead, null, null)?
-                                .Invoke(this, new MessageEventArgs(messageBytes));
+                            var payloadBytes = await ReadAsync(length - CodeLength, CancellationToken.None).ConfigureAwait(false);
+                            message.AddRange(payloadBytes);
+                            var messageBytes = message.ToArray();
+
+                            if (SoulseekClient.RaiseEventsAsynchronously)
+                            {
+                                Task.Run(() =>
+                                {
+                                    Interlocked.CompareExchange(ref MessageRead, null, null)?
+                                        .Invoke(this, new MessageEventArgs(messageBytes));
+                                }, CancellationToken.None).Forget();
+                            }
+                            else
+                            {
+                                Interlocked.CompareExchange(ref MessageRead, null, null)?
+                                    .Invoke(this, new MessageEventArgs(messageBytes));
+                            }
                         }
                     }
                     finally

--- a/src/Network/MessageConnection.cs
+++ b/src/Network/MessageConnection.cs
@@ -140,6 +140,33 @@ namespace Soulseek.Network
         /// </summary>
         public string Username { get; } = string.Empty;
 
+        private ConcurrentDictionary<int, ConcurrentQueue<(Stream Stream, Action Callback)>> MessageHandlingOverrideRegistrations { get; } = new ConcurrentDictionary<int, ConcurrentQueue<(Stream Stream, Action Callback)>>();
+
+        /// <summary>
+        ///     Registers an override for handling of the specified <paramref name="messageCode"/>, which will divert the
+        ///     received data packets to the specified <paramref name="stream"/> instead of the attached message handler,
+        ///     and will invoke the specified <paramref name="callback"/> when the message has been fully recieved.
+        /// </summary>
+        /// <remarks>
+        ///     Registrations are added to a FIFO queue internally, and messages will be streamed to handlers in the order
+        ///     they are registered and received. There is no way to guarantee that the remote client will respond in
+        ///     chronological order, so avoid using this for messages that are variable in this way (e.g. search responses).
+        /// </remarks>
+        /// <param name="messageCode">The message code of the message for which to override handling.</param>
+        /// <param name="stream">The stream to write the message data to.</param>
+        /// <param name="callback">The callback to invoke when the message has been fully received.</param>
+        public void RegisterMessageHandlingOverride(int messageCode, Stream stream, Action callback)
+        {
+            MessageHandlingOverrideRegistrations.AddOrUpdate(
+                key: messageCode,
+                addValue: new ConcurrentQueue<(Stream Stream, Action Callback)>(new[] { (stream, callback) }),
+                updateValueFactory: (k, v) =>
+                {
+                    v.Enqueue((stream, callback));
+                    return v;
+                });
+        }
+
         /// <summary>
         ///     Begins the internal continuous read loop, if it has not yet started.
         /// </summary>

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -418,7 +418,7 @@ namespace Soulseek.Network.Tcp
         ///     is not connected.
         /// </exception>
         /// <exception cref="ConnectionReadException">Thrown when an unexpected error occurs.</exception>
-        public Task ReadAsync(long length, Stream outputStream, Func<int, CancellationToken, Task<int>> governor, Action<int, int, int> reporter = null, CancellationToken? cancellationToken = null)
+        public Task ReadAsync(long length, Stream outputStream, Func<int, CancellationToken, Task<int>> governor = null, Action<int, int, int> reporter = null, CancellationToken? cancellationToken = null)
         {
             if (length < 0)
             {

--- a/src/Network/Tcp/IConnection.cs
+++ b/src/Network/Tcp/IConnection.cs
@@ -165,7 +165,7 @@ namespace Soulseek.Network.Tcp
         ///     is not connected.
         /// </exception>
         /// <exception cref="ConnectionReadException">Thrown when an unexpected error occurs.</exception>
-        Task ReadAsync(long length, Stream outputStream, Func<int, CancellationToken, Task<int>> governor, Action<int, int, int> reporter = null, CancellationToken? cancellationToken = null);
+        Task ReadAsync(long length, Stream outputStream, Func<int, CancellationToken, Task<int>> governor = null, Action<int, int, int> reporter = null, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Waits for the connection to disconnect, returning the message or throwing the Exception which caused the disconnect.

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -777,6 +777,11 @@ namespace Soulseek
             return BrowseInternalAsync(username, options, cancellationToken ?? CancellationToken.None);
         }
 
+        public async Task BrowseAsync(string username, Action<Directory, bool> directoryHandler, BrowseOptions options = null, CancellationToken cancellationToken = default)
+        {
+            // todo: implement me!
+        }
+
         /// <summary>
         ///     Asynchronously changes the password for the currently logged in user.
         /// </summary>


### PR DESCRIPTION
Currently `BrowseAsync` returns the entire browse response as a C# object, which Soulseek.NET must build in memory from the decompressed payload sent from the other client.  Consumers must then take this C# object and read/manipulate it, possibly store it after serializing it to JSON.

For extremely large shares, the current approach puts a lot of memory pressure on Soulseek.NET and the containing application, requiring a copy of both the compressed and decompressed payloads in memory concurrently, at least.

This PR introduces a new overload of `BrowseAsync` that accepts an `Action<Directory, bool>` that's called by Soulseek.NET for each directory contained within a browse response, after decompressing the incoming response on the fly.  The bool is used to indicate whether the directory is locked, as there is no property associated with files or directories that carries this information today.

This PR is WIP that's predicated on the successful implementation of on-the-fly decompression and directory building that matches or beats the performance of the existing solution.  The successful technique will require staging chunks of data and searching for start and end markers for directories to re-assemble them, and I'm not confident that 1) this is even possible with the current ZLib implementation or 2) that this can be done in a memory efficient way (will require borrowed arrays from a buffer) and 3) that it won't be CPU intensive (doubtful, but who knows!)

If implemented successfully, this will allow implementing applications to serialize directory objects as they are received, avoiding potential OOM issues that are possible with the current approach.

Closes #889 