### PR TITLE
Add login rejection detail, if present

### DIFF
--- a/src/Messaging/Messages/Server/LoginResponse.cs
+++ b/src/Messaging/Messages/Server/LoginResponse.cs
@@ -68,7 +68,7 @@ namespace Soulseek.Messaging.Messages
         public bool IsSupporter { get; }
 
         /// <summary>
-        ///     Gets the reason for a login failure.
+        ///     Gets the MOTD if <see cref="Succeeded"/> is true, or the reason for a login failure if it is false.
         /// </summary>
         public string Message { get; }
 
@@ -107,6 +107,11 @@ namespace Soulseek.Messaging.Messages
 
                 hash = reader.ReadString();
                 isSupporter = reader.ReadByte() == 1;
+            }
+            else if (reader.HasMoreData)
+            {
+                var detail = reader.ReadString();
+                msg += string.IsNullOrWhiteSpace(detail) ? string.Empty : ": " + detail;
             }
 
             return new LoginResponse(succeeded, msg, ipAddress, hash, isSupporter);

--- a/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/LoginResponseTests.cs
+++ b/tests/Soulseek.Tests.Unit/Messaging/Messages/Server/LoginResponseTests.cs
@@ -94,6 +94,65 @@ namespace Soulseek.Tests.Unit.Messaging.Messages
         }
 
         [Trait("Category", "Parse")]
+        [Fact(DisplayName = "Parse appends rejection detail to message on failure with detail")]
+        public void Parse_Appends_Rejection_Detail_To_Message_On_Failure_With_Detail()
+        {
+            var detail = RandomGuid;
+
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Server.Login)
+                .WriteByte(0)
+                .WriteString("INVALIDUSERNAME")
+                .WriteString(detail)
+                .Build();
+
+            var response = LoginResponse.FromByteArray(msg);
+
+            Assert.False(response.Succeeded);
+            Assert.Equal($"INVALIDUSERNAME: {detail}", response.Message);
+        }
+
+        [Trait("Category", "Parse")]
+        [Fact(DisplayName = "Parse does not throw on INVALIDUSERNAME failure without detail")]
+        public void Parse_Does_Not_Throw_On_Invalid_Username_Failure_Without_Detail()
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Server.Login)
+                .WriteByte(0)
+                .WriteString("INVALIDUSERNAME")
+                .Build();
+
+            LoginResponse response = null;
+
+            var ex = Record.Exception(() => response = LoginResponse.FromByteArray(msg));
+
+            Assert.Null(ex);
+
+            Assert.False(response.Succeeded);
+            Assert.Equal("INVALIDUSERNAME", response.Message);
+        }
+
+        [Trait("Category", "Parse")]
+        [Theory(DisplayName = "Parse does not append rejection detail to message on failure with blank detail")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("	")]
+        public void Parse_Does_Not_Append_Rejection_Detail_To_Message_On_Failure_With_Blank_Detail(string detail)
+        {
+            var msg = new MessageBuilder()
+                .WriteCode(MessageCode.Server.Login)
+                .WriteByte(0)
+                .WriteString("INVALIDUSERNAME")
+                .WriteString(detail)
+                .Build();
+
+            var response = LoginResponse.FromByteArray(msg);
+
+            Assert.False(response.Succeeded);
+            Assert.Equal("INVALIDUSERNAME", response.Message);
+        }
+
+        [Trait("Category", "Parse")]
         [Fact(DisplayName = "Parse returns expected data on success")]
         public void Parse_Returns_Expected_Data_On_Success()
         {


### PR DESCRIPTION
Reviewing the [Nicotine+ docs](https://github.com/nicotine-plus/nicotine-plus/blob/master/doc/SLSKPROTOCOL.md#data-order), I realized that there's an extra string "detail" if login is rejected because of a bad username.  This PR adds support for reading it, and appends it to the rejection reason if present.  It also clarifies the `Message` property, which gives a MOTD message when login is successful and is not strictly used to communicate a rejection reason as previously stated.