### PR TITLE
Improve the resiliency of the Listener's accept loop

### DIFF
--- a/src/Common/Extensions.cs
+++ b/src/Common/Extensions.cs
@@ -66,7 +66,7 @@ namespace Soulseek
         public static void Forget(this Task task, TaskContinuationOptions? options = null)
         {
             task.ContinueWith(
-                continuationFunction: t => _ = t.Exception, // this is a no-op, but it marks the Exception as having been observed so it won't throw
+                continuationAction: t => _ = t.Exception, // this is a no-op, but it marks the Exception as having been observed so it won't throw
                 continuationOptions: TaskContinuationOptions.OnlyOnFaulted | (options ?? TaskContinuationOptions.RunContinuationsAsynchronously));
         }
 

--- a/src/Common/Extensions.cs
+++ b/src/Common/Extensions.cs
@@ -124,5 +124,23 @@ namespace Soulseek
 
             return sBuilder.ToString();
         }
+
+        /// <summary>
+        ///     Safely disposes an <see cref="IDisposable"/> instance.
+        /// </summary>
+        /// <param name="obj">The IDisposable instance to dispose.</param>
+        /// <returns>A value indicating whether the disposal succeeded.</returns>
+        public static bool TryDispose(this IDisposable obj)
+        {
+            try
+            {
+                obj.Dispose();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Network/IListenerHandler.cs
+++ b/src/Network/IListenerHandler.cs
@@ -23,6 +23,7 @@
 
 namespace Soulseek.Network
 {
+    using System;
     using Soulseek.Diagnostics;
     using Soulseek.Network.Tcp;
 
@@ -37,5 +38,12 @@ namespace Soulseek.Network
         /// <param name="sender">The originating <see cref="IListener"/> instance.</param>
         /// <param name="connection">The accepted connection.</param>
         void HandleConnection(object sender, IConnection connection);
+
+        /// <summary>
+        ///     Handle <see cref="IListener.Error"/> events.
+        /// </summary>
+        /// <param name="sender">The originating <see cref="IListener"/> instance.</param>
+        /// <param name="exception">The Exception associated with the error.</param>
+        void HandleError(object sender, Exception exception);
     }
 }

--- a/src/Network/ListenerHandler.cs
+++ b/src/Network/ListenerHandler.cs
@@ -157,5 +157,15 @@ namespace Soulseek.Network
                 connection.Dispose();
             }
         }
+
+        /// <summary>
+        ///     Handle <see cref="IListener.Error"/> events.
+        /// </summary>
+        /// <param name="sender">The originating <see cref="IListener"/> instance.</param>
+        /// <param name="exception">The Exception associated with the error.</param>
+        public void HandleError(object sender, Exception exception)
+        {
+            Diagnostic.Warning($"Failed to establish an incoming connection: {exception.Message}", exception);
+        }
     }
 }

--- a/src/Network/Tcp/Connection.cs
+++ b/src/Network/Tcp/Connection.cs
@@ -596,10 +596,11 @@ namespace Soulseek.Network.Tcp
                     InactivityTimer?.Dispose();
                     WatchdogTimer.Dispose();
                     Stream?.Dispose();
-                    TcpClient?.Dispose();
 
                     WriteSemaphore?.Dispose();
                     WriteQueueSemaphore?.Dispose();
+
+                    TcpClient?.Dispose();
                 }
 
                 Disposed = true;

--- a/src/Network/Tcp/IListener.cs
+++ b/src/Network/Tcp/IListener.cs
@@ -37,6 +37,11 @@ namespace Soulseek.Network.Tcp
         event EventHandler<IConnection> Accepted;
 
         /// <summary>
+        ///     Occurs when the listener encounters an exception while accepting a connection.
+        /// </summary>
+        event EventHandler<Exception> Error;
+
+        /// <summary>
         ///     Occurs when the listener has started listening.
         /// </summary>
         event EventHandler Started;

--- a/src/Network/Tcp/IListener.cs
+++ b/src/Network/Tcp/IListener.cs
@@ -37,6 +37,16 @@ namespace Soulseek.Network.Tcp
         event EventHandler<IConnection> Accepted;
 
         /// <summary>
+        ///     Occurs when the listener has started listening.
+        /// </summary>
+        event EventHandler Started;
+
+        /// <summary>
+        ///     Occurs when the listener has stopped listening.
+        /// </summary>
+        event EventHandler Stopped;
+
+        /// <summary>
         ///     Gets the options used when creating new <see cref="IConnection"/> instances.
         /// </summary>
         ConnectionOptions ConnectionOptions { get; }

--- a/src/Network/Tcp/IListener.cs
+++ b/src/Network/Tcp/IListener.cs
@@ -42,16 +42,6 @@ namespace Soulseek.Network.Tcp
         event EventHandler<Exception> Error;
 
         /// <summary>
-        ///     Occurs when the listener has started listening.
-        /// </summary>
-        event EventHandler Started;
-
-        /// <summary>
-        ///     Occurs when the listener has stopped listening.
-        /// </summary>
-        event EventHandler Stopped;
-
-        /// <summary>
         ///     Gets the options used when creating new <see cref="IConnection"/> instances.
         /// </summary>
         ConnectionOptions ConnectionOptions { get; }

