### PR TITLE
Ensure raw browse response stream is readable

### DIFF
--- a/src/RawBrowseResponse.cs
+++ b/src/RawBrowseResponse.cs
@@ -54,6 +54,11 @@ namespace Soulseek
                 throw new ArgumentNullException(nameof(stream), "The specified input stream is null");
             }
 
+            if (!stream.CanRead)
+            {
+                throw new ArgumentException("The specified input stream can not be read", nameof(stream));
+            }
+
             Length = length;
             Stream = stream;
         }

--- a/tests/Soulseek.Tests.Unit/RawBrowseResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/RawBrowseResponseTests.cs
@@ -61,5 +61,28 @@ namespace Soulseek.Tests.Unit
             Assert.NotNull(ex);
             Assert.IsType<ArgumentNullException>(ex);
         }
+
+        [Trait("Category", "Instantiation")]
+        [Theory(DisplayName = "Throws if the given stream can not be read"), AutoData]
+        public void Throws_If_The_Given_Stream_Can_Not_Be_Read(long length)
+        {
+            using (var stream = new UnreadableStream(Array.Empty<byte>()))
+            {
+                var ex = Record.Exception(() => new RawSearchResponse(length, stream));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+            }
+        }
+
+        private class UnreadableStream : MemoryStream
+        {
+            public UnreadableStream(byte[] buffer)
+                : base(buffer)
+            {
+            }
+
+            public override bool CanRead => false;
+        }
     }
 }

--- a/tests/Soulseek.Tests.Unit/RawBrowseResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/RawBrowseResponseTests.cs
@@ -68,7 +68,7 @@ namespace Soulseek.Tests.Unit
         {
             using (var stream = new UnreadableStream(Array.Empty<byte>()))
             {
-                var ex = Record.Exception(() => new RawSearchResponse(length, stream));
+                var ex = Record.Exception(() => new RawBrowseResponse(length, stream));
 
                 Assert.NotNull(ex);
                 Assert.IsType<ArgumentException>(ex);


### PR DESCRIPTION
Closed this hole in #954 for raw search responses, applying the same to raw browse responses