### PR TITLE
Update the Forget() Task extension so that it observes Exceptions

### DIFF
--- a/src/Common/Extensions.cs
+++ b/src/Common/Extensions.cs
@@ -57,21 +57,17 @@ namespace Soulseek
         /// <summary>
         ///     Continue a task and swallow any Exceptions.
         /// </summary>
+        /// <remarks>
+        ///     The continuation touches the Task <see cref="Task.Exception"/> (if one exists)
+        ///     to avoid an <see cref="TaskScheduler.UnobservedTaskException"/>.
+        /// </remarks>
         /// <param name="task">The task to continue.</param>
-        public static void Forget(this Task task)
+        /// <param name="options">Optional continuation options.</param>
+        public static void Forget(this Task task, TaskContinuationOptions? options = null)
         {
-            task.ContinueWith(t => { }, TaskContinuationOptions.RunContinuationsAsynchronously);
-        }
-
-        /// <summary>
-        ///     Continue a task and report an Exception if one is raised.
-        /// </summary>
-        /// <typeparam name="T">The type of Exception to throw.</typeparam>
-        /// <param name="task">The task to continue.</param>
-        public static void ForgetButThrowWhenFaulted<T>(this Task task)
-            where T : Exception
-        {
-            task.ContinueWith(t => { throw (T)Activator.CreateInstance(typeof(T), t.Exception.Message, t.Exception); }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.RunContinuationsAsynchronously);
+            task.ContinueWith(
+                continuationFunction: t => _ = t.Exception, // this is a no-op, but it marks the Exception as having been observed so it won't throw
+                continuationOptions: TaskContinuationOptions.OnlyOnFaulted | (options ?? TaskContinuationOptions.RunContinuationsAsynchronously));
         }
 
         /// <summary>

--- a/src/Network/MessageConnection.cs
+++ b/src/Network/MessageConnection.cs
@@ -74,7 +74,10 @@ namespace Soulseek.Network
                 // if Username is empty, this is a server connection. begin reading continuously, and throw on exception.
                 if (IsServerConnection)
                 {
-                    Task.Run(() => ReadContinuouslyAsync()).ForgetButThrowWhenFaulted<ConnectionException>();
+                    Task.Run(() => ReadContinuouslyAsync())
+                        .ContinueWith(
+                            continuationAction: t => throw new ConnectionException(t.Exception.Message, t.Exception),
+                            continuationOptions: TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.RunContinuationsAsynchronously);
                 }
                 else
                 {

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3444,6 +3444,11 @@ namespace Soulseek
                     },
                     cancellationToken: linkedCancellationToken);
 
+                // ensure the losing tasks don't raise an unbserved exception by attaching a continuation that will observe them with Forget()
+                readTask.Forget();
+                disconnectedTaskCancellationSource.Task.Forget();
+                download.RemoteTaskCompletionSource.Task.Forget();
+
                 var firstTask = await Task.WhenAny(
                     readTask, // we successfully read all of the data
                     disconnectedTaskCancellationSource.Task, // the connection is disconnected
@@ -4494,6 +4499,10 @@ namespace Soulseek
                 {
                     writeTask = Task.CompletedTask;
                 }
+
+                // ensure the losing tasks don't raise an unbserved exception by attaching a continuation that will observe them with Forget()
+                writeTask.Forget();
+                disconnectedTaskCancellationSource.Task.Forget();
 
                 var firstTask = await Task.WhenAny(
                     writeTask,


### PR DESCRIPTION
After briefly turning on unobserved task exception logging in slskd, I found that a ton were being thrown, most of which were related to connection and transfer races.  This PR updates the Forget() functions that's used for fire and forget tasks so that it references the Exception property and marks the Exception as being observed.

This should quiet things down considerably.