--- a/src/Network/Tcp/ITcpListener.cs
+++ b/src/Network/Tcp/ITcpListener.cs
@@ -33,11 +33,6 @@ namespace Soulseek.Network.Tcp
     internal interface ITcpListener
     {
         /// <summary>
-        ///     Gets the underlying <see cref="Socket"/> used by the listener.
-        /// </summary>
-        public Socket Server { get; }
-
-        /// <summary>
         ///     Accepts a pending connection request as an asynchronous operation.
         /// </summary>
         /// <returns>The operation context, including the new connection client.</returns>

--- a/src/Network/Tcp/ITcpListener.cs
+++ b/src/Network/Tcp/ITcpListener.cs
@@ -33,6 +33,11 @@ namespace Soulseek.Network.Tcp
     internal interface ITcpListener
     {
         /// <summary>
+        ///     Gets the underlying <see cref="Socket"/> used by the listener.
+        /// </summary>
+        public Socket Server { get; }
+
+        /// <summary>
         ///     Accepts a pending connection request as an asynchronous operation.
         /// </summary>
         /// <returns>The operation context, including the new connection client.</returns>
@@ -54,8 +59,10 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Starts listening for incoming connection requests.
         /// </summary>
+        /// <param name="backlog">The maximum number of pending connections the OS will queue for this listener.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when a negative backlog value is provided.</exception>
         /// <exception cref="SocketException">Thrown when an error occurrs while accessing the socket.</exception>
-        void Start();
+        void Start(int backlog = (int)SocketOptionName.MaxConnections);
 
         /// <summary>
         ///     Closes the listener.

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -63,6 +63,16 @@ namespace Soulseek.Network.Tcp
         public event EventHandler<IConnection> Accepted;
 
         /// <summary>
+        ///     Occurs when the listener has started listening.
+        /// </summary>
+        public event EventHandler Started;
+
+        /// <summary>
+        ///     Occurs when the listener has stopped listening.
+        /// </summary>
+        public event EventHandler Stopped;
+
+        /// <summary>
         ///     Gets the options used when creating new <see cref="IConnection"/> instances.
         /// </summary>
         public ConnectionOptions ConnectionOptions { get; }
@@ -82,6 +92,7 @@ namespace Soulseek.Network.Tcp
         /// </summary>
         public int Port { get; }
 
+        private object SyncRoot { get; } = new object();
         private ITcpListener TcpListener { get; set; }
 
         /// <summary>
@@ -89,9 +100,28 @@ namespace Soulseek.Network.Tcp
         /// </summary>
         public void Start()
         {
-            TcpListener.Start();
-            Listening = true;
-            Task.Run(() => ListenContinuouslyAsync()).Forget();
+            lock (SyncRoot)
+            {
+                if (Listening)
+                {
+                    return;
+                }
+
+                try
+                {
+                    TcpListener.Start();
+                    Listening = true;
+                    Task.Run(() => ListenContinuouslyAsync()).Forget();
+                }
+                catch (Exception)
+                {
+                    Listening = false;
+                    TcpListener.Stop(); // unblocks AcceptTcpClientAsync()
+                    throw;
+                }
+            }
+
+            Started?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -99,8 +129,18 @@ namespace Soulseek.Network.Tcp
         /// </summary>
         public void Stop()
         {
-            TcpListener.Stop();
-            Listening = false;
+            lock (SyncRoot)
+            {
+                if (!Listening)
+                {
+                    return;
+                }
+
+                Listening = false;
+                TcpListener.Stop(); // unblocks AcceptTcpClientAsync()
+            }
+
+            Stopped?.Invoke(this, EventArgs.Empty);
         }
 
         private async Task ListenContinuouslyAsync()
@@ -109,18 +149,30 @@ namespace Soulseek.Network.Tcp
             {
                 try
                 {
+                    /*
+                        throws if:
+
+                        * the accept() call offloaded to the OS errors for whatever reason (exhaustion, other side hung up)
+                        * the accept() call is being awaited and the Stop() method is invoked (the BCL cleans this up in the socket's finalizer)
+                          in addition to purging any connections that may have been waiting to be accepted
+                        * the Stop() method was invoked prior to this method's invocation (the underlying Socket has been disposed/nulled)
+                    */
                     var client = await TcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
 
                     Task.Run(() =>
                     {
                         var endPoint = (IPEndPoint)client.Client.RemoteEndPoint;
-                        var eventArgs = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
-                        Accepted?.Invoke(this, eventArgs);
+                        var connection = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
+                        Accepted?.Invoke(this, connection);
                     }).Forget();
                 }
                 catch (Exception ex)
                 {
-                    GlobalDiagnostic.Warning($"Listener failed to accept a TCP connection: {ex.Message}.  This is abnormal, and if it persists, restart the application.", ex);
+                    if (Listening)
+                    {
+                        GlobalDiagnostic.Warning($"Listener failed to accept a TCP connection: {ex.Message}.  This is abnormal, and if it persists, restart the application.", ex);
+                        await Task.Delay(100).ConfigureAwait(false);
+                    }
                 }
             }
         }

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -24,7 +24,6 @@
 namespace Soulseek.Network.Tcp
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Net;
     using System.Net.Sockets;
     using System.Threading.Tasks;
@@ -38,7 +37,6 @@ namespace Soulseek.Network.Tcp
     ///     bunch of hoops need to be jumped through to handle TcpClients coming from the listener not connected/without an
     ///     endpoint, both of which will and SHOULD throw exceptions and die.
     /// </remarks>
-    [ExcludeFromCodeCoverage]
     internal sealed class Listener : IListener
     {
         /// <summary>
@@ -127,7 +125,14 @@ namespace Soulseek.Network.Tcp
                 }
             }
 
-            Started?.Invoke(this, EventArgs.Empty);
+            try
+            {
+                Started?.Invoke(this, EventArgs.Empty);
+            }
+            catch
+            {
+                // noop
+            }
         }
 
         /// <summary>
@@ -146,7 +151,14 @@ namespace Soulseek.Network.Tcp
                 TcpListener.Stop(); // unblocks AcceptTcpClientAsync()
             }
 
-            Stopped?.Invoke(this, EventArgs.Empty);
+            try
+            {
+                Stopped?.Invoke(this, EventArgs.Empty);
+            }
+            catch
+            {
+                // noop
+            }
         }
 
         private async Task ListenContinuouslyAsync()

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -160,7 +160,7 @@ namespace Soulseek.Network.Tcp
                         {
                             // the remote client disconnected between the OS accepting the socket and construction of
                             // the Connection instance completing; treat this the same as any other accept failure
-                            throw new ConnectionException($"Failed to establish a connection to {endPoint}: the remote client disconnected before the connection could be accepted");
+                            throw new ConnectionException($"The remote client disconnected before the connection could be accepted");
                         }
 
                         ConsecutiveErrors = 0; // reset on success

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -65,16 +65,6 @@ namespace Soulseek.Network.Tcp
         public event EventHandler<Exception> Error;
 
         /// <summary>
-        ///     Occurs when the listener has started listening.
-        /// </summary>
-        public event EventHandler Started;
-
-        /// <summary>
-        ///     Occurs when the listener has stopped listening.
-        /// </summary>
-        public event EventHandler Stopped;
-
-        /// <summary>
         ///     Gets the options used when creating new <see cref="IConnection"/> instances.
         /// </summary>
         public ConnectionOptions ConnectionOptions { get; }
@@ -124,15 +114,6 @@ namespace Soulseek.Network.Tcp
                     throw;
                 }
             }
-
-            try
-            {
-                Started?.Invoke(this, EventArgs.Empty);
-            }
-            catch
-            {
-                // noop
-            }
         }
 
         /// <summary>
@@ -149,15 +130,6 @@ namespace Soulseek.Network.Tcp
 
                 Listening = false;
                 TcpListener.Stop(); // unblocks AcceptTcpClientAsync()
-            }
-
-            try
-            {
-                Stopped?.Invoke(this, EventArgs.Empty);
-            }
-            catch
-            {
-                // noop
             }
         }
 

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -28,7 +28,6 @@ namespace Soulseek.Network.Tcp
     using System.Net;
     using System.Net.Sockets;
     using System.Threading.Tasks;
-    using Soulseek.Diagnostics;
 
     /// <summary>
     ///     Listens for client connections for TCP network services.
@@ -99,6 +98,8 @@ namespace Soulseek.Network.Tcp
 
         private object SyncRoot { get; } = new object();
         private ITcpListener TcpListener { get; set; }
+        private long MaxConsecutiveErrors { get; } = 100;
+        private long ConsecutiveErrors { get; set; } // overflows after ~29 billion years
 
         /// <summary>
         ///     Starts the listener.
@@ -164,6 +165,8 @@ namespace Soulseek.Network.Tcp
                     */
                     var client = await TcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
 
