### PR TITLE
Remove code 1002 CannotCreateRoom

### DIFF
--- a/src/Messaging/MessageCode.cs
+++ b/src/Messaging/MessageCode.cs
@@ -673,11 +673,6 @@ namespace Soulseek.Messaging
             CannotConnect = 1001,
 
             /// <summary>
-            ///     1002
-            /// </summary>
-            CannotCreateRoom = 1002,
-
-            /// <summary>
             ///     1003
             /// </summary>
             CannotJoinRoom = 1003,


### PR DESCRIPTION
Closes #821 

There are only 2 codes in the 100x region: 1001 CannotConnect, and 1003 CannotJoinRoom.

According to the [Nicotine+ docs](https://github.com/nicotine-plus/nicotine-plus/blob/master/doc/SLSKPROTOCOL.md#cantcreateroom) this code has only been observed being sent when attempting to join/create a private room that already exists.

I'm going to leave this named `CannotJoinRoom`, which covers both the (hypothetical) join and create scenarios, as you must join a room to create it.  And the work is already done and tested.