### PR TITLE
Fix bug preventing raw search responses from being sent

### DIFF
--- a/src/RawSearchResponse.cs
+++ b/src/RawSearchResponse.cs
@@ -55,6 +55,11 @@ namespace Soulseek
                 throw new ArgumentNullException(nameof(stream), "The specified input stream is null");
             }
 
+            if (!stream.CanRead)
+            {
+                throw new ArgumentException("The specified input stream can not be read", nameof(stream));
+            }
+
             Length = length;
             Stream = stream;
         }

--- a/src/SearchResponder.cs
+++ b/src/SearchResponder.cs
@@ -134,16 +134,7 @@ namespace Soulseek
                 return false;
             }
 
-            // return early if we've been given a response with no files (SearchResponse)
-            // or a null, empty, or unreadable stream (RawSearchResponse)
-            if (searchResponse is RawSearchResponse rawResponse)
-            {
-                if (rawResponse.Length == 0 || rawResponse.Stream is null || !rawResponse.Stream.CanRead)
-                {
-                    return false;
-                }
-            }
-            else if (searchResponse.FileCount + searchResponse.LockedFileCount <= 0)
+            if (searchResponse is not RawSearchResponse && searchResponse.FileCount + searchResponse.LockedFileCount <= 0)
             {
                 return false;
             }

--- a/src/SearchResponder.cs
+++ b/src/SearchResponder.cs
@@ -129,7 +129,18 @@ namespace Soulseek
                 return false;
             }
 
-            if (searchResponse == null || searchResponse.FileCount + searchResponse.LockedFileCount <= 0)
+            if (searchResponse == null)
+            {
+                return false;
+            }
+
+            // return early if we've been given a response with no files (SearchResponse)
+            // or a null or empty stream (RawSearchResponse)
+            if (searchResponse is RawSearchResponse s && (s.Length == 0 || s.Stream is null || !s.Stream.CanRead))
+            {
+                return false;
+            }
+            else if (searchResponse.FileCount + searchResponse.LockedFileCount <= 0)
             {
                 return false;
             }

--- a/src/SearchResponder.cs
+++ b/src/SearchResponder.cs
@@ -135,10 +135,13 @@ namespace Soulseek
             }
 
             // return early if we've been given a response with no files (SearchResponse)
-            // or a null or empty stream (RawSearchResponse)
-            if (searchResponse is RawSearchResponse s && (s.Length == 0 || s.Stream is null || !s.Stream.CanRead))
+            // or a null, empty, or unreadable stream (RawSearchResponse)
+            if (searchResponse is RawSearchResponse rawResponse)
             {
-                return false;
+                if (rawResponse.Length == 0 || rawResponse.Stream is null || !rawResponse.Stream.CanRead)
+                {
+                    return false;
+                }
             }
             else if (searchResponse.FileCount + searchResponse.LockedFileCount <= 0)
             {

--- a/tests/Soulseek.Tests.Unit/RawSearchResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/RawSearchResponseTests.cs
@@ -61,5 +61,28 @@ namespace Soulseek.Tests.Unit
             Assert.NotNull(ex);
             Assert.IsType<ArgumentNullException>(ex);
         }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Throws if the given stream can not be read"), AutoData]
+        public void Throws_If_The_Given_Stream_Can_Not_Be_Read(long length)
+        {
+            using (var stream = new UnreadableStream(Array.Empty<byte>()))
+            {
+                var ex = Record.Exception(() => new RawSearchResponse(length, stream));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentNullException>(ex);
+            }
+        }
+
+        private class UnreadableStream : MemoryStream
+        {
+            public UnreadableStream(byte[] buffer)
+                : base(buffer)
+            {
+            }
+
+            public override bool CanRead => false;
+        }
     }
 }

--- a/tests/Soulseek.Tests.Unit/RawSearchResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/RawSearchResponseTests.cs
@@ -71,7 +71,7 @@ namespace Soulseek.Tests.Unit
                 var ex = Record.Exception(() => new RawSearchResponse(length, stream));
 
                 Assert.NotNull(ex);