+                    ConsecutiveErrors = 0; // reset on success
+
                     Task.Run(() =>
                     {
                         var endPoint = (IPEndPoint)client.Client.RemoteEndPoint;
@@ -173,10 +176,32 @@ namespace Soulseek.Network.Tcp
                 }
                 catch (Exception ex)
                 {
-                    if (Listening)
+                    // if Listening has dropped, Stop() was called and we should exit. the exception isn't interesting here
+                    // because Stop() will cause any waiting AcceptTcpClientAsync() call to throw when it's called
+                    if (!Listening)
                     {
-                        GlobalDiagnostic.Warning($"Listener failed to accept a TCP connection: {ex.Message}.  This is abnormal, and if it persists, restart the application.", ex);
-                        await Task.Delay(100).ConfigureAwait(false);
+                        return;
+                    }
+
+                    ConsecutiveErrors++;
+
+                    try
+                    {
+                        Error?.Invoke(this, ex);
+                    }
+                    finally
+                    {
+                        /*
+                            if AcceptTcpClientAsync() threw because of a non-transient issue, allowing the loop to come
+                            back around and call it immediately will put this in a continuous, fast loop and peg the CPU.
+                            once we have hit our MaxConsecutiveErrors, begin waiting a generous amount of time before looping again.
+                            this spares the pegged CPU while also allowing the listener to recover automatically if/when whatever
+                            condition that's causing the exceptions is resolved (outside of the application)
+                        */
+                        if (ConsecutiveErrors > MaxConsecutiveErrors)
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        }
                     }
                 }
             }

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -98,7 +98,7 @@ namespace Soulseek.Network.Tcp
 
         private object SyncRoot { get; } = new object();
         private ITcpListener TcpListener { get; set; }
-        private long MaxConsecutiveErrors { get; } = 100;
+        private long MaxConsecutiveErrors { get; } = 20;
         private long ConsecutiveErrors { get; set; } // overflows after ~29 billion years
 
         /// <summary>

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -165,14 +165,26 @@ namespace Soulseek.Network.Tcp
                     */
                     var client = await TcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
 
-                    ConsecutiveErrors = 0; // reset on success
+                    Connection connection = default;
 
-                    Task.Run(() =>
+                    try
                     {
                         var endPoint = (IPEndPoint)client.Client.RemoteEndPoint;
-                        var connection = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
-                        Accepted?.Invoke(this, connection);
-                    }).Forget();
+                        connection = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
+
+                        ConsecutiveErrors = 0; // reset on success
+
+                        _ = Task
+                            .Run(() => Accepted?.Invoke(this, connection))
+                            .ContinueWith(task => _ = task.Exception, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.RunContinuationsAsynchronously);
+                    }
+                    catch
+                    {
+                        client?.TryDispose();
+                        connection?.TryDispose();
+
+                        throw;
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -189,6 +201,10 @@ namespace Soulseek.Network.Tcp
                     {
                         Error?.Invoke(this, ex);
                     }
+                    catch
+                    {
+                        // noop
+                    }
                     finally
                     {
                         /*
@@ -198,7 +214,7 @@ namespace Soulseek.Network.Tcp
                             this spares the pegged CPU while also allowing the listener to recover automatically if/when whatever
                             condition that's causing the exceptions is resolved (outside of the application)
                         */
-                        if (ConsecutiveErrors > MaxConsecutiveErrors)
+                        if (ConsecutiveErrors >= MaxConsecutiveErrors)
                         {
                             await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                         }

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -28,6 +28,7 @@ namespace Soulseek.Network.Tcp
     using System.Net;
     using System.Net.Sockets;
     using System.Threading.Tasks;
+    using Soulseek.Diagnostics;
 
     /// <summary>
     ///     Listens for client connections for TCP network services.
@@ -106,14 +107,21 @@ namespace Soulseek.Network.Tcp
         {
             while (Listening)
             {
-                var client = await TcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
-
-                Task.Run(() =>
+                try
                 {
-                    var endPoint = (IPEndPoint)client.Client.RemoteEndPoint;
-                    var eventArgs = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
-                    Accepted?.Invoke(this, eventArgs);
-                }).Forget();
+                    var client = await TcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
+
+                    Task.Run(() =>
+                    {
+                        var endPoint = (IPEndPoint)client.Client.RemoteEndPoint;
+                        var eventArgs = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
+                        Accepted?.Invoke(this, eventArgs);
+                    }).Forget();
+                }
+                catch (Exception ex)
+                {
+                    GlobalDiagnostic.Warning($"Listener failed to accept a TCP connection: {ex.Message}.  This is abnormal, and if it persists, restart the application.", ex);
+                }
             }
         }
     }

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -63,6 +63,11 @@ namespace Soulseek.Network.Tcp
         public event EventHandler<IConnection> Accepted;
 
         /// <summary>
+        ///     Occurs when the listener encounters an exception while accepting a connection.
+        /// </summary>
+        public event EventHandler<Exception> Error;
+
+        /// <summary>
         ///     Occurs when the listener has started listening.
         /// </summary>
         public event EventHandler Started;

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -184,6 +184,13 @@ namespace Soulseek.Network.Tcp
                         var endPoint = (IPEndPoint)client.Client.RemoteEndPoint;
                         connection = new Connection(endPoint, ConnectionOptions, new TcpClientAdapter(client));
 
+                        if (connection.State != ConnectionState.Connected)
+                        {
+                            // the remote client disconnected between the OS accepting the socket and construction of
+                            // the Connection instance completing; treat this the same as any other accept failure
+                            throw new ConnectionException($"Failed to establish a connection to {endPoint}: the remote client disconnected before the connection could be accepted");
+                        }
+
                         ConsecutiveErrors = 0; // reset on success
 
                         _ = Task

--- a/src/Network/Tcp/TcpListenerAdapter.cs
+++ b/src/Network/Tcp/TcpListenerAdapter.cs
@@ -48,6 +48,11 @@ namespace Soulseek.Network.Tcp
             TcpListener = tcpListener ?? new TcpListener(IPAddress.Parse("0.0.0.0"), 1);
         }
 
+        /// <summary>
+        ///     Gets the underlying <see cref="Socket"/> used by the listener.
+        /// </summary>
+        public Socket Server => TcpListener.Server;
+
         private TcpListener TcpListener { get; set; }
 
         /// <summary>
@@ -78,10 +83,12 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Starts listening for incoming connection requests.
         /// </summary>
+        /// <param name="backlog">The maximum number of pending connections the OS will queue for this listener.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when a negative backlog value is provided.</exception>
         /// <exception cref="SocketException">Thrown when an error occurrs while accessing the socket.</exception>
-        public void Start()
+        public void Start(int backlog = (int)SocketOptionName.MaxConnections)
         {
-            TcpListener.Start();
+            TcpListener.Start(backlog);
         }
 
         /// <summary>

--- a/src/Network/Tcp/TcpListenerAdapter.cs
+++ b/src/Network/Tcp/TcpListenerAdapter.cs
@@ -48,11 +48,6 @@ namespace Soulseek.Network.Tcp
             TcpListener = tcpListener ?? new TcpListener(IPAddress.Parse("0.0.0.0"), 1);
         }
 
