### PR TITLE
Add the ability to add and remove liked and hated interests

### DIFF
--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -1261,6 +1261,15 @@ namespace Soulseek
         Task SetStatusAsync(UserPresence status, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        ///     Asynchronously informs the server of the user's liked and disliked interests.
+        /// </summary>
+        /// <param name="likes">A collection of liked interests.</param>
+        /// <param name="dislikes">A collection of disliked interests.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetInterestsAsync(IEnumerable<string> likes, IEnumerable<string> dislikes, CancellationToken? cancellationToken = null);
+
+        /// <summary>
         ///     Asynchronously starts receiving public chat messages.
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -1343,15 +1343,6 @@ namespace Soulseek
         Task SetStatusAsync(UserPresence status, CancellationToken? cancellationToken = null);
 
         /// <summary>
-        ///     Asynchronously informs the server of the user's liked and disliked interests.
-        /// </summary>
-        /// <param name="likes">A collection of liked interests.</param>
-        /// <param name="dislikes">A collection of disliked interests.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task SetInterestsAsync(IEnumerable<string> likes, IEnumerable<string> dislikes, CancellationToken? cancellationToken = null);
-
-        /// <summary>
         ///     Asynchronously starts receiving public chat messages.
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/src/ISoulseekClient.cs
+++ b/src/ISoulseekClient.cs
@@ -363,6 +363,36 @@ namespace Soulseek
         Task AcknowledgePrivilegeNotificationAsync(int privilegeNotificationId, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        ///     Asynchronously adds the specified <paramref name="interest"/> to the list of the user's hated interests.
+        /// </summary>
+        /// <param name="interest">The interest to add.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        Task AddHatedInterestAsync(string interest, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        ///     Asynchronously adds the specified <paramref name="interest"/> to the list of the user's liked interests.
+        /// </summary>
+        /// <param name="interest">The interest to add.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        Task AddLikedInterestAsync(string interest, CancellationToken? cancellationToken = null);
+
+        /// <summary>
         ///     Asynchronously adds the specified <paramref name="username"/> to the list of members in the specified private <paramref name="roomName"/>.
         /// </summary>
         /// <param name="roomName">The room to which to add the user.</param>
@@ -1111,6 +1141,36 @@ namespace Soulseek
         /// <exception cref="ListenException">Thrown when binding a listener to the specified address and/or port fails.</exception>
         /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
         Task<bool> ReconfigureOptionsAsync(SoulseekClientOptionsPatch patch, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        ///     Asynchronously removes the specified <paramref name="interest"/> from the list of the user's hated interests.
+        /// </summary>
+        /// <param name="interest">The interest to remove.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        Task RemoveHatedInterestAsync(string interest, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        ///     Asynchronously removes the specified <paramref name="interest"/> from the list of the user's liked interests.
+        /// </summary>
+        /// <param name="interest">The interest to remove.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        Task RemoveLikedInterestAsync(string interest, CancellationToken? cancellationToken = null);
 
         /// <summary>
         ///     Asynchronously removes the specified <paramref name="username"/> from the list of members in the specified private <paramref name="roomName"/>.

--- a/src/Messaging/MessageCode.cs
+++ b/src/Messaging/MessageCode.cs
@@ -350,12 +350,12 @@ namespace Soulseek.Messaging
             /// <summary>
             ///     51
             /// </summary>
-            InterestAdd = 51,
+            LikedInterestAdd = 51,
 
             /// <summary>
             ///     52
             /// </summary>
-            InterestRemove = 52,
+            LikedInterestRemove = 52,
 
             /// <summary>
             ///     54

--- a/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="HatedInterestAddCommand.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Messaging.Messages.Server
+{
+    using Soulseek.Messaging;
+
+    /// <summary>
+    ///     Adds a disliked interest to the user's profile on the server.
+    /// </summary>
+    internal class HatedInterestAddCommand : IOutgoingMessage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="HatedInterestAddCommand"/> class.
+        /// </summary>
+        /// <param name="interest">The disliked interest to add.</param>
+        public HatedInterestAddCommand(string interest)
+        {
+            Interest = interest;
+        }
+
+        /// <summary>
+        ///     Gets the disliked interest to add.
+        /// </summary>
+        public string Interest { get; }
+
+        /// <summary>
+        ///     Constructs a <see cref="byte"/> array from this message.
+        /// </summary>
+        /// <returns>The constructed byte array.</returns>
+        public byte[] ToByteArray()
+        {
+            return new MessageBuilder()
+                .WriteCode((MessageCode.Server)117)
+                .WriteString(Interest)
+                .Build();
+        }
+    }
+}

--- a/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
@@ -21,7 +21,7 @@
 //     SPDX-License-Identifier: GPL-3.0-only
 // </copyright>
 
-namespace Soulseek.Messaging.Messages.Server
+namespace Soulseek.Messaging.Messages
 {
     using Soulseek.Messaging;
 

--- a/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestAddCommand.cs
@@ -26,7 +26,7 @@ namespace Soulseek.Messaging.Messages
     using Soulseek.Messaging;
 
     /// <summary>
-    ///     Adds a hated interest to the user's profile on the server.
+    ///     Adds an interest to the user's list of hated interests.
     /// </summary>
     internal class HatedInterestAddCommand : IOutgoingMessage
     {

--- a/src/Messaging/Messages/Server/HatedInterestRemoveCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestRemoveCommand.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HatedInterestAddCommand.cs" company="JP Dillingham">
+﻿// <copyright file="HatedInterestRemoveCommand.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -26,21 +26,21 @@ namespace Soulseek.Messaging.Messages.Server
     using Soulseek.Messaging;
 
     /// <summary>
-    ///     Adds a hated interest to the user's profile on the server.
+    ///     Removes a hated interest from the user's profile on the server.
     /// </summary>
-    internal class HatedInterestAddCommand : IOutgoingMessage
+    internal class HatedInterestRemoveCommand : IOutgoingMessage
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="HatedInterestAddCommand"/> class.
+        ///     Initializes a new instance of the <see cref="HatedInterestRemoveCommand"/> class.
         /// </summary>
-        /// <param name="interest">The hated interest to add.</param>
-        public HatedInterestAddCommand(string interest)
+        /// <param name="interest">The hated interest to remove.</param>
+        public HatedInterestRemoveCommand(string interest)
         {
             Interest = interest;
         }
 
         /// <summary>
-        ///     Gets the hated interest to add.
+        ///     Gets the hated interest to remove.
         /// </summary>
         public string Interest { get; }
 
@@ -51,7 +51,7 @@ namespace Soulseek.Messaging.Messages.Server
         public byte[] ToByteArray()
         {
             return new MessageBuilder()
-                .WriteCode(MessageCode.Server.HatedInterestAdd)
+                .WriteCode(MessageCode.Server.HatedInterestRemove)
                 .WriteString(Interest)
                 .Build();
         }

--- a/src/Messaging/Messages/Server/HatedInterestRemoveCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestRemoveCommand.cs
@@ -21,7 +21,7 @@
 //     SPDX-License-Identifier: GPL-3.0-only
 // </copyright>
 
-namespace Soulseek.Messaging.Messages.Server
+namespace Soulseek.Messaging.Messages
 {
     using Soulseek.Messaging;
 

--- a/src/Messaging/Messages/Server/HatedInterestRemoveCommand.cs
+++ b/src/Messaging/Messages/Server/HatedInterestRemoveCommand.cs
@@ -26,7 +26,7 @@ namespace Soulseek.Messaging.Messages
     using Soulseek.Messaging;
 
     /// <summary>
-    ///     Removes a hated interest from the user's profile on the server.
+    ///     Removes an interest from the user's list of hated interests.
     /// </summary>
     internal class HatedInterestRemoveCommand : IOutgoingMessage
     {

--- a/src/Messaging/Messages/Server/InterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/InterestAddCommand.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="InterestAddCommand.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Messaging.Messages.Server
+{
+    using Soulseek.Messaging;
+
+    /// <summary>
+    ///     Adds a liked interest to the user's profile on the server.
+    /// </summary>
+    internal class InterestAddCommand : IOutgoingMessage
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="InterestAddCommand"/> class.
+        /// </summary>
+        /// <param name="interest">The interest to add.</param>
+        public InterestAddCommand(string interest)
+        {
+            Interest = interest;
+        }
+
+        /// <summary>
+        ///     Gets the interest to add.
+        /// </summary>
+        public string Interest { get; }
+
+        /// <summary>
+        ///     Constructs a <see cref="byte"/> array from this message.
+        /// </summary>
+        /// <returns>The constructed byte array.</returns>
+        public byte[] ToByteArray()
+        {
+            return new MessageBuilder()
+                .WriteCode((MessageCode.Server)51)
+                .WriteString(Interest)
+                .Build();
+        }
+    }
+}

--- a/src/Messaging/Messages/Server/LikedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/LikedInterestAddCommand.cs
@@ -26,7 +26,7 @@ namespace Soulseek.Messaging.Messages
     using Soulseek.Messaging;
 
     /// <summary>
-    ///     Adds a liked interest to the user's profile on the server.
+    ///     Adds an interest to the user's list of liked interests.
     /// </summary>
     internal class LikedInterestAddCommand : IOutgoingMessage
     {

--- a/src/Messaging/Messages/Server/LikedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/LikedInterestAddCommand.cs
@@ -21,7 +21,7 @@
 //     SPDX-License-Identifier: GPL-3.0-only
 // </copyright>
 
-namespace Soulseek.Messaging.Messages.Server
+namespace Soulseek.Messaging.Messages
 {
     using Soulseek.Messaging;
 

--- a/src/Messaging/Messages/Server/LikedInterestAddCommand.cs
+++ b/src/Messaging/Messages/Server/LikedInterestAddCommand.cs
@@ -1,10 +1,9 @@
-﻿// <copyright file="InterestAddCommand.cs" company="JP Dillingham">
-//     Copyright (c) JP Dillingham. All rights reserved.
+﻿// <copyright file="LikedInterestAddCommand.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham.
 //
 //     This program is free software: you can redistribute it and/or modify
 //     it under the terms of the GNU General Public License as published by
-//     the Free Software Foundation, either version 3 of the License, or
-//     (at your option) any later version.
+//     the Free Software Foundation, version 3.
 //
 //     This program is distributed in the hope that it will be useful,
 //     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -13,6 +12,13 @@
 //
 //     You should have received a copy of the GNU General Public License
 //     along with this program.  If not, see https://www.gnu.org/licenses/.
+//
+//     This program is distributed with Additional Terms pursuant to Section 7
+//     of the GPLv3.  See the LICENSE file in the root directory of this
+//     project for the complete terms and conditions.
+//
+//     SPDX-FileCopyrightText: JP Dillingham
+//     SPDX-License-Identifier: GPL-3.0-only
 // </copyright>
 
 namespace Soulseek.Messaging.Messages.Server
@@ -22,19 +28,19 @@ namespace Soulseek.Messaging.Messages.Server
     /// <summary>
     ///     Adds a liked interest to the user's profile on the server.
     /// </summary>
-    internal class InterestAddCommand : IOutgoingMessage
+    internal class LikedInterestAddCommand : IOutgoingMessage
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="InterestAddCommand"/> class.
+        ///     Initializes a new instance of the <see cref="LikedInterestAddCommand"/> class.
         /// </summary>
-        /// <param name="interest">The interest to add.</param>
-        public InterestAddCommand(string interest)
+        /// <param name="interest">The liked interest to add.</param>
+        public LikedInterestAddCommand(string interest)
         {
             Interest = interest;
         }
 
         /// <summary>
-        ///     Gets the interest to add.
+        ///     Gets the liked interest to add.
         /// </summary>
         public string Interest { get; }
 
@@ -45,7 +51,7 @@ namespace Soulseek.Messaging.Messages.Server
         public byte[] ToByteArray()
         {
             return new MessageBuilder()
-                .WriteCode((MessageCode.Server)51)
+                .WriteCode(MessageCode.Server.LikedInterestAdd)
                 .WriteString(Interest)
                 .Build();
         }

--- a/src/Messaging/Messages/Server/LikedInterestRemoveCommand.cs
+++ b/src/Messaging/Messages/Server/LikedInterestRemoveCommand.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HatedInterestAddCommand.cs" company="JP Dillingham">
+﻿// <copyright file="LikedInterestRemoveCommand.cs" company="JP Dillingham">
 //     Copyright (c) JP Dillingham.
 //
 //     This program is free software: you can redistribute it and/or modify
@@ -26,21 +26,21 @@ namespace Soulseek.Messaging.Messages.Server
     using Soulseek.Messaging;
 
     /// <summary>
-    ///     Adds a hated interest to the user's profile on the server.
+    ///     Removes a liked interest from the user's profile on the server.
     /// </summary>
-    internal class HatedInterestAddCommand : IOutgoingMessage
+    internal class LikedInterestRemoveCommand : IOutgoingMessage
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="HatedInterestAddCommand"/> class.
+        ///     Initializes a new instance of the <see cref="LikedInterestRemoveCommand"/> class.
         /// </summary>
-        /// <param name="interest">The hated interest to add.</param>
-        public HatedInterestAddCommand(string interest)
+        /// <param name="interest">The liked interest to remove.</param>
+        public LikedInterestRemoveCommand(string interest)
         {
             Interest = interest;
         }
 
         /// <summary>
-        ///     Gets the hated interest to add.
+        ///     Gets the liked interest to remove.
         /// </summary>
         public string Interest { get; }
 
@@ -51,7 +51,7 @@ namespace Soulseek.Messaging.Messages.Server
         public byte[] ToByteArray()
         {
             return new MessageBuilder()
-                .WriteCode(MessageCode.Server.HatedInterestAdd)
+                .WriteCode(MessageCode.Server.LikedInterestRemove)
                 .WriteString(Interest)
                 .Build();
         }

--- a/src/Messaging/Messages/Server/LikedInterestRemoveCommand.cs
+++ b/src/Messaging/Messages/Server/LikedInterestRemoveCommand.cs
@@ -26,7 +26,7 @@ namespace Soulseek.Messaging.Messages
     using Soulseek.Messaging;
 
     /// <summary>
-    ///     Removes a liked interest from the user's profile on the server.
+    ///     Removes an interest from the user's list of liked interests.
     /// </summary>
     internal class LikedInterestRemoveCommand : IOutgoingMessage
     {

--- a/src/Messaging/Messages/Server/LikedInterestRemoveCommand.cs
+++ b/src/Messaging/Messages/Server/LikedInterestRemoveCommand.cs
@@ -21,7 +21,7 @@
 //     SPDX-License-Identifier: GPL-3.0-only
 // </copyright>
 
-namespace Soulseek.Messaging.Messages.Server
+namespace Soulseek.Messaging.Messages
 {
     using Soulseek.Messaging;
 

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -17,6 +17,13 @@
 
 namespace Soulseek
 {
+    using Soulseek.Diagnostics;
+    using Soulseek.Messaging;
+    using Soulseek.Messaging.Handlers;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Messaging.Messages.Server;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
@@ -27,12 +34,6 @@ namespace Soulseek
     using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
-    using Soulseek.Diagnostics;
-    using Soulseek.Messaging;
-    using Soulseek.Messaging.Handlers;
-    using Soulseek.Messaging.Messages;
-    using Soulseek.Network;
-    using Soulseek.Network.Tcp;
 
     /// <summary>
     ///     A client for the Soulseek file sharing network.
@@ -2478,6 +2479,58 @@ namespace Soulseek
                 throw new SoulseekClientException($"Failed to set shared counts to {directories} directories and {files} files: {ex.Message}", ex);
             }
         }
+
+
+
+        /// <summary>
+        ///     Asynchronously informs the server of the user's <paramref name="likes"/> and <paramref name="dislikes"/>.
+        /// </summary>
+        /// <param name="likes">A collection of liked interests.</param>
+        /// <param name="dislikes">A collection of disliked interests.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public async Task SetInterestsAsync(IEnumerable<string> likes, IEnumerable<string> dislikes, CancellationToken? cancellationToken = null)
+        {
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to set interests; currently {State}.");
+            }
+
+            var token = cancellationToken ?? CancellationToken.None;
+
+            try
+            {
+                if (likes != null)
+                {
+                    foreach (var like in likes)
+                    {
+                        if (string.IsNullOrWhiteSpace(like)) continue;
+
+                        await ServerConnection.WriteAsync(new InterestAddCommand(like), token).ConfigureAwait(false);
+                    }
+                }
+
+                if (dislikes != null)
+                {
+                    foreach (var dislike in dislikes)
+                    {
+                        if (string.IsNullOrWhiteSpace(dislike)) continue;
+
+                        await ServerConnection.WriteAsync(new HatedInterestAddCommand(dislike), token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
+            {
+                throw new SoulseekClientException($"Failed to set interests: {ex.Message}", ex);
+            }
+        }
+
+
 
         /// <summary>
         ///     Asynchronously informs the server of the current online <paramref name="status"/> of the client.

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -2486,58 +2486,6 @@ namespace Soulseek
             }
         }
 
-
-
-        /// <summary>
-        ///     Asynchronously informs the server of the user's <paramref name="likes"/> and <paramref name="dislikes"/>.
-        /// </summary>
-        /// <param name="likes">A collection of liked interests.</param>
-        /// <param name="dislikes">A collection of disliked interests.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>The Task representing the asynchronous operation.</returns>
-        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
-        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
-        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
-        public async Task SetInterestsAsync(IEnumerable<string> likes, IEnumerable<string> dislikes, CancellationToken? cancellationToken = null)
-        {
-            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
-            {
-                throw new InvalidOperationException($"The server connection must be connected and logged in to set interests; currently {State}.");
-            }
-
-            var token = cancellationToken ?? CancellationToken.None;
-
-            try
-            {
-                if (likes != null)
-                {
-                    foreach (var like in likes)
-                    {
-                        if (string.IsNullOrWhiteSpace(like)) continue;
-
-                        await ServerConnection.WriteAsync(new InterestAddCommand(like), token).ConfigureAwait(false);
-                    }
-                }
-
-                if (dislikes != null)
-                {
-                    foreach (var dislike in dislikes)
-                    {
-                        if (string.IsNullOrWhiteSpace(dislike)) continue;
-
-                        await ServerConnection.WriteAsync(new HatedInterestAddCommand(dislike), token).ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (Exception ex) when (!(ex is OperationCanceledException) && !(ex is TimeoutException))
-            {
-                throw new SoulseekClientException($"Failed to set interests: {ex.Message}", ex);
-            }
-        }
-
-
-
         /// <summary>
         ///     Asynchronously informs the server of the current online <paramref name="status"/> of the client.
         /// </summary>

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -23,13 +23,6 @@
 
 namespace Soulseek
 {
-    using Soulseek.Diagnostics;
-    using Soulseek.Messaging;
-    using Soulseek.Messaging.Handlers;
-    using Soulseek.Messaging.Messages;
-    using Soulseek.Messaging.Messages.Server;
-    using Soulseek.Network;
-    using Soulseek.Network.Tcp;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
@@ -40,6 +33,12 @@ namespace Soulseek
     using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
+    using Soulseek.Diagnostics;
+    using Soulseek.Messaging;
+    using Soulseek.Messaging.Handlers;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
 
     /// <summary>
     ///     A client for the Soulseek file sharing network.

--- a/src/SoulseekClient.cs
+++ b/src/SoulseekClient.cs
@@ -673,6 +673,62 @@ namespace Soulseek
         }
 
         /// <summary>
+        ///     Asynchronously adds the specified <paramref name="interest"/> to the list of the user's hated interests.
+        /// </summary>
+        /// <param name="interest">The interest to add.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public Task AddHatedInterestAsync(string interest, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(interest))
+            {
+                throw new ArgumentException("The interest must not be a null or empty string, or one consisting of only whitespace", nameof(interest));
+            }
+
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to add a hated interest (currently: {State})");
+            }
+
+            return AddHatedInterestInternalAsync(interest, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     Asynchronously adds the specified <paramref name="interest"/> to the list of the user's liked interests.
+        /// </summary>
+        /// <param name="interest">The interest to add.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public Task AddLikedInterestAsync(string interest, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(interest))
+            {
+                throw new ArgumentException("The interest must not be a null or empty string, or one consisting of only whitespace", nameof(interest));
+            }
+
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to add a liked interest (currently: {State})");
+            }
+
+            return AddLikedInterestInternalAsync(interest, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
         ///     Asynchronously adds the specified <paramref name="username"/> to the list of members in the specified private <paramref name="roomName"/>.
         /// </summary>
         /// <param name="roomName">The room to which to add the user.</param>
@@ -2095,6 +2151,62 @@ namespace Soulseek
         }
 
         /// <summary>
+        ///     Asynchronously removes the specified <paramref name="interest"/> from the list of the user's hated interests.
+        /// </summary>
+        /// <param name="interest">The interest to remove.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public Task RemoveHatedInterestAsync(string interest, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(interest))
+            {
+                throw new ArgumentException("The interest must not be a null or empty string, or one consisting of only whitespace", nameof(interest));
+            }
+
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to remove a hated interest (currently: {State})");
+            }
+
+            return RemoveHatedInterestInternalAsync(interest, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     Asynchronously removes the specified <paramref name="interest"/> from the list of the user's liked interests.
+        /// </summary>
+        /// <param name="interest">The interest to remove.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>The Task representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="interest"/> is null, empty, or consists only of whitespace.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">Thrown when the client is not connected or logged in.</exception>
+        /// <exception cref="TimeoutException">Thrown when the operation has timed out.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the operation has been cancelled.</exception>
+        /// <exception cref="SoulseekClientException">Thrown when an exception is encountered during the operation.</exception>
+        public Task RemoveLikedInterestAsync(string interest, CancellationToken? cancellationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(interest))
+            {
+                throw new ArgumentException("The interest must not be a null or empty string, or one consisting of only whitespace", nameof(interest));
+            }
+
+            if (!State.HasFlag(SoulseekClientStates.Connected) || !State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                throw new InvalidOperationException($"The server connection must be connected and logged in to remove a liked interest (currently: {State})");
+            }
+
+            return RemoveLikedInterestInternalAsync(interest, cancellationToken ?? CancellationToken.None);
+        }
+
+        /// <summary>
         ///     Asynchronously removes the specified <paramref name="username"/> from the list of members in the specified private <paramref name="roomName"/>.
         /// </summary>
         /// <param name="roomName">The room from which to remove the user.</param>
@@ -2859,6 +2971,30 @@ namespace Soulseek
             catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
             {
                 throw new SoulseekClientException($"Failed to acknowledge privilege notification with ID {privilegeNotificationId}: {ex.Message}", ex);
+            }
+        }
+
+        private async Task AddHatedInterestInternalAsync(string interest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await ServerConnection.WriteAsync(new HatedInterestAddCommand(interest), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
+            {
+                throw new SoulseekClientException($"Failed to add hated interest {interest}: {ex.Message}", ex);
+            }
+        }
+
+        private async Task AddLikedInterestInternalAsync(string interest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await ServerConnection.WriteAsync(new LikedInterestAddCommand(interest), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
+            {
+                throw new SoulseekClientException($"Failed to add liked interest {interest}: {ex.Message}", ex);
             }
         }
 
@@ -4050,6 +4186,30 @@ namespace Soulseek
             finally
             {
                 StateSyncRoot.Release();
+            }
+        }
+
+        private async Task RemoveHatedInterestInternalAsync(string interest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await ServerConnection.WriteAsync(new HatedInterestRemoveCommand(interest), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
+            {
+                throw new SoulseekClientException($"Failed to remove hated interest {interest}: {ex.Message}", ex);
+            }
+        }
+
+        private async Task RemoveLikedInterestInternalAsync(string interest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await ServerConnection.WriteAsync(new LikedInterestRemoveCommand(interest), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is TimeoutException) && !(ex is OperationCanceledException))
+            {
+                throw new SoulseekClientException($"Failed to remove liked interest {interest}: {ex.Message}", ex);
             }
         }
 

--- a/tests/Soulseek.Tests.Unit/Client/AddHatedInterestAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AddHatedInterestAsyncTests.cs
@@ -1,0 +1,192 @@
+﻿// <copyright file="AddHatedInterestAsyncTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit.Client
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoFixture.Xunit2;
+    using Moq;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
+    using Xunit;
+
+    public class AddHatedInterestAsyncTests
+    {
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync throws ArgumentException given bad interest")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        [InlineData("	")]
+        public async Task AddHatedInterestAsync_Throws_ArgumentException_Given_Bad_Interest(string interest)
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync(interest));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+                Assert.Equal("interest", ((ArgumentException)ex).ParamName);
+            }
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Fact(DisplayName = "AddHatedInterestAsync throws InvalidOperationException when not connected")]
+        public async Task AddHatedInterestAsync_Throws_InvalidOperationException_When_Not_Connected()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Fact(DisplayName = "AddHatedInterestAsync throws InvalidOperationException when not logged in")]
+        public async Task AddHatedInterestAsync_Throws_InvalidOperationException_When_Not_Logged_In()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync does not throw when write does not throw"), AutoData]
+        public async Task AddHatedInterestAsync_Does_Not_Throw_When_Write_Does_Not_Throw(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync sends expected interest"), AutoData]
+        public async Task AddHatedInterestAsync_Sends_Expected_Interest(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.Is<HatedInterestAddCommand>(c => c.Interest == interest), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync uses given CancellationToken"), AutoData]
+        public async Task AddHatedInterestAsync_Uses_Given_CancellationToken(string interest, CancellationToken cancellationToken)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await s.AddHatedInterestAsync(interest, cancellationToken);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync throws SoulseekClientException when write throws"), AutoData]
+        public async Task AddHatedInterestAsync_Throws_SoulseekClientException_When_Write_Throws(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new ConnectionWriteException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<SoulseekClientException>(ex);
+                Assert.IsType<ConnectionWriteException>(ex.InnerException);
+            }
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync throws TimeoutException when write times out"), AutoData]
+        public async Task AddHatedInterestAsync_Throws_TimeoutException_When_Write_Times_Out(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new TimeoutException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<TimeoutException>(ex);
+            }
+        }
+
+        [Trait("Category", "AddHatedInterestAsync")]
+        [Theory(DisplayName = "AddHatedInterestAsync throws OperationCanceledException when write is canceled"), AutoData]
+        public async Task AddHatedInterestAsync_Throws_OperationCanceledException_When_Write_Is_Canceled(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddHatedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+    }
+}

--- a/tests/Soulseek.Tests.Unit/Client/AddLikedInterestAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/AddLikedInterestAsyncTests.cs
@@ -1,0 +1,192 @@
+﻿// <copyright file="AddLikedInterestAsyncTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit.Client
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoFixture.Xunit2;
+    using Moq;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
+    using Xunit;
+
+    public class AddLikedInterestAsyncTests
+    {
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync throws ArgumentException given bad interest")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        [InlineData("	")]
+        public async Task AddLikedInterestAsync_Throws_ArgumentException_Given_Bad_Interest(string interest)
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync(interest));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+                Assert.Equal("interest", ((ArgumentException)ex).ParamName);
+            }
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Fact(DisplayName = "AddLikedInterestAsync throws InvalidOperationException when not connected")]
+        public async Task AddLikedInterestAsync_Throws_InvalidOperationException_When_Not_Connected()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Fact(DisplayName = "AddLikedInterestAsync throws InvalidOperationException when not logged in")]
+        public async Task AddLikedInterestAsync_Throws_InvalidOperationException_When_Not_Logged_In()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync does not throw when write does not throw"), AutoData]
+        public async Task AddLikedInterestAsync_Does_Not_Throw_When_Write_Does_Not_Throw(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync sends expected interest"), AutoData]
+        public async Task AddLikedInterestAsync_Sends_Expected_Interest(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.Is<LikedInterestAddCommand>(c => c.Interest == interest), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync uses given CancellationToken"), AutoData]
+        public async Task AddLikedInterestAsync_Uses_Given_CancellationToken(string interest, CancellationToken cancellationToken)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await s.AddLikedInterestAsync(interest, cancellationToken);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync throws SoulseekClientException when write throws"), AutoData]
+        public async Task AddLikedInterestAsync_Throws_SoulseekClientException_When_Write_Throws(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new ConnectionWriteException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<SoulseekClientException>(ex);
+                Assert.IsType<ConnectionWriteException>(ex.InnerException);
+            }
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync throws TimeoutException when write times out"), AutoData]
+        public async Task AddLikedInterestAsync_Throws_TimeoutException_When_Write_Times_Out(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new TimeoutException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<TimeoutException>(ex);
+            }
+        }
+
+        [Trait("Category", "AddLikedInterestAsync")]
+        [Theory(DisplayName = "AddLikedInterestAsync throws OperationCanceledException when write is canceled"), AutoData]
+        public async Task AddLikedInterestAsync_Throws_OperationCanceledException_When_Write_Is_Canceled(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.AddLikedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+    }
+}

--- a/tests/Soulseek.Tests.Unit/Client/RemoveHatedInterestAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/RemoveHatedInterestAsyncTests.cs
@@ -1,0 +1,192 @@
+﻿// <copyright file="RemoveHatedInterestAsyncTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit.Client
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoFixture.Xunit2;
+    using Moq;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
+    using Xunit;
+
+    public class RemoveHatedInterestAsyncTests
+    {
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync throws ArgumentException given bad interest")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        [InlineData("	")]
+        public async Task RemoveHatedInterestAsync_Throws_ArgumentException_Given_Bad_Interest(string interest)
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync(interest));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+                Assert.Equal("interest", ((ArgumentException)ex).ParamName);
+            }
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Fact(DisplayName = "RemoveHatedInterestAsync throws InvalidOperationException when not connected")]
+        public async Task RemoveHatedInterestAsync_Throws_InvalidOperationException_When_Not_Connected()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Fact(DisplayName = "RemoveHatedInterestAsync throws InvalidOperationException when not logged in")]
+        public async Task RemoveHatedInterestAsync_Throws_InvalidOperationException_When_Not_Logged_In()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync does not throw when write does not throw"), AutoData]
+        public async Task RemoveHatedInterestAsync_Does_Not_Throw_When_Write_Does_Not_Throw(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync sends expected interest"), AutoData]
+        public async Task RemoveHatedInterestAsync_Sends_Expected_Interest(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.Is<HatedInterestRemoveCommand>(c => c.Interest == interest), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync uses given CancellationToken"), AutoData]
+        public async Task RemoveHatedInterestAsync_Uses_Given_CancellationToken(string interest, CancellationToken cancellationToken)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await s.RemoveHatedInterestAsync(interest, cancellationToken);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync throws SoulseekClientException when write throws"), AutoData]
+        public async Task RemoveHatedInterestAsync_Throws_SoulseekClientException_When_Write_Throws(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new ConnectionWriteException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<SoulseekClientException>(ex);
+                Assert.IsType<ConnectionWriteException>(ex.InnerException);
+            }
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync throws TimeoutException when write times out"), AutoData]
+        public async Task RemoveHatedInterestAsync_Throws_TimeoutException_When_Write_Times_Out(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new TimeoutException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<TimeoutException>(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveHatedInterestAsync")]
+        [Theory(DisplayName = "RemoveHatedInterestAsync throws OperationCanceledException when write is canceled"), AutoData]
+        public async Task RemoveHatedInterestAsync_Throws_OperationCanceledException_When_Write_Is_Canceled(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveHatedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+    }
+}

--- a/tests/Soulseek.Tests.Unit/Client/RemoveLikedInterestAsyncTests.cs
+++ b/tests/Soulseek.Tests.Unit/Client/RemoveLikedInterestAsyncTests.cs
@@ -1,0 +1,192 @@
+﻿// <copyright file="RemoveLikedInterestAsyncTests.cs" company="JP Dillingham">
+//     Copyright (c) JP Dillingham. All rights reserved.
+//
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see https://www.gnu.org/licenses/.
+// </copyright>
+
+namespace Soulseek.Tests.Unit.Client
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoFixture.Xunit2;
+    using Moq;
+    using Soulseek.Messaging.Messages;
+    using Soulseek.Network;
+    using Soulseek.Network.Tcp;
+    using Xunit;
+
+    public class RemoveLikedInterestAsyncTests
+    {
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync throws ArgumentException given bad interest")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        [InlineData("	")]
+        public async Task RemoveLikedInterestAsync_Throws_ArgumentException_Given_Bad_Interest(string interest)
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync(interest));
+
+                Assert.NotNull(ex);
+                Assert.IsType<ArgumentException>(ex);
+                Assert.Equal("interest", ((ArgumentException)ex).ParamName);
+            }
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Fact(DisplayName = "RemoveLikedInterestAsync throws InvalidOperationException when not connected")]
+        public async Task RemoveLikedInterestAsync_Throws_InvalidOperationException_When_Not_Connected()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Fact(DisplayName = "RemoveLikedInterestAsync throws InvalidOperationException when not logged in")]
+        public async Task RemoveLikedInterestAsync_Throws_InvalidOperationException_When_Not_Logged_In()
+        {
+            using (var s = new SoulseekClient(minorVersion: 9999))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync("interest"));
+
+                Assert.NotNull(ex);
+                Assert.IsType<InvalidOperationException>(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync does not throw when write does not throw"), AutoData]
+        public async Task RemoveLikedInterestAsync_Does_Not_Throw_When_Write_Does_Not_Throw(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync sends expected interest"), AutoData]
+        public async Task RemoveLikedInterestAsync_Sends_Expected_Interest(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.State)
+                .Returns(ConnectionState.Connected);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync(interest));
+
+                Assert.Null(ex);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.Is<LikedInterestRemoveCommand>(c => c.Interest == interest), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync uses given CancellationToken"), AutoData]
+        public async Task RemoveLikedInterestAsync_Uses_Given_CancellationToken(string interest, CancellationToken cancellationToken)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await s.RemoveLikedInterestAsync(interest, cancellationToken);
+            }
+
+            conn.Verify(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), cancellationToken), Times.Once);
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync throws SoulseekClientException when write throws"), AutoData]
+        public async Task RemoveLikedInterestAsync_Throws_SoulseekClientException_When_Write_Throws(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new ConnectionWriteException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<SoulseekClientException>(ex);
+                Assert.IsType<ConnectionWriteException>(ex.InnerException);
+            }
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync throws TimeoutException when write times out"), AutoData]
+        public async Task RemoveLikedInterestAsync_Throws_TimeoutException_When_Write_Times_Out(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new TimeoutException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<TimeoutException>(ex);
+            }
+        }
+
+        [Trait("Category", "RemoveLikedInterestAsync")]
+        [Theory(DisplayName = "RemoveLikedInterestAsync throws OperationCanceledException when write is canceled"), AutoData]
+        public async Task RemoveLikedInterestAsync_Throws_OperationCanceledException_When_Write_Is_Canceled(string interest)
+        {
+            var conn = new Mock<IMessageConnection>();
+            conn.Setup(m => m.WriteAsync(It.IsAny<IOutgoingMessage>(), It.IsAny<CancellationToken>()))
+                .Throws(new OperationCanceledException());
+
+            using (var s = new SoulseekClient(minorVersion: 9999, serverConnection: conn.Object))
+            {
+                s.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                var ex = await Record.ExceptionAsync(() => s.RemoveLikedInterestAsync(interest, CancellationToken.None));
+
+                Assert.NotNull(ex);
+                Assert.IsType<OperationCanceledException>(ex);
+            }
+        }
+    }
+}

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/OutgoingTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/OutgoingTests.cs
@@ -823,5 +823,65 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
             Assert.Equal(username, reader.ReadString());
             Assert.False(reader.HasMoreData);
         }