-                Assert.IsType<ArgumentNullException>(ex);
+                Assert.IsType<ArgumentException>(ex);
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
@@ -398,6 +398,115 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync sends RawSearchResponse even when FileCount and LockedFileCount are zero"), AutoData]
+        public async Task TryRespondAsync_Sends_RawSearchResponse_Even_When_FileCount_And_LockedFileCount_Are_Zero(string username, int token, string query, IPEndPoint endpoint, int responseToken)
+        {
+            using (var stream = new System.IO.MemoryStream(new byte[] { 1, 2, 3 }))
+            {
+                var rawResponse = new RawSearchResponse(stream.Length, stream);
+
+                // a RawSearchResponse is opaque, pre-serialized bytes-- it never carries a parsed file list, so these
+                // are always zero. TryRespondAsync must not treat that as "no results" for a raw response.
+                Assert.Equal(0, rawResponse.FileCount);
+                Assert.Equal(0, rawResponse.LockedFileCount);
+
+                var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+                mocks.Client.Setup(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(endpoint));
+                mocks.Client.Setup(m => m.GetNextToken())
+                    .Returns(responseToken);
+
+                var conn = new Mock<IMessageConnection>();
+
+                mocks.PeerConnectionManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, responseToken, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+
+                var responded = await responder.TryRespondAsync(username, token, query);
+
+                Assert.True(responded);
+            }
+        }
+
+        [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync writes RawSearchResponse directly instead of serializing"), AutoData]
+        public async Task TryRespondAsync_Writes_RawSearchResponse_Directly_Instead_Of_Serializing(string username, int token, string query, IPEndPoint endpoint, int responseToken)
+        {
+            using (var stream = new System.IO.MemoryStream(new byte[] { 1, 2, 3 }))
+            {
+                var rawResponse = new RawSearchResponse(stream.Length, stream);
+
+                var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+                mocks.Client.Setup(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()))
+                    .Returns(Task.FromResult(endpoint));
+                mocks.Client.Setup(m => m.GetNextToken())
+                    .Returns(responseToken);
+
+                var conn = new Mock<IMessageConnection>();
+
+                mocks.PeerConnectionManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, responseToken, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(conn.Object));
+
+                var responded = await responder.TryRespondAsync(username, token, query);
+
+                Assert.True(responded);
+
+                conn.Verify(m => m.WriteAsync(rawResponse.Length, rawResponse.Stream, It.IsAny<Func<int, CancellationToken, Task<int>>>(), It.IsAny<Action<int, int, int>>(), It.IsAny<CancellationToken?>()), Times.Once);
+                conn.Verify(m => m.WriteAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken?>()), Times.Never);
+            }
+        }
+
+        [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync disposes RawSearchResponse stream after write"), AutoData]
+        public async Task TryRespondAsync_Disposes_RawSearchResponse_Stream_After_Write(string username, int token, string query, IPEndPoint endpoint, int responseToken)
+        {
+            var stream = new TrackingDisposeStream(new byte[] { 1, 2, 3 });
+            var rawResponse = new RawSearchResponse(stream.Length, stream);
+
+            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+            mocks.Client.Setup(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()))
+                .Returns(Task.FromResult(endpoint));
+            mocks.Client.Setup(m => m.GetNextToken())
+                .Returns(responseToken);
+
+            var conn = new Mock<IMessageConnection>();
+
+            mocks.PeerConnectionManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, responseToken, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(conn.Object));
+
+            var responded = await responder.TryRespondAsync(username, token, query);
+
+            Assert.True(responded);
+            Assert.True(stream.WasDisposed);
+        }
+
+        [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync does not throw when disposing RawSearchResponse stream fails"), AutoData]
+        public async Task TryRespondAsync_Does_Not_Throw_When_Disposing_RawSearchResponse_Stream_Fails(string username, int token, string query, IPEndPoint endpoint, int responseToken)
+        {
+            var stream = new FaultyDisposeStream(new byte[] { 1, 2, 3 });
+            var rawResponse = new RawSearchResponse(stream.Length, stream);
+
+            var (responder, mocks) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+            mocks.Client.Setup(m => m.GetUserEndPointAsync(username, It.IsAny<CancellationToken?>()))
+                .Returns(Task.FromResult(endpoint));
+            mocks.Client.Setup(m => m.GetNextToken())
+                .Returns(responseToken);
+
+            var conn = new Mock<IMessageConnection>();
+
+            mocks.PeerConnectionManager.Setup(m => m.GetOrAddMessageConnectionAsync(username, endpoint, responseToken, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(conn.Object));
+
+            var ex = await Record.ExceptionAsync(() => responder.TryRespondAsync(username, token, query));
+
+            Assert.Null(ex);
+        }
+
+        [Trait("Category", "TryRespondAsync")]
         [Theory(DisplayName = "TryRespondAsync returns false on failure"), AutoData]
         public async Task TryRespondAsync_Returns_False_On_Failure(string username, int token, string query, SearchResponse searchResponse, IPEndPoint endpoint, int responseToken)
         {
@@ -783,6 +892,35 @@ namespace Soulseek.Tests.Unit
             var ex = Record.Exception(() => diag.Info("test"));
 
             Assert.Null(ex);
+        }
+
+        private class TrackingDisposeStream : System.IO.MemoryStream
+        {
+            public TrackingDisposeStream(byte[] buffer)
+                : base(buffer)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+                base.Dispose(disposing);
+            }
+        }
+
+        private class FaultyDisposeStream : System.IO.MemoryStream
+        {
+            public FaultyDisposeStream(byte[] buffer)
+                : base(buffer)
+            {
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                throw new Exception("Dispose failed");
+            }
         }
 
         private static (SearchResponder SearchResponder, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)

--- a/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
@@ -281,6 +281,55 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync returns false if RawSearchResponse stream is null"), AutoData]
+        public async Task TryRespondAsync_Returns_False_If_RawSearchResponse_Stream_Is_Null(string username, int token, string query)
+        {
+            var rawResponse = new RawSearchResponse(42, null);
+
+            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+            var responded = await responder.TryRespondAsync(username, token, query);
+
+            Assert.False(responded);
+        }
+
+        [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync returns false if RawSearchResponse stream is not readable"), AutoData]
+        public async Task TryRespondAsync_Returns_False_If_RawSearchResponse_Stream_Is_Not_Readable(string username, int token, string query)
+        {
+            using (var stream = new UnreadableStream(new byte[] { 1, 2, 3 }))
+            {
+                var rawResponse = new RawSearchResponse(stream.Length, stream);
+
+                Assert.False(rawResponse.Stream.CanRead);
+
+                var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+                var responded = await responder.TryRespondAsync(username, token, query);
+
+                Assert.False(responded);
+            }
+        }
+
+        [Trait("Category", "TryRespondAsync")]
+        [Theory(DisplayName = "TryRespondAsync returns false if RawSearchResponse length is zero"), AutoData]
+        public async Task TryRespondAsync_Returns_False_If_RawSearchResponse_Length_Is_Zero(string username, int token, string query)
+        {
+            using (var stream = new System.IO.MemoryStream(new byte[] { 1, 2, 3 }))
+            {
+                var rawResponse = new RawSearchResponse(0, stream);
+
+                Assert.True(rawResponse.Stream.CanRead);
+
+                var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
+
+                var responded = await responder.TryRespondAsync(username, token, query);
+
+                Assert.False(responded);
+            }
+        }
+
+        [Trait("Category", "TryRespondAsync")]
         [Theory(DisplayName = "TryRespondAsync raises RequestReceived"), AutoData]
         public async Task TryRespondAsync_Raises_RequestReceived(string username, int token, string query)
         {
@@ -921,6 +970,16 @@ namespace Soulseek.Tests.Unit
             {
                 throw new Exception("Dispose failed");
             }
+        }
+
+        private class UnreadableStream : System.IO.MemoryStream
+        {
+            public UnreadableStream(byte[] buffer)
+                : base(buffer)
+            {
+            }
+
+            public override bool CanRead => false;
         }
 
         private static (SearchResponder SearchResponder, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)

--- a/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
@@ -281,37 +281,6 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "TryRespondAsync")]
-        [Theory(DisplayName = "TryRespondAsync returns false if RawSearchResponse stream is null"), AutoData]
-        public async Task TryRespondAsync_Returns_False_If_RawSearchResponse_Stream_Is_Null(string username, int token, string query)
-        {
-            var rawResponse = new RawSearchResponse(42, null);
-
-            var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
-
-            var responded = await responder.TryRespondAsync(username, token, query);
-
-            Assert.False(responded);
-        }
-
-        [Trait("Category", "TryRespondAsync")]
-        [Theory(DisplayName = "TryRespondAsync returns false if RawSearchResponse stream is not readable"), AutoData]
-        public async Task TryRespondAsync_Returns_False_If_RawSearchResponse_Stream_Is_Not_Readable(string username, int token, string query)
-        {
-            using (var stream = new UnreadableStream(new byte[] { 1, 2, 3 }))
-            {
-                var rawResponse = new RawSearchResponse(stream.Length, stream);
-
-                Assert.False(rawResponse.Stream.CanRead);
-
-                var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
-
-                var responded = await responder.TryRespondAsync(username, token, query);
-
-                Assert.False(responded);
-            }
-        }
-
-        [Trait("Category", "TryRespondAsync")]
         [Theory(DisplayName = "TryRespondAsync raises RequestReceived"), AutoData]
         public async Task TryRespondAsync_Raises_RequestReceived(string username, int token, string query)
         {
@@ -952,16 +921,6 @@ namespace Soulseek.Tests.Unit
             {
                 throw new Exception("Dispose failed");
             }
-        }
-
-        private class UnreadableStream : System.IO.MemoryStream
-        {
-            public UnreadableStream(byte[] buffer)
-                : base(buffer)
-            {
-            }
-
-            public override bool CanRead => false;
         }
 
         private static (SearchResponder SearchResponder, Mocks Mocks) GetFixture(SoulseekClientOptions options = null)