-        /// <summary>
-        ///     Gets the underlying <see cref="Socket"/> used by the listener.
-        /// </summary>
-        public Socket Server => TcpListener.Server;
-
         private TcpListener TcpListener { get; set; }
 
         /// <summary>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3093,6 +3093,7 @@ namespace Soulseek
                     {
                         Listener = new Listener(Options.ListenIPAddress, Options.ListenPort, connectionOptions: Options.IncomingConnectionOptions);
                         Listener.Accepted += ListenerHandler.HandleConnection;
+                        Listener.Error += ListenerHandler.HandleError;
                         Listener.Start();
                     }
 
@@ -3995,6 +3996,7 @@ namespace Soulseek
                     {
                         Listener = new Listener(Options.ListenIPAddress, Options.ListenPort, Options.IncomingConnectionOptions);
                         Listener.Accepted += ListenerHandler.HandleConnection;
+                        Listener.Error += ListenerHandler.HandleError;
                         Listener.Start();
                     }
                 }

--- a/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ConnectAsyncTests.cs
@@ -93,6 +93,25 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "Connect")]
+        [Theory(DisplayName = "Assigns a handler to Listener.Error when EnableListener is true"), AutoData]
+        public async Task Assigns_A_Handler_To_Listener_Error_When_EnableListener_Is_True(string username, string password)
+        {
+            var (client, mocks) = GetFixture(new SoulseekClientOptions(enableListener: true, listenPort: Mocks.Port));
+
+            using (client)
+            {
+                await client.ConnectAsync(username, password);
+
+                Assert.NotNull(client.Listener);
+
+                var raisedException = new Exception("error raised for test");
+                client.Listener.RaiseEvent(typeof(Listener), "Error", raisedException);
+
+                mocks.ListenerHandler.Verify(m => m.HandleError(client.Listener, raisedException), Times.Once);
+            }
+        }
+
+        [Trait("Category", "Connect")]
         [Theory(DisplayName = "Address throws ArgumentOutOfRangeException on bad port")]
         [InlineData(-1)]
         [InlineData(65536)]
@@ -596,6 +615,7 @@ namespace Soulseek.Tests.Unit.Client
                 distributedConnectionManager: mocks.DistributedConnectionManager.Object,
                 connectionFactory: mocks.ConnectionFactory.Object,
                 waiter: mocks.Waiter.Object,
+                listenerHandler: mocks.ListenerHandler.Object,
                 options: clientOptions ?? new SoulseekClientOptions(enableListener: false));
 
             return (client, mocks);
@@ -631,6 +651,7 @@ namespace Soulseek.Tests.Unit.Client
             public Mock<IWaiter> Waiter { get; } = new Mock<IWaiter>();
             public Mock<IConnectionFactory> ConnectionFactory { get; }
             public Mock<IDistributedConnectionManager> DistributedConnectionManager { get; }
+            public Mock<IListenerHandler> ListenerHandler { get; } = new Mock<IListenerHandler>();
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -317,6 +317,31 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Assigns a handler to Listener.Error when a new listener is created")]
+        public async Task Assigns_A_Handler_To_Listener_Error_When_A_New_Listener_Is_Created()
+        {
+            var (client, mocks) = GetFixture(new SoulseekClientOptions(listenPort: Mocks.Port));
+
+            mocks.Listener.Setup(m => m.Listening).Returns(true);
+
+            var patch = new SoulseekClientOptionsPatch(listenPort: Mocks.Port);
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await client.ReconfigureOptionsAsync(patch);
+
+                Assert.NotNull(client.Listener);
+
+                var raisedException = new Exception("error raised for test");
+                client.Listener.RaiseEvent(typeof(Listener), "Error", raisedException);
+
+                mocks.ListenerHandler.Verify(m => m.HandleError(client.Listener, raisedException), Times.Once);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
         [Fact(DisplayName = "Reconfigures listener if ListenIPAddress changed")]
         public async Task Reconfigures_Listener_If_ListenIPAddress_Changed()
         {
@@ -646,6 +671,7 @@ namespace Soulseek.Tests.Unit.Client
                 connectionFactory: mocks.ConnectionFactory.Object,
                 serverConnection: mocks.ServerConnection.Object,
                 listener: mocks.Listener.Object,
+                listenerHandler: mocks.ListenerHandler.Object,
                 uploadTokenBucket: mocks.UploadTokenBucket.Object,
                 downloadTokenBucket: mocks.DownloadTokenBucket.Object,
                 options: clientOptions ?? new SoulseekClientOptions(enableListener: false));
@@ -679,6 +705,7 @@ namespace Soulseek.Tests.Unit.Client
             public Mock<IMessageConnection> ServerConnection { get; } = new Mock<IMessageConnection>();
             public Mock<IConnectionFactory> ConnectionFactory { get; }
             public Mock<IListener> Listener { get; } = new Mock<IListener>();
+            public Mock<IListenerHandler> ListenerHandler { get; } = new Mock<IListenerHandler>();
             public Mock<IDistributedConnectionManager> DistributedConnectionManager { get; }
             public Mock<ITokenBucket> UploadTokenBucket { get; } = new Mock<ITokenBucket>();
             public Mock<ITokenBucket> DownloadTokenBucket { get; } = new Mock<ITokenBucket>();

--- a/tests/Soulseek.Tests.Unit/Common/ExtensionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Common/ExtensionsTests.cs
@@ -20,6 +20,7 @@ namespace Soulseek.Tests.Unit
     using System;
     using System.Collections.Concurrent;
     using System.Timers;
+    using Moq;
     using Xunit;
 
     public class ExtensionsTests
@@ -60,6 +61,41 @@ namespace Soulseek.Tests.Unit
             var ex = Record.Exception(() => timer.Reset());
 
             Assert.Null(ex);
+        }
+
+        [Trait("Category", "Extension")]
+        [Fact(DisplayName = "TryDispose does not throw if Dispose throws")]
+        public void TryDispose_Does_Not_Throw_If_Dispose_Throws()
+        {
+            var obj = new Mock<IDisposable>();
+            obj.Setup(m => m.Dispose()).Throws(new Exception());
+
+            var ex1 = Record.Exception(() => obj.Object.Dispose());
+
+            Assert.NotNull(ex1);
+
+            var ex2 = Record.Exception(() => obj.Object.TryDispose());
+
+            Assert.Null(ex2);
+        }
+
+        [Trait("Category", "Extension")]
+        [Fact(DisplayName = "TryDispose returns false if Dispose throws")]
+        public void TryDispose_Returns_False_If_Dispose_Throws()
+        {
+            var obj = new Mock<IDisposable>();
+            obj.Setup(m => m.Dispose()).Throws(new Exception());
+
+            Assert.False(obj.Object.TryDispose());
+        }
+
+        [Trait("Category", "Extension")]
+        [Fact(DisplayName = "TryDispose returns true if Dispose does not throw")]
+        public void TryDispose_Returns_True_If_Dispose_Does_Not_Throw()
+        {
+            var obj = new Mock<IDisposable>();
+
+            Assert.True(obj.Object.TryDispose());
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Network/ListenerHandlerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/ListenerHandlerTests.cs
@@ -107,6 +107,25 @@ namespace Soulseek.Tests.Unit.Network
         }
 
         [Trait("Category", "Diagnostic")]
