### PR TITLE
Add ListenBacklog option

### DIFF
--- a/src/Network/Tcp/IListener.cs
+++ b/src/Network/Tcp/IListener.cs
@@ -25,6 +25,7 @@ namespace Soulseek.Network.Tcp
 {
     using System;
     using System.Net;
+    using System.Net.Sockets;
 
     /// <summary>
     ///     Listens for client connections for TCP network services.
@@ -64,7 +65,8 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Starts the listener.
         /// </summary>
-        void Start();
+        /// <param name="backlog">The maximum number of pending connections the OS will queue for this listener.</param>
+        void Start(int backlog = (int)SocketOptionName.MaxConnections);
 
         /// <summary>
         ///     Stops the listener.

--- a/src/Network/Tcp/Listener.cs
+++ b/src/Network/Tcp/Listener.cs
@@ -92,7 +92,8 @@ namespace Soulseek.Network.Tcp
         /// <summary>
         ///     Starts the listener.
         /// </summary>
-        public void Start()
+        /// <param name="backlog">The maximum number of pending connections the OS will queue for this listener.</param>
+        public void Start(int backlog = (int)SocketOptionName.MaxConnections)
         {
             lock (SyncRoot)
             {
@@ -103,7 +104,7 @@ namespace Soulseek.Network.Tcp
 
                 try
                 {
-                    TcpListener.Start();
+                    TcpListener.Start(backlog);
                     Listening = true;
                     Task.Run(() => ListenContinuouslyAsync()).Forget();
                 }

--- a/src/Options/SoulseekClientOptions.cs
+++ b/src/Options/SoulseekClientOptions.cs
@@ -27,6 +27,7 @@ namespace Soulseek
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading.Tasks;
     using Soulseek.Diagnostics;
     using Soulseek.Messaging.Messages;
@@ -54,6 +55,7 @@ namespace Soulseek
         /// <param name="enableListener">A value indicating whether to listen for incoming connections.</param>
         /// <param name="listenIPAddress">The IP address on which to listen for incoming connections.</param>
         /// <param name="listenPort">The port on which to listen for incoming connections.</param>
+        /// <param name="listenBacklog">The maximum size of the listener backlog.</param>
         /// <param name="enableDistributedNetwork">A value indicating whether to establish distributed network connections.</param>
         /// <param name="acceptDistributedChildren">A value indicating whether to accept distributed child connections.</param>
         /// <param name="distributedChildLimit">The number of allowed distributed children.</param>
@@ -111,6 +113,7 @@ namespace Soulseek
             bool enableListener = true,
             IPAddress listenIPAddress = null,
             int listenPort = 50000,
+            int listenBacklog = (int)SocketOptionName.MaxConnections,
             bool enableDistributedNetwork = true,
             bool acceptDistributedChildren = true,
             int distributedChildLimit = 25,
@@ -149,6 +152,13 @@ namespace Soulseek
             if (ListenPort < 1024 || ListenPort > IPEndPoint.MaxPort)
             {
                 throw new ArgumentOutOfRangeException(nameof(listenPort), $"Must be between 1024 and {IPEndPoint.MaxPort}");
+            }
+
+            ListenBacklog = listenBacklog;
+
+            if (ListenBacklog < 128)
+            {
+                throw new ArgumentOutOfRangeException(nameof(listenBacklog), $"Must be greater than or equal to 128");
             }
 
             EnableDistributedNetwork = enableDistributedNetwork;
@@ -288,6 +298,11 @@ namespace Soulseek
         public ConnectionOptions IncomingConnectionOptions { get; }
 
         /// <summary>
+        ///     Gets the maximum size of the listener backlog. (Default = int.MaxValue).
+        /// </summary>
+        public int ListenBacklog { get; }
+
+        /// <summary>
         ///     Gets the IP Address on which to listen for incoming connections. (Default = IPAddress.Any/"0.0.0.0").
         /// </summary>
         public IPAddress ListenIPAddress { get; }
@@ -408,6 +423,7 @@ namespace Soulseek
                 enableListener: patch.EnableListener,
                 listenIPAddress: patch.ListenIPAddress,
                 listenPort: patch.ListenPort,
+                listenBacklog: patch.ListenBacklog,
                 enableDistributedNetwork: patch.EnableDistributedNetwork,
                 acceptDistributedChildren: patch.AcceptDistributedChildren,
                 distributedChildLimit: patch.DistributedChildLimit,
@@ -438,6 +454,7 @@ namespace Soulseek
         /// <param name="enableListener">A value indicating whether to listen for incoming connections.</param>
         /// <param name="listenIPAddress">The IP address on which to listen for incoming connections.</param>
         /// <param name="listenPort">The port on which to listen for incoming connections.</param>
+        /// <param name="listenBacklog">The maximum size of the listener backlog.</param>
         /// <param name="enableDistributedNetwork">A value indicating whether to establish distributed network connections.</param>
         /// <param name="acceptDistributedChildren">A value indicating whether to accept distributed child connections.</param>
         /// <param name="distributedChildLimit">The number of allowed distributed children.</param>
@@ -481,6 +498,7 @@ namespace Soulseek
             bool? enableListener = null,
             IPAddress listenIPAddress = null,
             int? listenPort = null,
+            int? listenBacklog = null,
             bool? enableDistributedNetwork = null,
             bool? acceptDistributedChildren = null,
             int? distributedChildLimit = null,
@@ -508,6 +526,7 @@ namespace Soulseek
                 enableListener: enableListener ?? EnableListener,
                 listenIPAddress: listenIPAddress ?? ListenIPAddress,
                 listenPort: listenPort ?? ListenPort,
+                listenBacklog: listenBacklog ?? ListenBacklog,
                 enableDistributedNetwork: enableDistributedNetwork ?? EnableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren ?? AcceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit ?? DistributedChildLimit,

--- a/src/Options/SoulseekClientOptionsPatch.cs
+++ b/src/Options/SoulseekClientOptionsPatch.cs
@@ -40,6 +40,7 @@ namespace Soulseek
         /// <param name="enableListener">A value indicating whether to listen for incoming connections.</param>
         /// <param name="listenIPAddress">The IP address on which to listen for incoming connections.</param>
         /// <param name="listenPort">The port on which to listen for incoming connections.</param>
+        /// <param name="listenBacklog">The maximum size of the listener backlog.</param>
         /// <param name="enableDistributedNetwork">A value indicating whether to establish distributed network connections.</param>
         /// <param name="acceptDistributedChildren">A value indicating whether to accept distributed child connections.</param>
         /// <param name="distributedChildLimit">The number of allowed distributed children.</param>
@@ -88,6 +89,7 @@ namespace Soulseek
             bool? enableListener = null,
             IPAddress listenIPAddress = null,
             int? listenPort = null,
+            int? listenBacklog = null,
             bool? enableDistributedNetwork = null,
             bool? acceptDistributedChildren = null,
             int? distributedChildLimit = null,
@@ -119,6 +121,13 @@ namespace Soulseek
             if (ListenPort < 1024 || ListenPort > IPEndPoint.MaxPort)
             {
                 throw new ArgumentOutOfRangeException(nameof(listenPort), "Must be between 1024 and 65535");
+            }
+
+            ListenBacklog = listenBacklog;
+
+            if (ListenBacklog.HasValue && ListenBacklog.Value < 128)
+            {
+                throw new ArgumentOutOfRangeException(nameof(listenBacklog), $"Must be greater than or equal to 128");
             }
 
             EnableDistributedNetwork = enableDistributedNetwork;
@@ -226,6 +235,11 @@ namespace Soulseek
         ///     Gets the options for incoming connections.
         /// </summary>
         public ConnectionOptions IncomingConnectionOptions { get; }
+
+        /// <summary>
+        ///     Gets the maximum size of the listener backlog. (Default = null = Operating System maximum).
+        /// </summary>
+        public int? ListenBacklog { get; }
 
         /// <summary>
         ///     Gets the IP address on which to listen for incoming connections. (Default = IPAddress.Any/"0.0.0.0").

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3094,7 +3094,7 @@ namespace Soulseek
                         Listener = new Listener(Options.ListenIPAddress, Options.ListenPort, connectionOptions: Options.IncomingConnectionOptions);
                         Listener.Accepted += ListenerHandler.HandleConnection;
                         Listener.Error += ListenerHandler.HandleError;
-                        Listener.Start();
+                        Listener.Start(Options.ListenBacklog);
                     }
 
                     ServerConnection = ConnectionFactory.GetServerConnection(
@@ -3997,7 +3997,7 @@ namespace Soulseek
                         Listener = new Listener(Options.ListenIPAddress, Options.ListenPort, Options.IncomingConnectionOptions);
                         Listener.Accepted += ListenerHandler.HandleConnection;
                         Listener.Error += ListenerHandler.HandleError;
-                        Listener.Start();
+                        Listener.Start(Options.ListenBacklog);
                     }
                 }
 

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -3977,9 +3977,10 @@ namespace Soulseek
                 var enableListenerChanged = patch.EnableListener.HasValue && patch.EnableListener.Value != Options.EnableListener;
                 var listenAddressChanged = patch.ListenIPAddress != null && !patch.ListenIPAddress.Equals(Options.ListenIPAddress);
                 var listenPortChanged = patch.ListenPort.HasValue && patch.ListenPort.Value != Options.ListenPort;
+                var listenBacklogChanged = patch.ListenBacklog.HasValue && patch.ListenBacklog.Value != Options.ListenBacklog;
                 var incomingConnectionOptionsChanged = patch.IncomingConnectionOptions != null && patch.IncomingConnectionOptions != Options.IncomingConnectionOptions;
 
-                if (enableListenerChanged || listenAddressChanged || listenPortChanged || incomingConnectionOptionsChanged)
+                if (enableListenerChanged || listenAddressChanged || listenPortChanged || listenBacklogChanged || incomingConnectionOptionsChanged)
                 {
                     var wasListening = Listener?.Listening ?? false;
 
@@ -3990,6 +3991,7 @@ namespace Soulseek
                         enableListener: patch.EnableListener,
                         listenIPAddress: patch.ListenIPAddress,
                         listenPort: patch.ListenPort,
+                        listenBacklog: patch.ListenBacklog,
                         incomingConnectionOptions: patch.IncomingConnectionOptions);
 
                     if (wasListening && Options.EnableListener)

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -317,6 +317,50 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Reconfigures listener if ListenBacklog changed")]
+        public async Task Reconfigures_Listener_If_ListenBacklog_Changed()
+        {
+            var (client, mocks) = GetFixture(new SoulseekClientOptions(listenPort: Mocks.Port, listenBacklog: 128));
+
+            mocks.Listener.Setup(m => m.Listening).Returns(true);
+
+            var patch = new SoulseekClientOptionsPatch(listenBacklog: 129);
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await client.ReconfigureOptionsAsync(patch);
+
+                Assert.Equal(patch.ListenBacklog, client.Options.ListenBacklog);
+
+                mocks.Listener.Verify(m => m.Start(129), Times.Once);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Does not reconfigure listener if ListenBacklog unchanged")]
+        public async Task Does_Not_Reconfigure_Listener_If_ListenBacklog_Unchanged()
+        {
+            var (client, mocks) = GetFixture(new SoulseekClientOptions(listenPort: Mocks.Port, listenBacklog: 128));
+
+            mocks.Listener.Setup(m => m.Listening).Returns(true);
+
+            var patch = new SoulseekClientOptionsPatch(listenBacklog: 128);
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await client.ReconfigureOptionsAsync(patch);
+
+                Assert.Equal(mocks.Listener.Object, client.Listener);
+
+                mocks.Listener.Verify(m => m.Start(It.IsAny<int>()), Times.Never);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
         [Fact(DisplayName = "Assigns a handler to Listener.Error when a new listener is created")]
         public async Task Assigns_A_Handler_To_Listener_Error_When_A_New_Listener_Is_Created()
         {
@@ -513,6 +557,7 @@ namespace Soulseek.Tests.Unit.Client
             var (client, _) = GetFixture(new SoulseekClientOptions(
                 enableListener: false,
                 listenPort: Mocks.Port,
+                listenBacklog: 128,
                 enableDistributedNetwork: false,
                 acceptDistributedChildren: false,
                 distributedChildLimit: 5,
@@ -539,6 +584,7 @@ namespace Soulseek.Tests.Unit.Client
             var patch = new SoulseekClientOptionsPatch(
                 enableListener: true,
                 listenPort: Mocks.Port,
+                listenBacklog: 129,
                 enableDistributedNetwork: true,
                 acceptDistributedChildren: true,
                 distributedChildLimit: 10,
@@ -568,6 +614,7 @@ namespace Soulseek.Tests.Unit.Client
 
                 Assert.Equal(patch.EnableListener, client.Options.EnableListener);
                 Assert.Equal(patch.ListenPort, client.Options.ListenPort);
+                Assert.Equal(patch.ListenBacklog, client.Options.ListenBacklog);
                 Assert.Equal(patch.EnableDistributedNetwork, client.Options.EnableDistributedNetwork);
                 Assert.Equal(patch.AcceptDistributedChildren, client.Options.AcceptDistributedChildren);
                 Assert.Equal(patch.DistributedChildLimit, client.Options.DistributedChildLimit);

--- a/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -329,12 +329,12 @@ namespace Soulseek.Tests.Unit.Client
             using (client)
             {
                 client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+                var ogListener = client.Listener;
 
                 await client.ReconfigureOptionsAsync(patch);
 
                 Assert.Equal(patch.ListenBacklog, client.Options.ListenBacklog);
-
-                mocks.Listener.Verify(m => m.Start(129), Times.Once);
+                Assert.NotEqual(ogListener, client.Listener);
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="ListenerTests.cs" company="JP Dillingham">
+﻿// <copyright file="ListenerTests.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham. All rights reserved.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -125,6 +125,37 @@ namespace Soulseek.Tests.Unit.Network.Tcp
             l.Start();
 
             tcpListener.Verify(m => m.Start(It.IsAny<int>()), Times.Once);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start passes the given backlog to the TcpListener")]
+        public void Start_Passes_The_Given_Backlog_To_The_TcpListener()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+            var backlog = new Random().Next(128, int.MaxValue);
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start(backlog);
+
+            tcpListener.Verify(m => m.Start(backlog), Times.Once);
+        }
+
+        [Trait("Category", "Start")]
+        [Fact(DisplayName = "Start defaults Backlog to SocketOptionName.MaxConnections if not given")]
+        public void Start_Defaults_Backlog_To_MaxConnections_If_Not_Given()
+        {
+            var options = new ConnectionOptions();
+            var port = GetPort();
+            var tcpListener = new Mock<ITcpListener>();
+
+            var l = new Listener(IPAddress.Any, port, options, tcpListener.Object);
+
+            l.Start();
+
+            tcpListener.Verify(m => m.Start(int.MaxValue), Times.Once);
         }
 
         [Trait("Category", "Start")]

--- a/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
+++ b/tests/Soulseek.Tests.Unit/Network/Tcp/ListenerTests.cs
@@ -155,7 +155,7 @@ namespace Soulseek.Tests.Unit.Network.Tcp
 
             l.Start();
 
-            tcpListener.Verify(m => m.Start(int.MaxValue), Times.Once);
+            tcpListener.Verify(m => m.Start((int)SocketOptionName.MaxConnections), Times.Once);
         }
 
         [Trait("Category", "Start")]

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsPatchTests.cs
@@ -60,11 +60,13 @@ namespace Soulseek.Tests.Unit.Options
             var rnd = new Random();
             var listenAddress = IPAddress.Parse(string.Join(".", rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString()));
             var listenPort = rnd.Next(1024, 65535);
+            var listenBacklog = rnd.Next(128, int.MaxValue);
 
             var o = new SoulseekClientOptionsPatch(
                 enableListener,
                 listenAddress,
                 listenPort,
+                listenBacklog: listenBacklog,
                 enableDistributedNetwork: enableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit,
@@ -91,6 +93,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenAddress, o.ListenIPAddress);
             Assert.Equal(listenPort, o.ListenPort);
+            Assert.Equal(listenBacklog, o.ListenBacklog);
             Assert.Equal(enableDistributedNetwork, o.EnableDistributedNetwork);
             Assert.Equal(acceptDistributedChildren, o.AcceptDistributedChildren);
             Assert.Equal(distributedChildLimit, o.DistributedChildLimit);
@@ -192,6 +195,36 @@ namespace Soulseek.Tests.Unit.Options
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentOutOfRangeException>(ex);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Defaults ListenBacklog to null")]
+        public void Defaults_ListenBacklog_To_Null()
+        {
+            var o = new SoulseekClientOptionsPatch();
+
+            Assert.Null(o.ListenBacklog);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Throws if listen backlog is less than 128")]
+        public void Throws_If_Listen_Backlog_Is_Less_Than_128()
+        {
+            SoulseekClientOptionsPatch x;
+            var ex = Record.Exception(() => x = new SoulseekClientOptionsPatch(listenBacklog: 127));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentOutOfRangeException>(ex);
+            Assert.Equal("listenBacklog", ((ArgumentOutOfRangeException)ex).ParamName);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Does not throw if listen backlog is exactly 128")]
+        public void Does_Not_Throw_If_Listen_Backlog_Is_Exactly_128()
+        {
+            var ex = Record.Exception(() => new SoulseekClientOptionsPatch(listenBacklog: 128));
+
+            Assert.Null(ex);
         }
     }
 }

--- a/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
+++ b/tests/Soulseek.Tests.Unit/Options/SoulseekClientOptionsTests.cs
@@ -22,6 +22,7 @@ namespace Soulseek.Tests.Unit.Options
 
     using System.Linq;
     using System.Net;
+    using System.Net.Sockets;
     using System.Threading.Tasks;
     using AutoFixture.Xunit2;
     using Moq;
@@ -70,11 +71,13 @@ namespace Soulseek.Tests.Unit.Options
             var rnd = new Random();
             var listenAddress = IPAddress.Parse(string.Join(".", rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString()));
             var listenPort = rnd.Next(1024, 65535);
+            var listenBacklog = rnd.Next(128, int.MaxValue);
 
             var o = new SoulseekClientOptions(
                 enableListener,
                 listenAddress,
                 listenPort,
+                listenBacklog: listenBacklog,
                 enableDistributedNetwork: enableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit,
@@ -107,6 +110,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenAddress, o.ListenIPAddress);
             Assert.Equal(listenPort, o.ListenPort);
+            Assert.Equal(listenBacklog, o.ListenBacklog);
             Assert.Equal(enableDistributedNetwork, o.EnableDistributedNetwork);
             Assert.Equal(acceptDistributedChildren, o.AcceptDistributedChildren);
             Assert.Equal(distributedChildLimit, o.DistributedChildLimit);
@@ -304,6 +308,36 @@ namespace Soulseek.Tests.Unit.Options
         }
 
         [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Instantiates with default ListenBacklog")]
+        public void Instantiates_With_Default_ListenBacklog()
+        {
+            var o = new SoulseekClientOptions();
+
+            Assert.Equal((int)SocketOptionName.MaxConnections, o.ListenBacklog);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Throws if listen backlog is less than 128")]
+        public void Throws_If_Listen_Backlog_Is_Less_Than_128()
+        {
+            SoulseekClientOptions x;
+            var ex = Record.Exception(() => x = new SoulseekClientOptions(listenBacklog: 127));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentOutOfRangeException>(ex);
+            Assert.Equal("listenBacklog", ((ArgumentOutOfRangeException)ex).ParamName);
+        }
+
+        [Trait("Category", "Instantiation")]
+        [Fact(DisplayName = "Does not throw if listen backlog is exactly 128")]
+        public void Does_Not_Throw_If_Listen_Backlog_Is_Exactly_128()
+        {
+            var ex = Record.Exception(() => new SoulseekClientOptions(listenBacklog: 128));
+
+            Assert.Null(ex);
+        }
+
+        [Trait("Category", "Instantiation")]
         [Fact(DisplayName = "Throws if MaxConcurrentSearches is negative")]
         public void Throws_If_MaxConcurrentSearches_Is_Negative()
         {
@@ -368,11 +402,13 @@ namespace Soulseek.Tests.Unit.Options
             var rnd = new Random();
             var listenAddress = IPAddress.Parse(string.Join(".", rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString()));
             var listenPort = rnd.Next(1024, 65535);
+            var listenBacklog = rnd.Next(128, int.MaxValue);
 
             var patch = new SoulseekClientOptionsPatch(
                 enableListener,
                 listenAddress,
                 listenPort,
+                listenBacklog: listenBacklog,
                 enableDistributedNetwork: enableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit,
@@ -411,6 +447,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenAddress, o.ListenIPAddress);
             Assert.Equal(listenPort, o.ListenPort);
+            Assert.Equal(listenBacklog, o.ListenBacklog);
             Assert.Equal(enableDistributedNetwork, o.EnableDistributedNetwork);
             Assert.Equal(acceptDistributedChildren, o.AcceptDistributedChildren);
             Assert.Equal(distributedChildLimit, o.DistributedChildLimit);
@@ -477,11 +514,13 @@ namespace Soulseek.Tests.Unit.Options
             var rnd = new Random();
             var listenAddress = IPAddress.Parse(string.Join(".", rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString(), rnd.Next(0, 254).ToString()));
             var listenPort = rnd.Next(1024, 65535);
+            var listenBacklog = rnd.Next(128, int.MaxValue);
 
             var o = new SoulseekClientOptions().With(
                 enableListener,
                 listenAddress,
                 listenPort,
+                listenBacklog: listenBacklog,
                 enableDistributedNetwork: enableDistributedNetwork,
                 acceptDistributedChildren: acceptDistributedChildren,
                 distributedChildLimit: distributedChildLimit,
@@ -508,6 +547,7 @@ namespace Soulseek.Tests.Unit.Options
             Assert.Equal(enableListener, o.EnableListener);
             Assert.Equal(listenAddress, o.ListenIPAddress);
             Assert.Equal(listenPort, o.ListenPort);
+            Assert.Equal(listenBacklog, o.ListenBacklog);
             Assert.Equal(enableDistributedNetwork, o.EnableDistributedNetwork);
             Assert.Equal(acceptDistributedChildren, o.AcceptDistributedChildren);
             Assert.Equal(distributedChildLimit, o.DistributedChildLimit);


### PR DESCRIPTION
The `TcpListener` class allows a `backlog` to be specified when the listener is started.

The OS accepts incoming connections and then passes them to the `TcpListener` to be accepted.  The number of connections that have been accepted by the OS but not yet accepted by the listener is called the `backlog`.  Once the backlog is full, the OS will begin rejecting incoming connections.

By default, the backlog is set to the maximum size, which will defer the size to the operating system.  It generally won't be necessary to change this number, but low spec, high traffic installations might benefit from lowering it if they find that the number of the connections in the backlog is causing a problem.