--- a/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
+++ b/tests/Soulseek.Tests.Unit/SearchResponderTests.cs
@@ -312,24 +312,6 @@ namespace Soulseek.Tests.Unit
         }
 
         [Trait("Category", "TryRespondAsync")]
-        [Theory(DisplayName = "TryRespondAsync returns false if RawSearchResponse length is zero"), AutoData]
-        public async Task TryRespondAsync_Returns_False_If_RawSearchResponse_Length_Is_Zero(string username, int token, string query)
-        {
-            using (var stream = new System.IO.MemoryStream(new byte[] { 1, 2, 3 }))
-            {
-                var rawResponse = new RawSearchResponse(0, stream);
-
-                Assert.True(rawResponse.Stream.CanRead);
-
-                var (responder, _) = GetFixture(new SoulseekClientOptions(searchResponseResolver: (u, t, q) => Task.FromResult<SearchResponse>(rawResponse)));
-
-                var responded = await responder.TryRespondAsync(username, token, query);
-
-                Assert.False(responded);
-            }
-        }
-
-        [Trait("Category", "TryRespondAsync")]
         [Theory(DisplayName = "TryRespondAsync raises RequestReceived"), AutoData]
         public async Task TryRespondAsync_Raises_RequestReceived(string username, int token, string query)
         {

--- a/tests/Soulseek.Tests.Unit/TestIsolationExtensions.cs
+++ b/tests/Soulseek.Tests.Unit/TestIsolationExtensions.cs
@@ -204,6 +204,27 @@ namespace Soulseek.Tests.Unit
                 throw new ArgumentException($"No such property '{propertyName}' exists on target Type {type.Name}.", nameof(propertyName));
             }
 
+            // get-only auto properties have no setter, so fall back to the compiler generated backing field
+            if (!property.CanWrite)
+            {
+                var backingField = type.GetField($"<{propertyName}>k__BackingField", Flags);
+
+                if (backingField == default)
+                {
+                    throw new ArgumentException($"Property '{propertyName}' on target Type {type.Name} is read only and has no backing field.", nameof(propertyName));
+                }
+
+                try
+                {
+                    backingField.SetValue(target, value);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Failed to set backing field for property '{propertyName}' on target Type {type.Name}.  See inner Exception for details.", ex);
+                }
+            }
+
             try
             {
                 property.SetValue(target, value);


### PR DESCRIPTION
`RawSearchResponse` instances have a hard coded `FileCount`, and a short circuit in the search responder class was detecting this and returning early without sending the response.  I don't think any [one|thing] is actually using this, but I found it while looking to improve test coverage and it needed to be fixed.