+        [Theory(DisplayName = "Creates diagnostic on error"), AutoData]
+        public void Creates_Diagnostic_On_Error(IPEndPoint endpoint, string message)
+        {
+            var (handler, mocks) = GetFixture(endpoint);
+
+            mocks.Diagnostic.Setup(m => m.Warning(It.IsAny<string>(), It.IsAny<Exception>()));
+
+            var exception = new Exception(message);
+
+            handler.HandleError(null, exception);
+
+            mocks.Diagnostic.Verify(
+                m => m.Warning(
+                    It.Is<string>(s => s.Contains("Failed to establish an incoming connection", StringComparison.InvariantCultureIgnoreCase) && s.Contains(message, StringComparison.InvariantCultureIgnoreCase)),
+                    exception),
+                Times.Once);
+        }
+
+        [Trait("Category", "Diagnostic")]
         [Theory(DisplayName = "Creates diagnostic on unknown connection"), AutoData]
         public void Creates_Diagnostic_On_Unknown_Connection(IPEndPoint endpoint)
         {

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -441,7 +441,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.AtLeast(2));
         }
 
-        [Trait("Category", "Stop")]
+        [Trait("Category", "Accept Loop")]
         [Fact(DisplayName = "Stop halts the accept loop")]
         public async Task Stop_Halts_The_Accept_Loop()
         {

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -638,12 +638,11 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             var options = new ConnectionOptions();
             var port = GetPort();
 
-            var client = new DisposeTrackingTcpClient
-            {
-                // forces a NullReferenceException when the loop dereferences client.Client.RemoteEndPoint,
-                // so the exception is thrown before "connection" is ever assigned in ListenContinuouslyAsync
-                Client = null,
-            };
+            var client = new DisposeTrackingTcpClient();
+
+            // dispose the underlying socket directly so client.Client.RemoteEndPoint throws ObjectDisposedException
+            // this happens before "connection" is ever assigned in ListenContinuouslyAsync, so connection stays unset
+            client.Client.Dispose();
 
             var tcpListener = new Mock<ITcpListener>();
             tcpListener.Setup(m => m.AcceptTcpClientAsync())
@@ -666,7 +665,43 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             await task;
 
             Assert.True(client.Disposed);
-            Assert.IsType<NullReferenceException>(raised);
+            Assert.IsType<ObjectDisposedException>(raised);
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop disposes the client and connection and rethrows when the accepted client never finished connecting")]
+        public async Task Accept_Loop_Disposes_The_Client_And_Connection_And_Rethrows_When_The_Accepted_Client_Never_Finished_Connecting()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            // a freshly-constructed, never-connected TcpClient: client.Client.RemoteEndPoint resolves to null
+            // (rather than throwing) for a live-but-unconnected socket, so the endpoint cast succeeds and
+            // Connection construction completes, but with TcpClient.Connected == false the whole way through
+            var client = new DisposeTrackingTcpClient();
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ReturnsAsync(client);
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+            l.SetProperty("Listening", true);
+
+            Exception raised = null;
+            l.Error += (sender, ex) =>
+            {
+                raised = ex;
+                l.SetProperty("Listening", false); // stop the loop after the first (and only) iteration
+            };
+
+            var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+            var completed = await Task.WhenAny(task, Task.Delay(2000));
+            Assert.Same(task, completed);
+            await task;
+
+            Assert.True(client.Disposed);
+            Assert.IsType<ConnectionException>(raised);
         }
 
         [Trait("Category", "Accept Loop")]

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -20,13 +20,12 @@ namespace Soulseek.Tests.Unit.Network.Tcp
     using System;
     using System.Net;
     using System.Net.Sockets;
+    using System.Threading;
     using System.Threading.Tasks;
     using Moq;
-    using Soulseek.Diagnostics;
     using Soulseek.Network.Tcp;
     using Xunit;
 
-    [Collection(nameof(GlobalDiagnosticTests))]
     public class ListenerTests
     {
         private static readonly Random RNG = new Random();
@@ -136,6 +135,117 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             // if the exception thrown while dispatching the accepted connection escaped and killed the loop,
             // AcceptTcpClientAsync() would only ever be called once
             tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.AtLeast(2));
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop continues if AcceptTcpClientAsync throws a non-socket exception")]
+        public async Task Accept_Loop_Continues_If_AcceptTcpClientAsync_Throws_Non_Socket_Exception()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+
+            // the catch block should be broad enough to handle any exception, not just SocketException
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ThrowsAsync(new InvalidOperationException("boom"));
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            await Task.Delay(200);
+
+            l.Stop();
+
+            tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.AtLeast(2));
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop halts the accept loop")]
+        public async Task Stop_Halts_The_Accept_Loop()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ThrowsAsync(new SocketException());
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            await Task.Delay(200);
+
+            l.Stop();
+
+            // give any in-flight iteration a chance to finish and the loop to observe Listening == false
+            await Task.Delay(200);
+
+            var countAfterStop = tcpListener.Invocations.Count;
+
+            await Task.Delay(200);
+
+            // no further calls should occur once the loop has actually exited
+            Assert.Equal(countAfterStop, tcpListener.Invocations.Count);
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop raises Accepted with the accepted connection")]
+        public async Task Accept_Loop_Raises_Accepted_With_Accepted_Connection()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            // a real, connected loopback pair is required here; an unconnected TcpClient throws
+            // when its RemoteEndPoint is accessed, so a mock TcpClient won't do
+            var serverListener = new TcpListener(IPAddress.Loopback, 0);
+            serverListener.Start();
+            var serverPort = ((IPEndPoint)serverListener.LocalEndpoint).Port;
+
+            using (var client = new TcpClient())
+            {
+                var connectTask = client.ConnectAsync(IPAddress.Loopback, serverPort);
+                var acceptedClient = await serverListener.AcceptTcpClientAsync();
+                await connectTask;
+
+                serverListener.Stop();
+
+                var callCount = 0;
+
+                var tcpListener = new Mock<ITcpListener>();
+                tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                    .Returns(() =>
+                    {
+                        // hand back the real connection once, then fail fast on every subsequent call so the
+                        // loop spins harmlessly (and quickly) until Stop() is called
+                        if (Interlocked.Increment(ref callCount) == 1)
+                        {
+                            return Task.FromResult(acceptedClient);
+                        }
+
+                        return Task.FromException<TcpClient>(new ObjectDisposedException(nameof(TcpListener)));
+                    });
+
+                var tcs = new TaskCompletionSource<IConnection>();
+
+                var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+                l.Accepted += (sender, connection) => tcs.TrySetResult(connection);
+
+                l.Start();
+
+                var completed = await Task.WhenAny(tcs.Task, Task.Delay(2000));
+
+                l.Stop();
+
+                Assert.Same(tcs.Task, completed);
+
+                var raised = await tcs.Task;
+
+                Assert.NotNull(raised);
+                Assert.Equal(((IPEndPoint)acceptedClient.Client.RemoteEndPoint).Address, raised.IPEndPoint.Address);
+            }
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -41,8 +41,9 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var options = new ConnectionOptions();
             var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
 
