### PR TITLE
Prevent unnecessary lingering in uploads when the other client doesn't disconnect and ReadAsync() doesn't return immediately

### DIFF
--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -4531,20 +4531,23 @@ namespace Soulseek
                 // comes to this, so linger time shouldn't be less than a couple of seconds.
                 try
                 {
-                    var lingerStartTime = DateTime.UtcNow;
-                    using var lingerCancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(options.MaximumLingerTime));
-                    using var linkedLingerCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lingerCancellationTokenSource.Token);
+                    var lingerDeadline = DateTime.UtcNow.AddMilliseconds(options.MaximumLingerTime);
 
                     while (!cancellationToken.IsCancellationRequested)
                     {
-                        if (lingerStartTime.AddMilliseconds(options.MaximumLingerTime) <= DateTime.UtcNow)
+                        if (lingerDeadline <= DateTime.UtcNow)
                         {
                             upload.Connection.Disconnect("Transfer complete, maximum linger time exceeded");
                             Diagnostic.Warning($"Transfer connection for upload of {Path.GetFileName(upload.Filename)} to {username} forcibly closed after exceeding maximum linger time of {options.MaximumLingerTime}ms.");
                             break;
                         }
 
-                        await upload.Connection.ReadAsync(1, linkedLingerCancellationTokenSource.Token).ConfigureAwait(false);
+                        // sometimes attempting this read will block instead of throwing immediately; in those cases we
+                        // need to make sure it doesn't block until the connection is closed due to inactivity
+                        await (await Task.WhenAny(
+                            upload.Connection.ReadAsync(1, cancellationToken),
+                            Task.Delay(lingerDeadline - DateTime.UtcNow, cancellationToken)).ConfigureAwait(false)).ConfigureAwait(false);
+
                         await Task.Delay(100, cancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -4532,6 +4532,8 @@ namespace Soulseek
                 try
                 {
                     var lingerStartTime = DateTime.UtcNow;
+                    using var lingerCancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(options.MaximumLingerTime));
+                    using var linkedLingerCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lingerCancellationTokenSource.Token);
 
                     while (!cancellationToken.IsCancellationRequested)
                     {
@@ -4542,7 +4544,7 @@ namespace Soulseek
                             break;
                         }
 
-                        await upload.Connection.ReadAsync(1, cancellationToken).ConfigureAwait(false);
+                        await upload.Connection.ReadAsync(1, linkedLingerCancellationTokenSource.Token).ConfigureAwait(false);
                         await Task.Delay(100, cancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -4504,7 +4504,7 @@ namespace Soulseek
                     writeTask = Task.CompletedTask;
                 }
 
-                // ensure the losing tasks don't raise an unbserved exception by attaching a continuation that will observe them with Forget()
+                // ensure the losing tasks don't raise an unobserved exception by attaching a continuation that will observe them with Forget()
                 writeTask.Forget();
                 disconnectedTaskCancellationSource.Task.Forget();
 
@@ -4543,9 +4543,15 @@ namespace Soulseek
                         }
 
                         // sometimes attempting this read will block instead of throwing immediately; in those cases we
-                        // need to make sure it doesn't block until the connection is closed due to inactivity
+                        // need to make sure it doesn't block until the connection is closed due to inactivity by racing
+                        // it against a Task.Delay()
+                        var readTask = upload.Connection.ReadAsync(1, cancellationToken);
+
+                        // ensure the read doesn't raise an unobserved exception if the Delay wins the race
+                        readTask.Forget();
+
                         await (await Task.WhenAny(
-                            upload.Connection.ReadAsync(1, cancellationToken),
+                            readTask,
                             Task.Delay(lingerDeadline - DateTime.UtcNow, cancellationToken)).ConfigureAwait(false)).ConfigureAwait(false);
 
                         await Task.Delay(100, cancellationToken).ConfigureAwait(false);

--- a/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/UploadAsyncTests.cs
@@ -1197,6 +1197,65 @@ namespace Soulseek.Tests.Unit.Client
             }
         }
 
+        [Trait("Category", "UploadFromFileAsync")]
+        [Theory(DisplayName = "UploadFromFileAsync disconnects after MaximumLingerTime when trailing read blocks instead of throwing"), AutoData]
+        public async Task UploadFromFileAsync_Disconnects_After_MaximumLingerTime_When_Trailing_Read_Blocks(string username, IPEndPoint endpoint, string filename, int token, int size)
+        {
+            using (var testFile = new TestFile())
+            {
+                // give the (mocked, and therefore inert) transfer connection a very long inactivity timeout so it's
+                // clear that the disconnect in this test is driven by MaximumLingerTime, not some other timeout
+                var options = new SoulseekClientOptions(messageTimeout: 5, transferConnectionOptions: new ConnectionOptions(inactivityTimeout: int.MaxValue));
+
+                var response = new TransferResponse(token, size);
+                var responseWaitKey = new WaitKey(MessageCode.Peer.TransferResponse, username, token);
+
+                var waiter = new Mock<IWaiter>();
+                waiter.Setup(m => m.Wait<TransferResponse>(It.Is<WaitKey>(w => w.Equals(responseWaitKey)), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(response));
+                waiter.Setup(m => m.Wait<UserAddressResponse>(It.IsAny<WaitKey>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new UserAddressResponse(username, endpoint.Address, endpoint.Port)));
+
+                var conn = new Mock<IMessageConnection>();
+                conn.Setup(m => m.State)
+                    .Returns(ConnectionState.Connected);
+
+                var transferConn = new Mock<IConnection>();
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 8), It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(BitConverter.GetBytes(0L)));
+
+                // simulate a trailing read that blocks rather than immediately returning or failing. this task is never
+                // completed, so the only way the loop can proceed is by racing it against the delay
+                var readForeverTcs = new TaskCompletionSource<byte[]>();
+                transferConn.Setup(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()))
+                    .Returns(readForeverTcs.Task);
+
+                var connManager = new Mock<IPeerConnectionManager>();
+                connManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+                connManager.Setup(m => m.GetTransferConnectionAsync(username, endpoint, token, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(transferConn.Object));
+
+                var txOptions = new TransferOptions(maximumLingerTime: 200);
+
+                using (var s = new SoulseekClient(minorVersion: 9999, options: options, waiter: waiter.Object, serverConnection: conn.Object, peerConnectionManager: connManager.Object))
+                {
+                    s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                    var ex = await Record.ExceptionAsync(() => s.InvokeMethod<Task>("UploadFromFileAsync", username, filename, testFile.Path, token, txOptions, null));
+
+                    Assert.Null(ex);
+                }
+
+                // the blocked read is only attempted once; the loop must not retry it while it is still pending
+                transferConn.Verify(m => m.ReadAsync(It.Is<long>(l => l == 1), It.IsAny<CancellationToken?>()), Times.Once);
+
+                // the connection is forcibly disconnected once MaximumLingerTime elapses, rather than waiting on the
+                // blocked read indefinitely
+                transferConn.Verify(m => m.Disconnect(It.Is<string>(msg => msg.ContainsInsensitive("maximum linger time")), null), Times.Once);
+            }
+        }
+
         [Trait("Category", "UploadFromStreamAsync")]
         [Theory(DisplayName = "UploadFromStreamAsync throws DuplicateTransferException when failing to insert UniqueKeyDictionary"), AutoData]
         public async Task UploadFromStreamAsync_Throws_DuplicateTransferException_If_Unique_Key_Add_Fails(string username, string filename, int token)


### PR DESCRIPTION
Reported by someone's OpenClaw in #945 