+
+        [Trait("Category", "ToByteArray")]
+        [Trait("Request", "LikedInterestAddCommand")]
+        [Theory(DisplayName = "LikedInterestAddCommand constructs the correct message"), AutoData]
+        public void LikedInterestAddCommand_Constructs_The_Correct_Message(string interest)
+        {
+            var a = new LikedInterestAddCommand(interest);
+            var msg = a.ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Server>(msg);
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Server.LikedInterestAdd, code);
+            Assert.Equal(interest, reader.ReadString());
+        }
+
+        [Trait("Category", "ToByteArray")]
+        [Trait("Request", "LikedInterestRemoveCommand")]
+        [Theory(DisplayName = "LikedInterestRemoveCommand constructs the correct message"), AutoData]
+        public void LikedInterestRemoveCommand_Constructs_The_Correct_Message(string interest)
+        {
+            var a = new LikedInterestRemoveCommand(interest);
+            var msg = a.ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Server>(msg);
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Server.LikedInterestRemove, code);
+            Assert.Equal(interest, reader.ReadString());
+        }
+
+        [Trait("Category", "ToByteArray")]
+        [Trait("Request", "HatedInterestAddCommand")]
+        [Theory(DisplayName = "HatedInterestAddCommand constructs the correct message"), AutoData]
+        public void HatedInterestAddCommand_Constructs_The_Correct_Message(string interest)
+        {
+            var a = new HatedInterestAddCommand(interest);
+            var msg = a.ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Server>(msg);
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Server.HatedInterestAdd, code);
+            Assert.Equal(interest, reader.ReadString());
+        }
+
+        [Trait("Category", "ToByteArray")]
+        [Trait("Request", "HatedInterestRemoveCommand")]
+        [Theory(DisplayName = "HatedInterestRemoveCommand constructs the correct message"), AutoData]
+        public void HatedInterestRemoveCommand_Constructs_The_Correct_Message(string interest)
+        {
+            var a = new HatedInterestRemoveCommand(interest);
+            var msg = a.ToByteArray();
+
+            var reader = new MessageReader<MessageCode.Server>(msg);
+            var code = reader.ReadCode();
+
+            Assert.Equal(MessageCode.Server.HatedInterestRemove, code);
+            Assert.Equal(interest, reader.ReadString());
+        }
     }
 }


### PR DESCRIPTION
Extension of #906 

The original PR accepted arrays for likes and dislikes, which would be convenient for callers, but doesn't match the design of the library.  Because repeated messages must be sent to the server, an error in the middle of the process would leave the caller in a nondeterministic state, not knowing which failed or succeeded.

For something like this it's not a concern at all, but consistency is important in the public API

Thanks for the original PR @Vxrtrauter