-            var l = new Listener(IPAddress.Any, port, options);
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
 
             Assert.Equal(IPAddress.Any, l.IPAddress);
             Assert.Equal(port, l.Port);
@@ -56,8 +57,9 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         public void Uses_Default_ConnectionOptions_If_None_Supplied()
         {
             var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
 
-            var l = new Listener(IPAddress.Any, port, connectionOptions: null);
+            var l = new Listener(IPAddress.Any, port, connectionOptions: null, tcpListener.Object);
 
             Assert.NotNull(l.ConnectionOptions);
         }
@@ -97,8 +99,9 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var options = new ConnectionOptions();
             var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
 
-            var l = new Listener(IPAddress.Any, port, options);
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
 
             var first = l.Listening;
 
@@ -106,6 +109,135 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             Assert.False(first);
             Assert.True(l.Listening);
+
+            tcpListener.Verify(m => m.Start(It.IsAny<int>()), Times.Once);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start starts TcpListener")]
+        public void Start_Starts_TcpListner()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            tcpListener.Verify(m => m.Start(It.IsAny<int>()), Times.Once);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start raises Started when starting")]
+        public void Start_Raises_Started_When_Starting()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            var raised = false;
+            l.Started += (sender, args) => raised = true;
+
+            l.Start();
+
+            Assert.True(raised);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start does not raise Started if already listening")]
+        public void Start_Does_Not_Raise_Started_If_Already_Listening()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            var raised = false;
+            l.Started += (sender, args) => raised = true;
+
+            l.Start();
+
+            Assert.False(raised);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start does not start listener if already listening")]
+        public void Start_Does_Not_Start_Listener_If_Already_Listening()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+            l.Start();
+
+            tcpListener.Verify(m => m.Start(It.IsAny<int>()), Times.Once);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start does not throw when Started is unbound")]
+        public void Start_Does_Not_Throw_When_Started_Is_Unbound()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            var ex = Record.Exception(() => l.Start());
+
+            Assert.Null(ex);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start does not throw when Started throws")]
+        public void Start_Does_Not_Throw_When_Started_Throws()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Started += (_, e) => throw new Exception();
+
+            var ex = Record.Exception(() => l.Start());
+
+            Assert.Null(ex);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start stops the listener if an exception is encountered")]
+        public void Start_Stops_The_Listener_If_An_Exception_Is_Encountered()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.Start(It.IsAny<int>()))
+                .Throws(new SocketException());
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            var startedRaised = false;
+            l.Started += (sender, args) => startedRaised = true;
+
+            var ex = Record.Exception(() => l.Start());
+
+            Assert.NotNull(ex);
+            Assert.False(l.Listening);
+            Assert.False(startedRaised);
+
+            // Stop() is invoked to unblock any pending AcceptTcpClientAsync() call, even though Start() never succeeded
+            tcpListener.Verify(m => m.Stop(), Times.Once);
         }
 
         [Trait("Category", "Stop")]

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -18,6 +18,7 @@
 namespace Soulseek.Tests.Unit.Network.Tcp
 {
     using System;
+    using System.Diagnostics;
     using System.Net;
     using System.Net.Sockets;
     using System.Threading;
@@ -525,6 +526,296 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
                 Assert.NotNull(raised);
                 Assert.Equal(((IPEndPoint)acceptedClient.Client.RemoteEndPoint).Address, raised.IPEndPoint.Address);
+            }
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop exits when Listening transitions to false between iterations")]
+        public async Task Accept_Loop_Exits_When_Listening_Transitions_To_False_Between_Iterations()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var (acceptedClient, connectingClient, _) = await CreateConnectedClientPairAsync();
+
+            using (connectingClient)
+            using (acceptedClient)
+            {
+                var tcpListener = new Mock<ITcpListener>();
+
+                var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+                // the accept succeeds (no exception), so the loop should return to the top, observe that
+                // Listening has gone false, and exit via the while condition rather than via the catch block
+                tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                    .Callback(() => l.SetProperty("Listening", false))
+                    .ReturnsAsync(acceptedClient);
+
+                l.SetProperty("Listening", true);
+
+                var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+                var completed = await Task.WhenAny(task, Task.Delay(2000));
+                Assert.Same(task, completed);
+                await task;
+
+                tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.Once);
+            }
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop does not raise Error when a pending accept throws after Listening has stopped")]
+        public async Task Accept_Loop_Does_Not_Raise_Error_When_A_Pending_Accept_Throws_After_Listening_Has_Stopped()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var acceptTcs = new TaskCompletionSource<TcpClient>();
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .Returns(acceptTcs.Task);
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+            l.SetProperty("Listening", true);
+
+            var errorRaised = false;
+            l.Error += (sender, ex) => errorRaised = true;
+
+            var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+            // simulate Stop() having been called while AcceptTcpClientAsync() was still pending; Stop()
+            // itself would cause that pending call to throw, so replicate that directly via the tcs
+            l.SetProperty("Listening", false);
+            acceptTcs.TrySetException(new ObjectDisposedException(nameof(TcpListener)));
+
+            var completed = await Task.WhenAny(task, Task.Delay(2000));
+            Assert.Same(task, completed);
+            await task; // should not throw; the exception is expected and swallowed
+
+            Assert.False(errorRaised);
+            Assert.Equal(0, l.GetProperty<long>("ConsecutiveErrors"));
+            tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.Once);
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop raises Error for exceptions encountered while still listening")]
+        public async Task Accept_Loop_Raises_Error_For_Exceptions_Encountered_While_Still_Listening()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var thrown = new InvalidOperationException("boom");
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ThrowsAsync(thrown);
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+            l.SetProperty("Listening", true);
+
+            Exception raised = null;
+            l.Error += (sender, ex) =>
+            {
+                raised = ex;
+                l.SetProperty("Listening", false); // stop the loop once the failure has been reported
+            };
+
+            var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+            var completed = await Task.WhenAny(task, Task.Delay(2000));
+            Assert.Same(task, completed);
+            await task;
+
+            Assert.Same(thrown, raised);
+            Assert.Equal(1, l.GetProperty<long>("ConsecutiveErrors"));
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop disposes the client and rethrows when the accepted client's endpoint can't be resolved")]
+        public async Task Accept_Loop_Disposes_The_Client_And_Rethrows_When_The_Endpoint_Cannot_Be_Resolved()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var client = new DisposeTrackingTcpClient
+            {
+                // forces a NullReferenceException when the loop dereferences client.Client.RemoteEndPoint,
+                // so the exception is thrown before "connection" is ever assigned in ListenContinuouslyAsync
+                Client = null,
+            };
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ReturnsAsync(client);
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+            l.SetProperty("Listening", true);
+
+            Exception raised = null;
+            l.Error += (sender, ex) =>
+            {
+                raised = ex;
+                l.SetProperty("Listening", false); // stop the loop after the first (and only) iteration
+            };
+
+            var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+            var completed = await Task.WhenAny(task, Task.Delay(2000));
+            Assert.Same(task, completed);
+            await task;
+
+            Assert.True(client.Disposed);
+            Assert.IsType<NullReferenceException>(raised);
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop delays one second once consecutive errors reach the maximum")]
+        public async Task Accept_Loop_Delays_One_Second_Once_Consecutive_Errors_Reach_The_Maximum()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            var max = l.GetProperty<long>("MaxConsecutiveErrors");
+
+            var callCount = 0L;
+            var stopwatch = Stopwatch.StartNew();
+            var elapsedAtMax = -1L;
+            var elapsedAfterMax = -1L;
+
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .Returns(() =>
+                {
+                    var count = Interlocked.Increment(ref callCount);
+
+                    if (count == max)
+                    {
+                        elapsedAtMax = stopwatch.ElapsedMilliseconds;
+                    }
+                    else if (count == max + 1)
+                    {
+                        elapsedAfterMax = stopwatch.ElapsedMilliseconds;
+
+                        // stop the loop; this call's exception will hit the early-return path instead of looping again
+                        l.SetProperty("Listening", false);
+                    }
+
+                    return Task.FromException<TcpClient>(new SocketException());
+                });
+
+            l.SetProperty("Listening", true);
+
+            var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+            var completed = await Task.WhenAny(task, Task.Delay(5000));
+            Assert.Same(task, completed);
+            await task;
+
+            Assert.True(elapsedAtMax >= 0 && elapsedAtMax < 500, $"expected the first {max} failures to run back-to-back without delay, but they took {elapsedAtMax}ms");
+            Assert.True(elapsedAfterMax - elapsedAtMax >= 900, $"expected a ~1 second delay after the {max}th consecutive failure, but only {elapsedAfterMax - elapsedAtMax}ms elapsed");
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop resets the consecutive error count after a successful accept")]
+        public async Task Accept_Loop_Resets_The_Consecutive_Error_Count_After_A_Successful_Accept()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var (acceptedClient, connectingClient, _) = await CreateConnectedClientPairAsync();
+
+            using (connectingClient)
+            using (acceptedClient)
+            {
+                var callCount = 0;
+
+                var tcpListener = new Mock<ITcpListener>();
+                var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+                tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                    .Returns(() =>
+                    {
+                        var count = Interlocked.Increment(ref callCount);
+
+                        if (count <= 2)
+                        {
+                            return Task.FromException<TcpClient>(new SocketException());
+                        }
+
+                        // stop the loop once the successful accept has been fully processed
+                        l.SetProperty("Listening", false);
+                        return Task.FromResult(acceptedClient);
+                    });
+
+                l.SetProperty("Listening", true);
+
+                var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+                var completed = await Task.WhenAny(task, Task.Delay(2000));
+                Assert.Same(task, completed);
+                await task;
+
+                Assert.Equal(0, l.GetProperty<long>("ConsecutiveErrors"));
+            }
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop does not throw when the Error handler throws")]
+        public async Task Accept_Loop_Does_Not_Throw_When_The_Error_Handler_Throws()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ThrowsAsync(new SocketException());
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+            l.SetProperty("Listening", true);
+
+            l.Error += (sender, err) =>
+            {
+                l.SetProperty("Listening", false); // stop the loop before the handler throws
+                throw new Exception("handler boom");
+            };
+
+            var task = l.InvokeMethod<Task>("ListenContinuouslyAsync");
+
+            var completed = await Task.WhenAny(task, Task.Delay(2000));
+            Assert.Same(task, completed);
+
+            var ex = await Record.ExceptionAsync(() => task);
+
+            Assert.Null(ex);
+        }
+
+        private static async Task<(TcpClient AcceptedClient, TcpClient ConnectingClient, TcpListener ServerListener)> CreateConnectedClientPairAsync()
+        {
+            var serverListener = new TcpListener(IPAddress.Loopback, 0);
+            serverListener.Start();
+            var serverPort = ((IPEndPoint)serverListener.LocalEndpoint).Port;
+
+            var connectingClient = new TcpClient();
+            var connectTask = connectingClient.ConnectAsync(IPAddress.Loopback, serverPort);
+            var acceptedClient = await serverListener.AcceptTcpClientAsync();
+            await connectTask;
+
+            serverListener.Stop();
+
+            return (acceptedClient, connectingClient, serverListener);
+        }
+
+        private sealed class DisposeTrackingTcpClient : TcpClient
+        {
+            public bool Disposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = true;
+                base.Dispose(disposing);
             }
         }
     }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -19,9 +19,14 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 {
     using System;
     using System.Net;
+    using System.Net.Sockets;
+    using System.Threading.Tasks;
+    using Moq;
+    using Soulseek.Diagnostics;
     using Soulseek.Network.Tcp;
     using Xunit;
 
+    [Collection(nameof(GlobalDiagnosticTests))]
     public class ListenerTests
     {
         private static readonly Random RNG = new Random();
@@ -81,6 +86,56 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             Assert.True(first);
             Assert.False(l.Listening);
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop continues if AcceptTcpClientAsync throws")]
+        public async Task Accept_Loop_Continues_If_AcceptTcpClientAsync_Throws()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ThrowsAsync(new SocketException());
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            await Task.Delay(200);
+
+            l.Stop();
+
+            // if the exception thrown by AcceptTcpClientAsync() escaped the loop, it would only ever be called once
+            tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.AtLeast(2));
+        }
+
+        [Trait("Category", "Accept Loop")]
+        [Fact(DisplayName = "Accept loop continues if the accepted connection dispatch throws")]
+        public async Task Accept_Loop_Continues_If_Accepted_Dispatch_Throws()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var tcpListener = new Mock<ITcpListener>();
+
+            // an unconnected TcpClient throws when its RemoteEndPoint is accessed; this happens inside the
+            // fire-and-forget Task.Run() used to dispatch the Accepted event, not in the loop's try/catch
+            tcpListener.Setup(m => m.AcceptTcpClientAsync())
+                .ReturnsAsync(() => new TcpClient());
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            await Task.Delay(200);
+
+            l.Stop();
+
+            // if the exception thrown while dispatching the accepted connection escaped and killed the loop,
+            // AcceptTcpClientAsync() would only ever be called once
+            tcpListener.Verify(m => m.AcceptTcpClientAsync(), Times.AtLeast(2));
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -128,44 +128,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         }
 
         [Trait("Category", "Start")]
-        [Fact(DisplayName = "Start raises Started when starting")]
-        public void Start_Raises_Started_When_Starting()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            var raised = false;
-            l.Started += (sender, args) => raised = true;
-
-            l.Start();
-
-            Assert.True(raised);
-        }
-
-        [Trait("Category", "Start")]
-        [Fact(DisplayName = "Start does not raise Started if already listening")]
-        public void Start_Does_Not_Raise_Started_If_Already_Listening()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            l.Start();
-
-            var raised = false;
-            l.Started += (sender, args) => raised = true;
-
-            l.Start();
-
-            Assert.False(raised);
-        }
-
-        [Trait("Category", "Start")]
         [Fact(DisplayName = "Start does not start listener if already listening")]
         public void Start_Does_Not_Start_Listener_If_Already_Listening()
         {
@@ -182,38 +144,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         }
 
         [Trait("Category", "Start")]
-        [Fact(DisplayName = "Start does not throw when Started is unbound")]
-        public void Start_Does_Not_Throw_When_Started_Is_Unbound()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            var ex = Record.Exception(() => l.Start());
-
-            Assert.Null(ex);
-        }
-
-        [Trait("Category", "Start")]
-        [Fact(DisplayName = "Start does not throw when Started throws")]
-        public void Start_Does_Not_Throw_When_Started_Throws()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            l.Started += (_, e) => throw new Exception();
-
-            var ex = Record.Exception(() => l.Start());
-
-            Assert.Null(ex);
-        }
-
-        [Trait("Category", "Start")]
         [Fact(DisplayName = "Start stops the listener if an exception is encountered")]
         public void Start_Stops_The_Listener_If_An_Exception_Is_Encountered()
         {
@@ -226,16 +156,13 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
 
-            var startedRaised = false;
-            l.Started += (sender, args) => startedRaised = true;
-
             var ex = Record.Exception(() => l.Start());
 
             Assert.NotNull(ex);
             Assert.False(l.Listening);
-            Assert.False(startedRaised);
 
             // Stop() is invoked to unblock any pending AcceptTcpClientAsync() call, even though Start() never succeeded
+            tcpListener.Verify(m => m.Start(It.IsAny<int>()), Times.Once);
             tcpListener.Verify(m => m.Stop(), Times.Once);
         }
 
@@ -276,45 +203,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         }
 
         [Trait("Category", "Stop")]
-        [Fact(DisplayName = "Stop raises Stopped when stopping")]
-        public void Stop_Raises_Stopped_When_Stopping()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            l.Start();
-
-            var raised = false;
-            l.Stopped += (sender, args) => raised = true;
-
-            l.Stop();
-
-            Assert.True(raised);
-        }
-
-        [Trait("Category", "Stop")]
-        [Fact(DisplayName = "Stop does not raise Stopped if not listening")]
-        public void Stop_Does_Not_Raise_Stopped_If_Not_Listening()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            // start never called
-            var raised = false;
-            l.Stopped += (sender, args) => raised = true;
-
-            l.Stop();
-
-            Assert.False(raised);
-        }
-
-        [Trait("Category", "Stop")]
         [Fact(DisplayName = "Stop does not stop listener if not listening")]
         public void Stop_Does_Not_Stop_Listener_If_Not_Listening()
         {
@@ -330,42 +218,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             l.Stop();
 
             tcpListener.Verify(m => m.Stop(), Times.Once);
-        }
-
-        [Trait("Category", "Stop")]
-        [Fact(DisplayName = "Stop does not throw when Stopped is unbound")]
-        public void Stop_Does_Not_Throw_When_Stopped_Is_Unbound()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            l.Start();
-
-            var ex = Record.Exception(() => l.Stop());
-
-            Assert.Null(ex);
-        }
-
-        [Trait("Category", "Stop")]
-        [Fact(DisplayName = "Stop does not throw when Stopped throws")]
-        public void Stop_Does_Not_Throw_When_Stopped_Throws()
-        {
-            var options = new ConnectionOptions();
-            var port = GetPort();
-            var tcpListener = new Mock<ITcpListener>();
-
-            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
-
-            l.Stopped += (_, e) => throw new Exception();
-
-            l.Start();
-
-            var ex = Record.Exception(() => l.Stop());
-
-            Assert.Null(ex);
         }
 
         [Trait("Category", "Accept Loop")]

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ListenerTests.cs" company="JP Dillingham">
+// <copyright file="ListenerTests.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -49,6 +49,46 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             Assert.Equal(options, l.ConnectionOptions);
 
             Assert.False(l.Listening);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Uses default ConnectionOptions if none supplied")]
+        public void Uses_Default_ConnectionOptions_If_None_Supplied()
+        {
+            var port = GetPort();
+
+            var l = new Listener(IPAddress.Any, port, connectionOptions: null);
+
+            Assert.NotNull(l.ConnectionOptions);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Uses supplied TcpListener")]
+        public void Uses_Supplied_TcpListener()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var listener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener: listener.Object);
+
+            var val = l.GetProperty<ITcpListener>("TcpListener");
+
+            Assert.Equal(listener.Object, val);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Creates TcpListener if none supplied")]
+        public void Creates_TcpListener_If_None_Supplied()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+
+            var l = new Listener(IPAddress.Any, port, options);
+
+            var val = l.GetProperty<ITcpListener>("TcpListener");
+
+            Assert.NotNull(val);
         }
 
         [Trait("Category", "Start")]

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -109,8 +109,6 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             Assert.False(first);
             Assert.True(l.Listening);
-
-            tcpListener.Verify(m => m.Start(It.IsAny<int>()), Times.Once);
         }
 
         [Trait("Category", "Start")]
@@ -246,8 +244,9 @@ namespace Soulseek.Tests.Unit.Network.Tcp
         {
             var options = new ConnectionOptions();
             var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
 
-            var l = new Listener(IPAddress.Any, port, options);
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
 
             l.Start();
 
@@ -257,6 +256,115 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             Assert.True(first);
             Assert.False(l.Listening);
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop stops TcpListener")]
+        public void Stop_Stops_TcpListener()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+            l.Stop();
+
+            tcpListener.Verify(m => m.Stop(), Times.Once);
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop raises Stopped when stopping")]
+        public void Stop_Raises_Stopped_When_Stopping()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            var raised = false;
+            l.Stopped += (sender, args) => raised = true;
+
+            l.Stop();
+
+            Assert.True(raised);
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop does not raise Stopped if not listening")]
+        public void Stop_Does_Not_Raise_Stopped_If_Not_Listening()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            // start never called
+            var raised = false;
+            l.Stopped += (sender, args) => raised = true;
+
+            l.Stop();
+
+            Assert.False(raised);
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop does not stop listener if not listening")]
+        public void Stop_Does_Not_Stop_Listener_If_Not_Listening()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            l.Stop();
+            l.Stop();
+
+            tcpListener.Verify(m => m.Stop(), Times.Once);
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop does not throw when Stopped is unbound")]
+        public void Stop_Does_Not_Throw_When_Stopped_Is_Unbound()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            var ex = Record.Exception(() => l.Stop());
+
+            Assert.Null(ex);
+        }
+
+        [Trait("Category", "Stop")]
+        [Fact(DisplayName = "Stop does not throw when Stopped throws")]
+        public void Stop_Does_Not_Throw_When_Stopped_Throws()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Stopped += (_, e) => throw new Exception();
+
+            l.Start();
+
+            var ex = Record.Exception(() => l.Stop());
+
+            Assert.Null(ex);
         }
 
         [Trait("Category", "Accept Loop")]


### PR DESCRIPTION
Currently if an `AcceptAsync()` call threw an exception, the accept loop would exit and leave the client unable to accept new connections, in spite of listening for them.  This would eventually fill up the TCP listener's backlog at the OS level, and the situation is only recoverable with a restart.

Reported in https://github.com/slskd/slskd/issues/1800.

Outstanding work:

* Do something with the events the `Listener` class now emits (diagnostics? bubble one or more up to the client level?)
* Add the new `backlog` option somewhere and plumb it in